### PR TITLE
Adding New Feature: Easier creation of IPFIX BasicList Structure with `IpfixBasicList` class

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,9 @@ ipfixprobe_src=main.cpp \
 		idpcontentplugin.h \
 		idpcontentplugin.cpp \
 		netbiosplugin.h \
-		netbiosplugin.cpp
+		netbiosplugin.cpp \
+		ipfix-basiclist.cpp \
+		ipfix-basiclist.h
 
 
 if WITH_NEMEA

--- a/byte-utils.h
+++ b/byte-utils.h
@@ -36,6 +36,9 @@
  * otherwise) arising in any way out of the use of this software, even
  * if advised of the possibility of such damage.
 */
+#ifndef BYTEUTILS
+#define BYTEUTILS
+
 #include <stdint.h>
 
 /**
@@ -55,4 +58,6 @@ static inline uint64_t swap_uint64(uint64_t value)
    value = ((value << 16) & 0xFFFF0000FFFF0000ULL ) | ((value >> 16) & 0x0000FFFF0000FFFFULL );
    return (value << 32) | (value >> 32);
 }
+#endif
+
 #endif

--- a/ipfix-basiclist.cpp
+++ b/ipfix-basiclist.cpp
@@ -1,0 +1,138 @@
+/**
+ * \file ipfix-basiclist.cpp
+ * \brief Plugin representing ipfix basiclist fmt.
+ * \author Karel Hynek <hynekkar@fit.cvut.cz>
+ * \date 2020
+ */
+/*
+ * Copyright (C) 2020 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
+
+
+#include "ipfix-basiclist.h"
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, uint16_t *values, uint16_t len, uint16_t fieldID)
+{
+   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint16_t), fieldID);
+
+   for (int i = 0; i < len; i++) {
+      (*reinterpret_cast<uint16_t *>(buffer + written)) = htons(values[i]);
+      written += sizeof(uint16_t);
+   }
+   return written;
+}
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, int16_t *values, uint16_t len, uint16_t fieldID)
+{
+   return this->FillBuffer(buffer, (uint16_t *) values, len, fieldID);
+}
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, uint32_t *values, uint16_t len, uint16_t fieldID)
+{
+   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint32_t), fieldID);
+
+   for (int i = 0; i < len; i++) {
+      (*reinterpret_cast<uint32_t *>(buffer + written)) = htonl(values[i]);
+      written += sizeof(uint32_t);
+   }
+   return written;
+}
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, int32_t *values, uint16_t len, uint16_t fieldID)
+{
+   return this->FillBuffer(buffer, (uint32_t *) values, len, fieldID);
+}
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, struct timeval *values, uint16_t len, uint16_t fieldID)
+{
+   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint64_t), fieldID);
+
+   for (int i = 0; i < len; i++) {
+      (*reinterpret_cast<uint64_t *>(buffer + written)) = swap_uint64(Tv2Ts(values[i]));
+      written += sizeof(uint64_t);
+   }
+   return written;
+}
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, uint8_t *values, uint16_t len, uint16_t fieldID)
+{
+   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint8_t), fieldID);
+
+   memcpy(buffer + written, values, len);
+   written += len;
+   return written;
+}
+
+int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, int8_t *values, uint16_t len, uint16_t fieldID)
+{
+   return this->FillBuffer(buffer, (uint8_t *) values, len, fieldID);
+}
+
+int32_t IpfixBasicList::FillBufferHdr(uint8_t *buffer, uint16_t length, uint16_t elementLength, uint16_t fieldID)
+{
+   uint32_t bufferPtr = 0;
+
+   // Copy flag
+   buffer[bufferPtr] = flag;
+   bufferPtr        += sizeof(uint8_t);
+   // Copy length;
+   *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(IpfixBasicListHdrSize + length * elementLength);
+   bufferPtr += sizeof(uint16_t);
+   // copy hdr_semantic
+   buffer[bufferPtr] = hdrSemantic;
+   bufferPtr        += sizeof(uint8_t);
+   // copy hdr_field_id
+   *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons((1 << 15) | fieldID);
+   bufferPtr += sizeof(uint16_t);
+   // copy hdr_element_len
+   *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(elementLength);
+   bufferPtr += sizeof(uint16_t);
+   // copy enterprise num from hdr struct
+   *(reinterpret_cast<uint32_t *>(buffer + bufferPtr)) = htonl((uint32_t) hdrEnterpriseNum);
+   bufferPtr += sizeof(uint32_t);
+
+   return bufferPtr;
+}
+
+int32_t IpfixBasicList::HeaderSize()
+{
+   return IpfixBasicListRecordHdrSize;
+}
+
+uint64_t IpfixBasicList::Tv2Ts(timeval input)
+{
+   return static_cast<uint64_t>(input.tv_sec) * 1000 + (input.tv_usec / 1000);
+}

--- a/ipfix-basiclist.h
+++ b/ipfix-basiclist.h
@@ -1,0 +1,82 @@
+/**
+ * \file ipfix-basiclist.h
+ * \brief struct representing ipfix basiclist fmt
+ * \author Karel Hynek <hynekkar@fit.cvut.cz>
+ * \date 2020
+ */
+/*
+ * Copyright (C) 2020 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
+
+#ifndef IPFIXBASICLIST
+#define IPFIXBASICLIST
+
+
+#include <arpa/inet.h>
+#include <cstring>
+#include "byte-utils.h"
+
+
+struct IpfixBasicList {
+public:
+   static const uint8_t IpfixBasicListRecordHdrSize = 12;
+   static const uint8_t IpfixBasicListHdrSize       = 9;
+   static const uint8_t flag        = 255; // Maximum size see rfc631;
+   static const uint8_t hdrSemantic = 3;
+
+   enum ePEMNumber {
+      CesnetPEM = 8057,
+   };
+
+   ePEMNumber hdrEnterpriseNum;
+
+
+   static uint64_t Tv2Ts(timeval input);
+
+   int32_t HeaderSize();
+   int32_t FillBuffer(uint8_t *buffer, uint16_t *values, uint16_t len, uint16_t fieldID);
+   int32_t FillBuffer(uint8_t *buffer, int16_t *values, uint16_t len, uint16_t fieldID);
+   int32_t FillBuffer(uint8_t *buffer, uint32_t *values, uint16_t len, uint16_t fieldID);
+   int32_t FillBuffer(uint8_t *buffer, int32_t *values, uint16_t len, uint16_t fieldID);
+   int32_t FillBuffer(uint8_t *buffer, struct timeval *values, uint16_t len, uint16_t fieldID);
+   int32_t FillBuffer(uint8_t *buffer, uint8_t *values, uint16_t len, uint16_t fieldID);
+   int32_t FillBuffer(uint8_t *buffer, int8_t *values, uint16_t len, uint16_t fieldID);
+
+private:
+   int32_t FillBufferHdr(uint8_t *buffer, uint16_t length, uint16_t elementLength, uint16_t fieldID);
+};
+
+#endif // ifndef IPFIXBASICLIST

--- a/pstatsplugin.h
+++ b/pstatsplugin.h
@@ -57,18 +57,13 @@
 #include "packet.h"
 #include "ipfixprobe.h"
 #include "byte-utils.h"
-
+#include "ipfix-basiclist.h"
 
 #ifndef PSTATS_MAXELEMCOUNT
 # define PSTATS_MAXELEMCOUNT 30
 #endif
 
 using namespace std;
-
-static inline uint64_t tv2ts(timeval input)
-{
-   return static_cast<uint64_t>(input.tv_sec) * 1000 + (input.tv_usec / 1000);
-}
 
 /**
  * \brief Flow record extension header for storing parsed PSTATS packets.
@@ -87,53 +82,8 @@ struct RecordExtPSTATS : RecordExt {
       PktTmstp = 1014
    } eHdrSemantic;
 
-
-   struct IpfixBasicRecordListHdr {
-      IpfixBasicRecordListHdr(uint8_t flag, uint16_t length, uint8_t hdrSemantic,
-        uint16_t hdrFieldID, uint16_t hdrElementLength,
-        uint32_t hdrEnterpriseNum) : flag(flag),
-         length(length), hdrSemantic(hdrSemantic),
-         hdrFieldID(hdrFieldID),
-         hdrElementLength(hdrElementLength),
-         hdrEnterpriseNum(hdrEnterpriseNum){ };
-      uint8_t  flag;
-      uint16_t length;
-      uint8_t  hdrSemantic;
-      uint16_t hdrFieldID;
-      uint16_t hdrElementLength;
-      uint32_t hdrEnterpriseNum;
-   };
-
-   static const uint8_t  IpfixBasicListRecordHdrSize = 12;
-   static const uint8_t  IpfixBasicListHdrSize       = 9;
    static const uint32_t CesnetPem = 8057;
 
-   int32_t FillBasicListBuffer(RecordExtPSTATS::IpfixBasicRecordListHdr& IpfixBasicListRecord, uint8_t *buffer,
-     int size)
-   {
-      uint32_t bufferPtr = 0;
-
-      // Copy flag
-      buffer[bufferPtr] = IpfixBasicListRecord.flag;
-      bufferPtr        += sizeof(uint8_t);
-      // Copy length;
-      *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(IpfixBasicListRecord.length);
-      bufferPtr += sizeof(uint16_t);
-      // copy hdr_semantic
-      buffer[bufferPtr] = IpfixBasicListRecord.hdrSemantic;
-      bufferPtr        += sizeof(uint8_t);
-      // copy hdr_field_id
-      *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(IpfixBasicListRecord.hdrFieldID);
-      bufferPtr += sizeof(uint16_t);
-
-      *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(IpfixBasicListRecord.hdrElementLength);
-      bufferPtr += sizeof(uint16_t);
-
-      *(reinterpret_cast<uint32_t *>(buffer + bufferPtr)) = htonl(IpfixBasicListRecord.hdrEnterpriseNum);
-      bufferPtr += sizeof(uint32_t);
-
-      return bufferPtr;
-   }
 
    RecordExtPSTATS() : RecordExt(pstats)
    {
@@ -162,58 +112,26 @@ struct RecordExtPSTATS : RecordExt {
    virtual int fillIPFIX(uint8_t *buffer, int size)
    {
       int32_t bufferPtr;
-      RecordExtPSTATS::IpfixBasicRecordListHdr hdr(255,// Maximum size see rfc631
-        IpfixBasicListHdrSize + pkt_count * (sizeof(uint16_t)),
-        3,
-        ((1 << 15) | (uint16_t) PktSize),
-        sizeof(uint16_t),
-        CesnetPem);
-
-      // Check sufficient size of buffer
-      int req_size = 4 * IpfixBasicListRecordHdrSize /* sizes, times, flags, dirs */
-        + pkt_count * sizeof(uint16_t)               /* sizes */
-        + 2 * pkt_count * sizeof(uint32_t)           /* times */
-        + pkt_count                                  /* flags */
-        + pkt_count /* dirs */;
+      IpfixBasicList basiclist;
+      basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
+      //Check sufficient size of buffer
+      int req_size = 4 * basiclist.HeaderSize() /* sizes, times, flags, dirs */ +
+                       pkt_count * sizeof(uint16_t) /* sizes */ +
+                       2 * pkt_count * sizeof(uint32_t) /* times */ +
+                       pkt_count /* flags */ +
+                       pkt_count /* dirs */;
 
       if (req_size > size) {
          return -1;
       }
-
-      // Fill sizes
-      // fill buffer with basic list header and packet sizes
-      bufferPtr = FillBasicListBuffer(hdr, buffer, size);
-      for (int i = 0; i < pkt_count; i++) {
-         (*reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(pkt_sizes[i]);
-         bufferPtr += sizeof(uint16_t);
-      }
-
-      // update information in hdr for next basic list with packet timestamps
-      // timestamps are in format [i] = sec, [i+1] = usec
-      hdr.length           = IpfixBasicListHdrSize + pkt_count * (sizeof(uint64_t));
-      hdr.hdrFieldID       = ((1 << 15) | (uint16_t) PktTmstp);
-      hdr.hdrElementLength = sizeof(uint64_t);
-      bufferPtr += FillBasicListBuffer(hdr, buffer + bufferPtr, size);
-      for (int i = 0; i < pkt_count; i++) {
-         (*reinterpret_cast<uint64_t *>(buffer + bufferPtr)) = swap_uint64(tv2ts(pkt_timestamps[i]));
-         bufferPtr += sizeof(uint64_t);
-      }
-
+      // Fill packet sizes
+      bufferPtr = basiclist.FillBuffer(buffer, pkt_sizes, pkt_count, (uint16_t) PktSize);
+      // Fill timestamps
+      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, pkt_timestamps, pkt_count,(uint16_t) PktTmstp);
       // Fill tcp flags
-      hdr.length           = IpfixBasicListHdrSize + pkt_count * (sizeof(uint8_t));
-      hdr.hdrFieldID       = ((1 << 15) | (uint16_t) PktFlags);
-      hdr.hdrElementLength = sizeof(uint8_t);
-      bufferPtr += FillBasicListBuffer(hdr, buffer + bufferPtr, size);
-      memcpy(buffer + bufferPtr, pkt_tcp_flgs, pkt_count);
-      bufferPtr += pkt_count;
-
+      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, pkt_tcp_flgs, pkt_count, (uint16_t) PktFlags);
       // Fill directions
-      hdr.length           = IpfixBasicListHdrSize + pkt_count * (sizeof(int8_t));
-      hdr.hdrFieldID       = ((1 << 15) | (uint16_t) PktDir);
-      hdr.hdrElementLength = sizeof(int8_t);
-      bufferPtr += FillBasicListBuffer(hdr, buffer + bufferPtr, size);
-      memcpy(buffer + bufferPtr, pkt_dirs, pkt_count);
-      bufferPtr += pkt_count;
+      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, pkt_dirs, pkt_count,(uint16_t) PktDir);
 
       return bufferPtr;
    } // fillIPFIX


### PR DESCRIPTION
The `IpfixBasicList` class makes basic list export much easier. It literally creates the basic list structure with only one method and moves it to the c-style buffer