### PR TITLE
ipfixprobed: extend service to support list of interfaces

### DIFF
--- a/init/ipfixprobed
+++ b/init/ipfixprobed
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/bash
 
 CONFFILE="/etc/ipfixprobe/$1.conf"
 
@@ -9,7 +9,21 @@ if [ -e "$CONFFILE" ]; then
    else
       udpparam=""
    fi
-   exec /usr/bin/ipfixprobe -I "$NIC" -p "$PLUGINS" -L "$LINK" -D "$DIR" -x "$COLLECTOR" $udpparam
+   ifcargs=""
+   if `declare -p IFCLIST > /dev/null 2>/dev/null`; then
+      # list of interfaces/DMA channels
+      for ifc in "${!IFCLIST[@]}"; do
+         ifcargs="$ifcargs -I ${IFCLIST[ifc]}"
+      done
+   else
+      # use plain old one NIC interface
+      if [ -z "$NIC" ]; then
+         echo "Configuration file '$CONFFILE' does not exist, exitting." >&2
+         exit 1
+      fi
+      ifcargs="-I $NIC"
+   fi
+   exec /usr/bin/ipfixprobe $ifcargs -p "$PLUGINS" -L "$LINK" -D "$DIR" -x "$COLLECTOR" $udpparam
 else
    echo "Configuration file '$CONFFILE' does not exist, exitting." >&2
    exit 1

--- a/init/link0.conf.example
+++ b/init/link0.conf.example
@@ -1,7 +1,14 @@
 # set up shell-like variables
 
-# Network interface
-NIC=eth0
+# List of interfaces / DMA channels
+#   Specify array of devices using IFCLIST[], indexes (subscripts) must be unique
+IFCLIST[0]=/dev/nfb0:0
+IFCLIST[1]=/dev/nfb0:1
+# ... more IFCLIST can be added
+
+# One network interface
+#   NOTE: remove IFCLIST variables and uncomment NIC if you prefer to use this way:
+# NIC=eth0
 
 # List of activated plugins, to skip plugins, use "basic" only:
 # PLUGINS=basic


### PR DESCRIPTION
Configuration file now allows to declare IFCLIST array to specify
multiple instances of `-I` argument.

The example was added into link0.conf.example