### PR TITLE
Bugfixes

### DIFF
--- a/byte-utils.h
+++ b/byte-utils.h
@@ -41,24 +41,27 @@
 #define BYTEUTILS
 
 #include <stdint.h>
+#include <endian.h>
 
 /**
  * \brief Swaps byte order of 8 B value.
  * @param value Value to swap
  * @return Swapped value
  */
-#if BYTEORDER == 4321 /* Big endian */
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
 static inline uint64_t swap_uint64(uint64_t value)
 {
    return value;
 }
-#else
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
 static inline uint64_t swap_uint64(uint64_t value)
 {
    value = ((value << 8) & 0xFF00FF00FF00FF00ULL ) | ((value >> 8) & 0x00FF00FF00FF00FFULL );
    value = ((value << 16) & 0xFFFF0000FFFF0000ULL ) | ((value >> 16) & 0x0000FFFF0000FFFFULL );
    return (value << 32) | (value >> 32);
 }
-#endif
+# else
+#  error  "Please fix <endian.h>"
+# endif
 
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,13 @@ else
    AM_CONDITIONAL(HAVE_LIBPCAP, false)
 fi
 
+AC_ARG_WITH([flowcachesize],
+       AC_HELP_STRING([--with-flowcachesize=NUMBER],[Set default size of flow cache in number of flow records.]),
+       [
+       CPPFLAGS="$CPPFLAGS -DFLOW_CACHE_SIZE=$withval"
+       ]
+)
+
 AC_ARG_WITH([nemea],
         AC_HELP_STRING([--with-nemea],[Compile with NEMEA framework (nemea.liberouter.org).]),
         [

--- a/dns.h
+++ b/dns.h
@@ -45,6 +45,7 @@
 #define DNS_H
 
 #include <stdint.h>
+#include <endian.h>
 
 #define DNS_TYPE_A      1
 #define DNS_TYPE_NS     2
@@ -85,7 +86,7 @@ struct __attribute__ ((packed)) dns_hdr {
    uint16_t id;
    union {
       struct {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
          uint16_t recursion_desired:1;
          uint16_t truncation:1;
          uint16_t authoritative_answer:1;
@@ -96,7 +97,7 @@ struct __attribute__ ((packed)) dns_hdr {
          uint16_t auth_data:1;
          uint16_t reserved:1;
          uint16_t recursion_available:1;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
          uint16_t query_response:1;
          uint16_t op_code:4;
          uint16_t authoritative_answer:1;
@@ -107,7 +108,9 @@ struct __attribute__ ((packed)) dns_hdr {
          uint16_t auth_data:1;
          uint16_t checking_disabled:1;
          uint16_t response_code:4;
-#endif
+# else
+#  error  "Please fix <endian.h>"
+# endif
       };
       uint16_t flags;
    };

--- a/headers.h
+++ b/headers.h
@@ -265,4 +265,17 @@ struct __attribute__((packed)) trill_hdr {
    uint16_t ingress_nick;
 };
 
+struct __attribute__((packed)) pppoe_hdr {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+   uint8_t type:4;
+   uint8_t version:4;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+   uint8_t version:4;
+   uint8_t type:4;
+#endif
+   uint8_t code;
+   uint16_t sid;
+   uint16_t length;
+};
+
 #endif /* HEADERS_H */

--- a/headers.h
+++ b/headers.h
@@ -45,6 +45,7 @@
 #define HEADERS_H
 
 #include <netinet/in.h>
+#include <endian.h>
 
 #define ETH_P_8021AD  0x88A8
 #define ETH_P_8021AH  0x88E7
@@ -68,14 +69,14 @@ struct ethhdr {
 
 struct iphdr
 {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
    unsigned int ihl:4;
    unsigned int version:4;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
    unsigned int version:4;
    unsigned int ihl:4;
 #else
-# error  "Please fix <bits/endian.h>"
+# error  "Please fix <endian.h>"
 #endif
    uint8_t tos;
    uint16_t tot_len;
@@ -132,14 +133,14 @@ struct tcphdr
          uint16_t th_dport;   /* destination port */
          uint32_t th_seq;      /* sequence number */
          uint32_t th_ack;      /* acknowledgement number */
-# if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
          uint8_t th_x2:4;  /* (unused) */
          uint8_t th_off:4; /* data offset */
-# elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
          uint8_t th_off:4; /* data offset */
          uint8_t th_x2:4;  /* (unused) */
 # else
-#  error  "Please fix <bits/endian.h>"
+#  error  "Please fix <endian.h>"
 # endif
          uint8_t th_flags;
 # define TH_FIN   0x01
@@ -158,7 +159,7 @@ struct tcphdr
          uint16_t dest;
          uint32_t seq;
          uint32_t ack_seq;
-# if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
          uint16_t res1:4;
          uint16_t doff:4;
          uint16_t fin:1;
@@ -168,7 +169,7 @@ struct tcphdr
          uint16_t ack:1;
          uint16_t urg:1;
          uint16_t res2:2;
-# elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
          uint16_t doff:4;
          uint16_t res1:4;
          uint16_t res2:2;
@@ -179,7 +180,7 @@ struct tcphdr
          uint16_t syn:1;
          uint16_t fin:1;
 # else
-#  error "Adjust your <bits/endian.h> defines"
+#  error "Please fix <endian.h>"
 # endif
          uint16_t window;
          uint16_t check;
@@ -244,35 +245,37 @@ struct icmp6_hdr
 };
 
 struct __attribute__((packed)) trill_hdr {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
    uint8_t op_len1:3;
    uint8_t m:1;
    uint8_t res:2;
    uint8_t version:2;
    uint8_t hop_cnt:6;
    uint8_t op_len2:2;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
    uint8_t version:2;
    uint8_t res:2;
    uint8_t m:1;
    uint8_t op_len1:3;
    uint8_t op_len2:2;
    uint8_t hop_cnt:6;
-#else
-# error  "Please fix <bits/endian.h>"
-#endif
+# else
+#  error  "Please fix <endian.h>"
+# endif
    uint16_t egress_nick;
    uint16_t ingress_nick;
 };
 
 struct __attribute__((packed)) pppoe_hdr {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
    uint8_t type:4;
    uint8_t version:4;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
    uint8_t version:4;
    uint8_t type:4;
-#endif
+# else
+#  error  "Please fix <endian.h>"
+# endif
    uint8_t code;
    uint16_t sid;
    uint16_t length;

--- a/httpplugin.cpp
+++ b/httpplugin.cpp
@@ -302,7 +302,8 @@ bool HTTPPlugin::parse_http_request(const char *data, int payload_len, RecordExt
       DEBUG_MSG("Parser quits:\tflushing flow\n");
       return false;
    }
-   strcpy(rec->method, buffer);
+   strncpy(rec->method, buffer, sizeof(rec->method));
+   rec->method[sizeof(rec->method) - 1] = 0;
 
    copy_str(rec->uri, sizeof(rec->uri), begin + 1, end);
    DEBUG_MSG("\tMethod: %s\n",   rec->method);

--- a/ipfix-elements.h
+++ b/ipfix-elements.h
@@ -61,7 +61,7 @@
 /**
  * Difference between NTP and UNIX epoch in number of seconds.
  */
-#define EPOCH_DIFF 2208988800
+#define EPOCH_DIFF 2208988800ULL
 
 /**
  * Conversion from microseconds to NTP fraction (resolution 1/(2^32)s,  ~233 picoseconds).
@@ -72,7 +72,7 @@
 /**
  * Create 64 bit NTP timestamp which consist of 32 bit seconds part and 32 bit fraction part.
  */
-#define MK_NTP_TS(ts) (htonl(ts.tv_sec + EPOCH_DIFF) | ((uint64_t) htonl(NTP_USEC_TO_FRAC(ts.tv_usec)) << 32))
+#define MK_NTP_TS(ts) (((uint64_t) (ts.tv_sec + EPOCH_DIFF) << 32) | (uint64_t) NTP_USEC_TO_FRAC(ts.tv_usec))
 
 /**
  * Convert FIELD to its "attributes", i.e. BYTES(FIELD) used in the source code produces
@@ -86,8 +86,8 @@
 #define BYTES_REV(F)                  F(29305,    1,    8,   &flow.dst_octet_total_length)
 #define PACKETS(F)                    F(0,        2,    8,   (temp = (uint64_t) flow.src_pkt_total_cnt, &temp))
 #define PACKETS_REV(F)                F(29305,    2,    8,   (temp = (uint64_t) flow.dst_pkt_total_cnt, &temp))
-#define FLOW_START_USEC(F)            F(0,      154,    8,   (temp = swap_uint64(MK_NTP_TS(flow.time_first)), &temp))
-#define FLOW_END_USEC(F)              F(0,      155,    8,   (temp = swap_uint64(MK_NTP_TS(flow.time_last)), &temp))
+#define FLOW_START_USEC(F)            F(0,      154,    8,   (temp = MK_NTP_TS(flow.time_first), &temp))
+#define FLOW_END_USEC(F)              F(0,      155,    8,   (temp = MK_NTP_TS(flow.time_last), &temp))
 #define OBSERVATION_MSEC(F)           F(0,      323,    8,   NULL)
 #define INPUT_INTERFACE(F)            F(0,       10,    2,   &this->dir_bit_field)
 #define OUTPUT_INTERFACE(F)           F(0,       14,    2,   NULL)

--- a/ipfixprobe.h
+++ b/ipfixprobe.h
@@ -58,12 +58,12 @@ using namespace std;
 extern int stop;
 
 #ifdef FLOW_CACHE_SIZE
-const unsigned int DEFAULT_FLOW_CACHE_SIZE = FLOW_CACHE_SIZE;
+const uint32_t DEFAULT_FLOW_CACHE_SIZE = FLOW_CACHE_SIZE;
 #else
 #ifdef HAVE_NDP
-const unsigned int DEFAULT_FLOW_CACHE_SIZE = 524288;
+const uint32_t DEFAULT_FLOW_CACHE_SIZE = 524288;
 #else
-const unsigned int DEFAULT_FLOW_CACHE_SIZE = 131072;
+const uint32_t DEFAULT_FLOW_CACHE_SIZE = 131072;
 #endif /* HAVE_NDP */
 #endif /* FLOW_CACHE_SIZE */
 
@@ -75,6 +75,20 @@ const unsigned int DEFAULT_FLOW_LINE_SIZE = 16;
 #endif /* HAVE_NDP */
 const double DEFAULT_INACTIVE_TIMEOUT = 30.0;
 const double DEFAULT_ACTIVE_TIMEOUT = 300.0;
+
+/*
+ * \brief Count number of bits in 32 bit integer
+ * \param [in] num Number to count ones in
+ * \return Number of ones counted
+ */
+static constexpr int bitcount32(uint32_t num)
+{
+   return num == 0 ? 0 : (bitcount32(num >> 1) + (num & 1));
+}
+
+static_assert(bitcount32(DEFAULT_FLOW_CACHE_SIZE) == 1, "Flow cache size must be power of two number!");
+static_assert(bitcount32(DEFAULT_FLOW_LINE_SIZE) == 1, "Flow cache line size must be power of two number!");
+static_assert(DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE, "Flow cache size must be at least cache line size!");
 
 /**
  * \brief Struct containing module settings.

--- a/main.cpp
+++ b/main.cpp
@@ -929,10 +929,6 @@ int main(int argc, char *argv[])
       options.snaplen = MAXPCKTSIZE;
    }
 
-   if (!options.print_stats) {
-      plugin_wrapper.plugins.push_back(new StatsPlugin(options.cache_stats_interval, cout));
-   }
-
    FlowExporter *exporter;
    if (export_unirec) {
 #ifdef WITH_NEMEA
@@ -961,6 +957,10 @@ int main(int argc, char *argv[])
    ipx_ring_t *export_queue = ipx_ring_init(options.flow_cache_qsize, 1);
    if (export_queue == NULL) {
       return error("Unable to initialize ring buffer.");
+   }
+
+   if (!options.print_stats) {
+      plugin_wrapper.plugins.push_back(new StatsPlugin(options.cache_stats_interval, cout));
    }
 
    std::vector<WorkPipeline> pipelines;

--- a/parser.cpp
+++ b/parser.cpp
@@ -45,6 +45,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <sys/types.h>
 
 #ifndef HAVE_NDP
 #include <pcap/sll.h>

--- a/parser.cpp
+++ b/parser.cpp
@@ -549,19 +549,6 @@ uint16_t process_mpls(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
    return length;
 }
 
-struct __attribute__((packed)) pppoe_hdr {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-   uint8_t type:4;
-   uint8_t version:4;
-#elif __BYTE_ORDER == __BIG_ENDIAN
-   uint8_t version:4;
-   uint8_t type:4;
-#endif
-   uint8_t code;
-   uint16_t sid;
-   uint16_t length;
-};
-
 /**
  * \brief Parse PPPOE header and the following IP header.
  * \param [in] data_ptr Pointer to begin of header.

--- a/parser.h
+++ b/parser.h
@@ -46,10 +46,6 @@
 
 #include "packet.h"
 
-#ifndef u_char
-#define u_char unsigned char
-#endif
-
 #ifndef ETH_P_8021AD
 #define ETH_P_8021AD	0x88A8          /* 802.1ad Service VLAN*/
 #endif

--- a/smtpplugin.cpp
+++ b/smtpplugin.cpp
@@ -333,6 +333,9 @@ bool SMTPPlugin::parse_smtp_command(const char *data, int payload_len, RecordExt
          if (end != NULL && begin != NULL) {
             begin++;
             len = end - begin;
+            if (len >= sizeof(rec->domain)) {
+               len = sizeof(rec->domain) - 1;
+            }
 
             memcpy(rec->domain, begin, len);
             rec->domain[len] = 0;
@@ -351,6 +354,9 @@ bool SMTPPlugin::parse_smtp_command(const char *data, int payload_len, RecordExt
          if (end != NULL && begin != NULL) {
             begin++;
             len = end - begin;
+            if (len >= sizeof(rec->first_recipient)) {
+               len = sizeof(rec->first_recipient) - 1;
+            }
 
             memcpy(rec->first_recipient, begin, len);
             rec->first_recipient[len] = 0;
@@ -365,6 +371,9 @@ bool SMTPPlugin::parse_smtp_command(const char *data, int payload_len, RecordExt
          if (end != NULL && begin != NULL) {
             begin++;
             len = end - begin;
+            if (len >= sizeof(rec->first_sender)) {
+               len = sizeof(rec->first_sender) - 1;
+            }
 
             memcpy(rec->first_sender, begin, len);
             rec->first_sender[len] = 0;


### PR DESCRIPTION
Fixed the following issues:
- Problematic field parsing in HTTP plugin
- Problematic field parsing in SMTP plugin
- Missing configure parameter `flowcachesize` 
- Invalid timestamp conversion on big endian architectures
- Issues with packet headers compilation on big endian architectures

And added static checks for cache and cache line sizes.