### PR TITLE
Plugin export fix

### DIFF
--- a/idpcontentplugin.cpp
+++ b/idpcontentplugin.cpp
@@ -96,7 +96,7 @@ int IDPCONTENTPlugin::post_create(Flow &rec, const Packet &pkt)
    return 0;
 }
 
-int IDPCONTENTPlugin::post_update(Flow &rec, Packet &pkt)
+int IDPCONTENTPlugin::post_update(Flow &rec, const Packet &pkt)
 {
    RecordExtIDPCONTENT *idpcontent_data = static_cast<RecordExtIDPCONTENT *>(rec.getExtension(idpcontent));
    update_record(idpcontent_data, pkt);

--- a/idpcontentplugin.cpp
+++ b/idpcontentplugin.cpp
@@ -72,11 +72,6 @@ IDPCONTENTPlugin::IDPCONTENTPlugin(const options_t &module_options,
    print_stats = module_options.print_stats;
 }
 
-int IDPCONTENTPlugin::pre_create(Packet &pkt)
-{
-   return 0;
-}
-
 void IDPCONTENTPlugin::update_record(RecordExtIDPCONTENT *idpcontent_data, const Packet &pkt)
 {
    // create ptr into buffers from packet directions
@@ -101,10 +96,9 @@ int IDPCONTENTPlugin::post_create(Flow &rec, const Packet &pkt)
    return 0;
 }
 
-int IDPCONTENTPlugin::pre_update(Flow &rec, Packet &pkt)
+int IDPCONTENTPlugin::post_update(Flow &rec, Packet &pkt)
 {
    RecordExtIDPCONTENT *idpcontent_data = static_cast<RecordExtIDPCONTENT *>(rec.getExtension(idpcontent));
-
    update_record(idpcontent_data, pkt);
    return 0;
 }

--- a/idpcontentplugin.h
+++ b/idpcontentplugin.h
@@ -115,9 +115,8 @@ class IDPCONTENTPlugin : public FlowCachePlugin
 public:
    IDPCONTENTPlugin(const options_t &module_options);
    IDPCONTENTPlugin(const options_t &module_options, vector<plugin_opt> plugin_options);
-   int pre_create(Packet &pkt);
    int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
+   int post_update(Flow &rec, Packet &pkt);
    const char **get_ipfix_string();
    string get_unirec_field_string();
    void update_record(RecordExtIDPCONTENT *pstats_data, const Packet &pkt);

--- a/idpcontentplugin.h
+++ b/idpcontentplugin.h
@@ -116,7 +116,7 @@ public:
    IDPCONTENTPlugin(const options_t &module_options);
    IDPCONTENTPlugin(const options_t &module_options, vector<plugin_opt> plugin_options);
    int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, Packet &pkt);
+   int post_update(Flow &rec, const Packet &pkt);
    const char **get_ipfix_string();
    string get_unirec_field_string();
    void update_record(RecordExtIDPCONTENT *pstats_data, const Packet &pkt);

--- a/pstatsplugin.cpp
+++ b/pstatsplugin.cpp
@@ -81,11 +81,6 @@ PSTATSPlugin::PSTATSPlugin(const options_t &module_options, vector<plugin_opt> p
    print_stats = module_options.print_stats;
 }
 
-int PSTATSPlugin::pre_create(Packet &pkt)
-{
-   return 0;
-}
-
 void PSTATSPlugin::update_record(RecordExtPSTATS *pstats_data, const Packet &pkt)
 {
    /*
@@ -121,20 +116,11 @@ int PSTATSPlugin::post_create(Flow &rec, const Packet &pkt)
    return 0;
 }
 
-int PSTATSPlugin::pre_update(Flow &rec, Packet &pkt)
+int PSTATSPlugin::post_update(Flow &rec, const Packet &pkt)
 {
    RecordExtPSTATS *pstats_data = (RecordExtPSTATS *) rec.getExtension(pstats);
    update_record(pstats_data, pkt);
    return 0;
-}
-
-int PSTATSPlugin::post_update(Flow &rec, const Packet &pkt)
-{
-   return 0;
-}
-
-void PSTATSPlugin::pre_export(Flow &rec)
-{
 }
 
 void PSTATSPlugin::finish()

--- a/pstatsplugin.cpp
+++ b/pstatsplugin.cpp
@@ -123,13 +123,6 @@ int PSTATSPlugin::post_update(Flow &rec, const Packet &pkt)
    return 0;
 }
 
-void PSTATSPlugin::finish()
-{
-   if (print_stats) {
-      //cout << "PSTATS plugin stats:" << endl;
-   }
-}
-
 const char *ipfix_pstats_template[] = {
    IPFIX_PSTATS_TEMPLATE(IPFIX_FIELD_NAMES)
    NULL

--- a/pstatsplugin.h
+++ b/pstatsplugin.h
@@ -226,12 +226,9 @@ class PSTATSPlugin : public FlowCachePlugin
 public:
    PSTATSPlugin(const options_t &module_options);
    PSTATSPlugin(const options_t &module_options, vector<plugin_opt> plugin_options);
-   int pre_create(Packet &pkt);
    int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
    int post_update(Flow &rec, const Packet &pkt);
    void update_record(RecordExtPSTATS *pstats_data, const Packet &pkt);
-   void pre_export(Flow &rec);
    void finish();
    const char **get_ipfix_string();
    string get_unirec_field_string();

--- a/pstatsplugin.h
+++ b/pstatsplugin.h
@@ -229,7 +229,6 @@ public:
    int post_create(Flow &rec, const Packet &pkt);
    int post_update(Flow &rec, const Packet &pkt);
    void update_record(RecordExtPSTATS *pstats_data, const Packet &pkt);
-   void finish();
    const char **get_ipfix_string();
    string get_unirec_field_string();
    bool include_basic_flow_fields();


### PR DESCRIPTION
Fixed export of `pstats` and `idpcontent` plugins.
Problem was that parsing and data saving should been done in `post_update` instead of `pre_update` for general plugin (other protocol specific plugins could flushed and reinserted packet, thus exported data are duplicated).