### PR TITLE
fixed payload length computation for frames shorter than 64 bytes

### DIFF
--- a/packet.h
+++ b/packet.h
@@ -71,7 +71,8 @@ struct Packet : public Record {
    uint8_t     src_mac[6];
    uint16_t    ethertype;
 
-   uint16_t    ip_length;
+   uint16_t    ip_length; /**< Length of IP header + its payload */
+   uint16_t    ip_payload_length; /**< Length of IP payload */
    uint8_t     ip_version;
    uint8_t     ip_ttl;
    uint8_t     ip_proto;


### PR DESCRIPTION
Fixed bug in payload length computation. Padding bytes were included in the length.