### PR TITLE
Dpdk flexprobe extension

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,6 +115,16 @@ ipfixprobe_process_src+=\
 		process/quic.hpp \
 		process/quic.cpp
 endif
+if WITH_FLEXPROBE
+ipfixprobe_process_src+=\
+		process/flexprobe-data.h \
+		process/flexprobe-data-processing.cpp \
+		process/flexprobe-data-processing.h \
+		process/flexprobe-tcp-tracking.cpp \
+		process/flexprobe-tcp-tracking.h \
+		process/flexprobe-encryption-processing.cpp \
+		process/flexprobe-encryption-processing.h
+endif
 
 ipfixprobe_headers_src=\
 		include/ipfixprobe/plugin.hpp \
@@ -140,6 +150,8 @@ ipfixprobe_src=\
 		$(ipfixprobe_headers_src) \
 		pluginmgr.cpp \
 		pluginmgr.hpp \
+		stacktrace.cpp \
+		stacktrace.hpp \
 		options.cpp \
 		utils.cpp \
 		ring.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,12 @@ ipfixprobe_input_src+=\
 		input/pcap.hpp
 endif
 
+if WITH_STEM
+ipfixprobe_input_src+=\
+		input/stem.cpp \
+		input/stem.hpp
+endif
+
 ipfixprobe_storage_src=\
 		storage/cache.cpp \
 		storage/cache.hpp \
@@ -66,6 +72,8 @@ ipfixprobe_output_src+=\
 			fields.c \
 			fields.h
 endif
+
+
 
 ipfixprobe_process_src=\
 		process/http.cpp \
@@ -126,6 +134,12 @@ ipfixprobe_process_src+=\
 		process/flexprobe-encryption-processing.h
 endif
 
+if WITH_DPDK
+ipfixprobe_input_src+=\
+        input/dpdk.cpp \
+        input/dpdk.hpp
+endif
+
 ipfixprobe_headers_src=\
 		include/ipfixprobe/plugin.hpp \
 		include/ipfixprobe/input.hpp \
@@ -150,8 +164,6 @@ ipfixprobe_src=\
 		$(ipfixprobe_headers_src) \
 		pluginmgr.cpp \
 		pluginmgr.hpp \
-		stacktrace.cpp \
-		stacktrace.hpp \
 		options.cpp \
 		utils.cpp \
 		ring.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -137,7 +137,7 @@ endif
 if WITH_DPDK
 ipfixprobe_input_src+=\
         input/dpdk.cpp \
-        input/dpdk.hpp
+        input/dpdk.h
 endif
 
 ipfixprobe_headers_src=\

--- a/configure.ac
+++ b/configure.ac
@@ -326,35 +326,6 @@ else
    AM_CONDITIONAL(WITH_LIBUNWIND, false)
 fi
 
-if test x${withndp} = xno; then
-   AC_CHECK_HEADER(pcap.h,
-              AC_CHECK_LIB(pcap, pcap_open_live, [libpcap=yes],
-                           AC_CHECK_LIB(wpcap, pcap_open_live, [libwpcap=yes], AC_MSG_ERROR([libpcap not found. The ipfixprobe flow exporter will not be compiled.]))),
-                           AC_MSG_ERROR([pcap.h not found. The ipfixprobe flow exporter will not be compiled.]))
-
-   AM_CONDITIONAL(HAVE_LIBPCAP, test x${libpcap} = xyes || test x${libwpcap} = xyes)
-   if [[ -z "$HAVE_LIBPCAP_TRUE" ]]; then
-      if test x${libpcap} = xyes; then
-         LIBS="-lpcap $LIBS"
-         RPM_REQUIRES+=" libpcap"
-         RPM_BUILDREQ+=" libpcap-devel"
-      else
-         LIBS="-lwpcap $LIBS"
-         RPM_REQUIRES+=" libwpcap"
-         RPM_BUILDREQ+=" libwpcap-devel"
-      fi
-   fi
-else
-   AM_CONDITIONAL(HAVE_LIBPCAP, false)
-fi
-
-AC_ARG_WITH([flowcachesize],
-       AC_HELP_STRING([--with-flowcachesize=NUMBER],[Set default size of flow cache in number of flow records.]),
-       [
-       CPPFLAGS="$CPPFLAGS -DFLOW_CACHE_SIZE=$withval"
-       ]
-)
-
 AC_ARG_WITH([nemea],
         AC_HELP_STRING([--with-nemea],[Compile with NEMEA framework (nemea.liberouter.org).]),
         [

--- a/configure.ac
+++ b/configure.ac
@@ -409,7 +409,6 @@ AC_CONFIG_FILES([Makefile
                  ipfixprobe.spec
                  ipfixprobe.bash
                  input/nfbCInterface/Makefile
-                 input/Makefile
                  init/Makefile
                  tests/Makefile
                  tests/functional/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -205,65 +205,6 @@ if [[ -z "$WITH_NDP_TRUE" ]]; then
    RPM_BUILDREQ+=" netcope-common-devel"
 fi
 
-AC_ARG_WITH([flexprobe],
-         AC_HELP_STRING([--with-flexprobe], [Compile with support for flexprobe data processing plugins.]),
-         [
-            if test "$withval" = "yes"; then
-               withflexprobe="yes"
-            else
-               withflexprobe="no"
-            fi
-         ],
-         [withflexprobe="no"]
-)
-
-AM_CONDITIONAL(WITH_FLEXPROBE, test x${withflexprobe} = xyes)
-if [[ -z "$WITH_FLEXPROBE_TRUE" ]]; then
-   AC_DEFINE([WITH_FLEXPROBE], [1], [Define to 1 to use flexprobe plugins])
-fi
-
-AC_ARG_WITH([stem],
-         AC_HELP_STRING([--with-stem], [Compile with FlexProbe StEm testing interface]),
-         [
-            if test "$withval" = "yes"; then
-               withstem="yes"
-            else
-               withstem="no"
-            fi
-         ],
-         [withstem="no"]
-)
-
-AM_CONDITIONAL(WITH_STEM, test x${withstem} = xyes)
-if [[ -z "$WITH_STEM_TRUE" ]]; then
-   AC_DEFINE([WITH_STEM], [1], [Define to 1 to use flexprobe testing interface])
-   CFLAGS="-I/usr/local/include/Stem $CFLAGS"
-   CXXFLAGS="-I/usr/local/include/Stem -std=gnu++17 -g -Wno-write-strings $CXXFLAGS"
-   LIBS="-lstem $LIBS"
-fi
-
-AC_ARG_WITH([dpdk],
-         AS_HELP_STRING([--with-dpdk],[Compile ipfixprobe with DPDK interface support.]),
-         [
-            if test "$withval" = "yes"; then
-               withdpdk="yes"
-            else
-               withdpdk="no"
-            fi
-         ],
-         [withdpdk="no"]
-)
-
-AM_CONDITIONAL(WITH_DPDK, test x${withdpdk} = xyes)
-if [[ -z "$WITH_DPDK_TRUE" ]]; then
-   AC_DEFINE([WITH_DPDK], [1], [Define 1 if DPDK interface will be used])
-   PKG_CHECK_MODULES([DPDK], [libdpdk])
-   CFLAGS="$DPDK_CFLAGS $CFLAGS"
-   CXXFLAGS="$DPDK_CFLAGS $CXXFLAGS"
-   LIBS="$DPDK_LIBS $LIBS"
-   
-fi
-
 AC_ARG_WITH([pcap],
         AC_HELP_STRING([--with-pcap],[Compile ipfixprobe with pcap plugin for capturing using libpcap library]),
         [
@@ -348,6 +289,65 @@ if [[ -z "$WITH_NEMEA_TRUE" ]]; then
 AC_DEFINE([WITH_NEMEA], [1], [Define to 1 if the NEMEA is available])
 RPM_REQUIRES+=" libtrap"
 RPM_BUILDREQ+=" libtrap-devel unirec"
+fi
+
+
+AC_ARG_WITH([dpdk],
+         AS_HELP_STRING([--with-dpdk],[Compile ipfixprobe with DPDK interface support.]),
+         [
+            if test "$withval" = "yes"; then
+               withdpdk="yes"
+            else
+               withdpdk="no"
+            fi
+         ],
+         [withdpdk="no"]
+)
+
+AM_CONDITIONAL(WITH_DPDK, test x${withdpdk} = xyes)
+if [[ -z "$WITH_DPDK_TRUE" ]]; then
+   AC_DEFINE([WITH_DPDK], [1], [Define 1 if DPDK interface will be used])
+   PKG_CHECK_MODULES([DPDK], [libdpdk])
+   CFLAGS="$DPDK_CFLAGS $CFLAGS"
+   CXXFLAGS="$DPDK_CFLAGS $CXXFLAGS"
+   LIBS="$DPDK_LIBS $LIBS"
+fi
+
+AC_ARG_WITH([flexprobe],
+         AC_HELP_STRING([--with-flexprobe], [Compile with support for flexprobe data processing plugins.]),
+         [
+            if test "$withval" = "yes"; then
+               withflexprobe="yes"
+            else
+               withflexprobe="no"
+            fi
+         ],
+         [withflexprobe="no"]
+)
+
+AM_CONDITIONAL(WITH_FLEXPROBE, test x${withflexprobe} = xyes)
+if [[ -z "$WITH_FLEXPROBE_TRUE" ]]; then
+   AC_DEFINE([WITH_FLEXPROBE], [1], [Define to 1 to use flexprobe plugins])
+fi
+
+AC_ARG_WITH([stem],
+         AC_HELP_STRING([--with-stem], [Compile with FlexProbe StEm testing interface]),
+         [
+            if test "$withval" = "yes"; then
+               withstem="yes"
+            else
+               withstem="no"
+            fi
+         ],
+         [withstem="no"]
+)
+
+AM_CONDITIONAL(WITH_STEM, test x${withstem} = xyes)
+if [[ -z "$WITH_STEM_TRUE" ]]; then
+   AC_DEFINE([WITH_STEM], [1], [Define to 1 to use flexprobe testing interface])
+   CFLAGS="-I/usr/local/include/Stem $CFLAGS"
+   CXXFLAGS="-I/usr/local/include/Stem -std=gnu++17 -g -Wno-write-strings $CXXFLAGS"
+   LIBS="-lstem $LIBS"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -217,12 +217,52 @@ AC_ARG_WITH([flexprobe],
          [withflexprobe="no"]
 )
 
-# if test x${withflexprobe} = xyes; then
 AM_CONDITIONAL(WITH_FLEXPROBE, test x${withflexprobe} = xyes)
 if [[ -z "$WITH_FLEXPROBE_TRUE" ]]; then
    AC_DEFINE([WITH_FLEXPROBE], [1], [Define to 1 to use flexprobe plugins])
 fi
-# fi
+
+AC_ARG_WITH([stem],
+         AC_HELP_STRING([--with-stem], [Compile with FlexProbe StEm testing interface]),
+         [
+            if test "$withval" = "yes"; then
+               withstem="yes"
+            else
+               withstem="no"
+            fi
+         ],
+         [withstem="no"]
+)
+
+AM_CONDITIONAL(WITH_STEM, test x${withstem} = xyes)
+if [[ -z "$WITH_STEM_TRUE" ]]; then
+   AC_DEFINE([WITH_STEM], [1], [Define to 1 to use flexprobe testing interface])
+   CFLAGS="-I/usr/local/include/Stem $CFLAGS"
+   CXXFLAGS="-I/usr/local/include/Stem -std=gnu++17 -g -Wno-write-strings $CXXFLAGS"
+   LIBS="-lstem $LIBS"
+fi
+
+AC_ARG_WITH([dpdk],
+         AS_HELP_STRING([--with-dpdk],[Compile ipfixprobe with DPDK interface support.]),
+         [
+            if test "$withval" = "yes"; then
+               withdpdk="yes"
+            else
+               withdpdk="no"
+            fi
+         ],
+         [withdpdk="no"]
+)
+
+AM_CONDITIONAL(WITH_DPDK, test x${withdpdk} = xyes)
+if [[ -z "$WITH_DPDK_TRUE" ]]; then
+   AC_DEFINE([WITH_DPDK], [1], [Define 1 if DPDK interface will be used])
+   PKG_CHECK_MODULES([DPDK], [libdpdk])
+   CFLAGS="$DPDK_CFLAGS $CFLAGS"
+   CXXFLAGS="$DPDK_CFLAGS $CXXFLAGS"
+   LIBS="$DPDK_LIBS $LIBS"
+   
+fi
 
 AC_ARG_WITH([pcap],
         AC_HELP_STRING([--with-pcap],[Compile ipfixprobe with pcap plugin for capturing using libpcap library]),
@@ -417,22 +457,24 @@ echo
 echo
 echo "Configuration Options Summary:"
 echo
-echo "  ASM.(32 bit only)..: $ASM"
-echo "  Static binary......: $static"
+echo "  ASM.(32 bit only)......: $ASM"
+echo "  Static binary..........: $static"
 echo
-echo "Documentation..........: ${build_doc}"
+echo "Documentation............: ${build_doc}"
 echo
-echo "UniRec processor.......: $UNIRECPROC"
-echo "trap2man.sh............: $TRAP2MAN"
-echo "Compilation............: make (or gmake)"
-echo "  CPPFLAGS.............: $CPPFLAGS"
-echo "  CFLAGS...............: $CFLAGS"
-echo "  CXXFLAGS.............: $CXXFLAGS"
-echo "  LDFLAGS..............: $LDFLAGS"
-echo "  LIBS.................: $LIBS"
+echo "UniRec processor.........: $UNIRECPROC"
+echo "trap2man.sh..............: $TRAP2MAN"
+echo "Compilation..............: make (or gmake)"
+echo "  CPPFLAGS...............: $CPPFLAGS"
+echo "  CFLAGS.................: $CFLAGS"
+echo "  CXXFLAGS...............: $CXXFLAGS"
+echo "  LDFLAGS................: $LDFLAGS"
+echo "  LIBS...................: $LIBS"
 echo "Enforced NEMEA (for copr): $NEMEARPM"
+echo "FlexProbe Data Interface.: $withflexprobe"
+echo "DPDK Interface...........: $withdpdk"
 echo
-echo "Installation...........: make install (as root if needed, with 'su' or 'sudo')"
-echo "  prefix...............: $prefix"
+echo "Installation.............: make install (as root if needed, with 'su' or 'sudo')"
+echo "  prefix.................: $prefix"
 echo
 

--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,24 @@ if [[ -z "$WITH_NDP_TRUE" ]]; then
    RPM_BUILDREQ+=" netcope-common-devel"
 fi
 
+AC_ARG_WITH([flexprobe],
+         AC_HELP_STRING([--with-flexprobe], [Compile with support for flexprobe data processing plugins.]),
+         [
+            if test "$withval" = "yes"; then
+               withflexprobe="yes"
+            else
+               withflexprobe="no"
+            fi
+         ],
+         [withflexprobe="no"]
+)
+
+# if test x${withflexprobe} = xyes; then
+AM_CONDITIONAL(WITH_FLEXPROBE, test x${withflexprobe} = xyes)
+if [[ -z "$WITH_FLEXPROBE_TRUE" ]]; then
+   AC_DEFINE([WITH_FLEXPROBE], [1], [Define to 1 to use flexprobe plugins])
+fi
+# fi
 
 AC_ARG_WITH([pcap],
         AC_HELP_STRING([--with-pcap],[Compile ipfixprobe with pcap plugin for capturing using libpcap library]),
@@ -268,6 +286,34 @@ else
    AM_CONDITIONAL(WITH_LIBUNWIND, false)
 fi
 
+if test x${withndp} = xno; then
+   AC_CHECK_HEADER(pcap.h,
+              AC_CHECK_LIB(pcap, pcap_open_live, [libpcap=yes],
+                           AC_CHECK_LIB(wpcap, pcap_open_live, [libwpcap=yes], AC_MSG_ERROR([libpcap not found. The ipfixprobe flow exporter will not be compiled.]))),
+                           AC_MSG_ERROR([pcap.h not found. The ipfixprobe flow exporter will not be compiled.]))
+
+   AM_CONDITIONAL(HAVE_LIBPCAP, test x${libpcap} = xyes || test x${libwpcap} = xyes)
+   if [[ -z "$HAVE_LIBPCAP_TRUE" ]]; then
+      if test x${libpcap} = xyes; then
+         LIBS="-lpcap $LIBS"
+         RPM_REQUIRES+=" libpcap"
+         RPM_BUILDREQ+=" libpcap-devel"
+      else
+         LIBS="-lwpcap $LIBS"
+         RPM_REQUIRES+=" libwpcap"
+         RPM_BUILDREQ+=" libwpcap-devel"
+      fi
+   fi
+else
+   AM_CONDITIONAL(HAVE_LIBPCAP, false)
+fi
+
+AC_ARG_WITH([flowcachesize],
+       AC_HELP_STRING([--with-flowcachesize=NUMBER],[Set default size of flow cache in number of flow records.]),
+       [
+       CPPFLAGS="$CPPFLAGS -DFLOW_CACHE_SIZE=$withval"
+       ]
+)
 
 AC_ARG_WITH([nemea],
         AC_HELP_STRING([--with-nemea],[Compile with NEMEA framework (nemea.liberouter.org).]),
@@ -352,6 +398,7 @@ AC_CONFIG_FILES([Makefile
                  ipfixprobe.spec
                  ipfixprobe.bash
                  input/nfbCInterface/Makefile
+                 input/Makefile
                  init/Makefile
                  tests/Makefile
                  tests/functional/Makefile
@@ -388,3 +435,4 @@ echo
 echo "Installation...........: make install (as root if needed, with 'su' or 'sudo')"
 echo "  prefix...............: $prefix"
 echo
+

--- a/include/ipfixprobe/ipfix-elements.hpp
+++ b/include/ipfixprobe/ipfix-elements.hpp
@@ -252,6 +252,10 @@ namespace ipxp {
 
 #define QUIC_SNI(F)                   F(8057,    890,   -1,  nullptr)
 
+#ifdef WITH_FLEXPROBE
+#define FX_FRAME_SIGNATURE(F)         F(5715,   1010,  18,   NULL)
+#define FX_TCP_TRACKING(F)            F(5715,   1020,   1,   NULL)
+#endif
 
 /**
  * IPFIX Templates - list of elements
@@ -463,6 +467,15 @@ namespace ipxp {
 #define IPFIX_QUIC_TEMPLATE(F) \
   F(QUIC_SNI)
 
+#ifdef WITH_FLEXPROBE
+#define IPFIX_FLEXPROBE_DATA_TEMPLATE(F) F(FX_FRAME_SIGNATURE)
+#define IPFIX_FLEXPROBE_TCP_TEMPLATE(F) F(FX_TCP_TRACKING)
+#define IPFIX_FLEXPROBE_ENCR_TEMPLATE(F)
+#else
+#define IPFIX_FLEXPROBE_DATA_TEMPLATE(F)
+#define IPFIX_FLEXPROBE_TCP_TEMPLATE(F)
+#define IPFIX_FLEXPROBE_ENCR_TEMPLATE(F)
+#endif
 
 /**
  * List of all known templated.
@@ -491,7 +504,10 @@ namespace ipxp {
    IPFIX_BSTATS_TEMPLATE(F) \
    IPFIX_PHISTS_TEMPLATE(F) \
    IPFIX_WG_TEMPLATE(F) \
-   IPFIX_QUIC_TEMPLATE(F)
+   IPFIX_QUIC_TEMPLATE(F) \
+   IPFIX_FLEXPROBE_DATA_TEMPLATE(F) \
+   IPFIX_FLEXPROBE_TCP_TEMPLATE(F) \
+   IPFIX_FLEXPROBE_ENCR_TEMPLATE(F)
 
 /**
  * Helper macro, convert FIELD into its name as a C literal.

--- a/input/dpdk.cpp
+++ b/input/dpdk.cpp
@@ -4,7 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
-
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 
 #include <cstring>
 #include <rte_ethdev.h>

--- a/input/dpdk.cpp
+++ b/input/dpdk.cpp
@@ -1,0 +1,167 @@
+/**
+ * \file dpdk.h
+ * \brief DPDK input interface for ipfixprobe.
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
+
+
+#include <cstring>
+#include <rte_ethdev.h>
+
+#include "dpdk.h"
+#include "parser.hpp"
+
+#ifdef WITH_FLEXPROBE
+#include <process/flexprobe-data.h>
+#endif
+
+namespace ipxp
+{
+    __attribute__((constructor)) static void register_this_plugin()
+    {
+        static PluginRecord rec = PluginRecord("dpdk", [](){return new DpdkReader();});
+        register_plugin(&rec);
+    }
+
+#ifdef WITH_FLEXPROBE
+    static bool convert_from_flexprobe(const rte_mbuf* mbuf, Packet& pkt)
+    {
+        static constexpr unsigned DATA_OFFSET = 14; // size of preceeding header
+
+        auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData*>(rte_pktmbuf_mtod(mbuf, const uint8_t*) + DATA_OFFSET);
+        if (data_view->size() > pkt.buffer_size) {
+            return false;
+        }
+
+        pkt.ts = {data_view->arrival_time.sec, data_view->arrival_time.nsec / 1000};
+
+        std::memset(pkt.dst_mac, 0, sizeof(pkt.dst_mac));
+        std::memset(pkt.src_mac, 0, sizeof(pkt.src_mac));
+        pkt.ethertype = 0;
+
+        size_t vlan_cnt = (data_view->vlan_0 ? 1 : 0) + (data_view->vlan_1 ? 1 : 0);
+        size_t ip_offset = 14 + vlan_cnt * 4;
+
+        pkt.ip_len = data_view->packet_size - ip_offset;
+        pkt.ip_version = data_view->ip_version; // Get ip version
+        pkt.ip_ttl = 0;
+        pkt.ip_proto = data_view->l4_protocol;
+        pkt.ip_tos = 0;
+        pkt.ip_flags = 0;
+        if (pkt.ip_version == IP::v4) {
+            // IPv4 is in last 4 bytes
+            pkt.src_ip.v4 = *reinterpret_cast<const uint32_t*>(data_view->src_ip.data() + 12);
+            pkt.dst_ip.v4 = *reinterpret_cast<const uint32_t*>(data_view->dst_ip.data() + 12);
+            pkt.ip_payload_len = pkt.ip_len - 20; // default size of IPv4 header without any options
+        } else {
+            std::copy(data_view->src_ip.begin(), data_view->src_ip.end(), pkt.src_ip.v6);
+            std::copy(data_view->dst_ip.begin(), data_view->dst_ip.end(), pkt.dst_ip.v6);
+            pkt.ip_payload_len = pkt.ip_len - 40; // size of IPv6 header without extension headers
+        }
+
+        pkt.src_port = ntohs(data_view->src_port);
+        pkt.dst_port = ntohs(data_view->dst_port);
+        pkt.tcp_flags = data_view->l4_flags;
+        pkt.tcp_window = 0;
+        pkt.tcp_options = 0;
+        pkt.tcp_mss = 0;
+        pkt.tcp_seq = data_view->tcp_sequence_no;
+        pkt.tcp_ack = data_view->tcp_acknowledge_no;
+
+        std::uint16_t datalen = (rte_pktmbuf_pkt_len(mbuf) > pkt.buffer_size ? pkt.buffer_size : rte_pktmbuf_pkt_len(mbuf)) - DATA_OFFSET;
+
+        memcpy(pkt.buffer, rte_pktmbuf_mtod(mbuf, const char*) + DATA_OFFSET, datalen);
+
+        pkt.packet = pkt.buffer;
+        pkt.packet_len = 0;
+        pkt.packet_len_wire = datalen;
+
+        pkt.custom = pkt.buffer;
+        pkt.custom_len = datalen;
+
+        pkt.payload = pkt.buffer + data_view->size();
+        pkt.payload_len = datalen < data_view->size() ? 0 : datalen - data_view->size();
+        pkt.payload_len_wire = rte_pktmbuf_pkt_len(mbuf) - data_view->size();
+
+        return true;
+    }
+#endif
+
+    void DpdkReader::init(const char *params)
+    {
+        DpdkOptParser parser;
+        rte_eth_conf port_conf{.rxmode = {.max_rx_pkt_len = RTE_ETHER_MAX_LEN}};
+
+        try {
+            parser.parse(params);
+            mpool_ = rte_pktmbuf_pool_create("IPFIXPROBE", parser.pkt_mempool_size(), 256, 0, RTE_MBUF_DEFAULT_BUF_SIZE, rte_socket_id());
+            if (!mpool_) {
+                throw PluginError("Unable to create memory pool. " + std::string(rte_strerror(rte_errno)));
+            }
+            mbufs_.resize(parser.pkt_buffer_size());
+        } catch (ParserError& e) {
+            throw PluginError(e.what());
+        }
+
+        // open DPDK interfaces
+        if (!rte_eth_dev_is_valid_port(parser.port_num())) {
+            throw PluginError("Invalid DPDK port specified");
+        }
+
+        port_id_ = parser.port_num();
+
+        if (rte_eth_dev_configure(port_id_, 1, 0, &port_conf) != 0) {
+            throw PluginError("Unable to configure interface");
+        }
+
+        if (rte_eth_rx_queue_setup(port_id_, 0, mbufs_.size(), rte_eth_dev_socket_id(port_id_), nullptr, mpool_) < 0) {
+            throw PluginError("Unable to set up RX queues");
+        }
+
+        if (rte_eth_dev_start(port_id_) < 0) {
+            throw PluginError("Unable to start DPDK port");
+        }
+
+        rte_eth_promiscuous_enable(port_id_);
+    }
+
+    InputPlugin::Result DpdkReader::get(PacketBlock& packets)
+    {
+#ifndef WITH_FLEXPROBE
+        parser_opt_t opt{&packets, false, false, DLT_EN10MB};
+#endif
+        packets.cnt = 0;
+        for (auto M : mbufs_) {
+            rte_pktmbuf_free(M);
+        }
+
+        auto pkts_read = rte_eth_rx_burst(port_id_, 0, mbufs_.data(), mbufs_.size());
+        if (pkts_read == 0) {
+            return Result::NOT_PARSED;
+        }
+
+        for (auto i = 0; i < pkts_read; i++) {
+#ifdef WITH_FLEXPROBE
+            // Convert Flexprobe pre-parsed packet into IPFIXPROBE packet
+            auto conv_result = convert_from_flexprobe(mbufs_[i], packets.pkts[packets.cnt]);
+            packets.bytes += packets.pkts[packets.cnt].packet_len_wire;
+            m_processed++;
+
+            if (!conv_result) {
+                continue;
+            }
+            m_parsed++;
+            packets.cnt++;
+#else
+            parse_packet(&opt,
+                         timeval(),
+                         rte_pktmbuf_mtod(mbufs_[i], const std::uint8_t *),
+                         rte_pktmbuf_data_len(mbufs_[i]),
+                         rte_pktmbuf_data_len(mbufs_[i]));
+#endif
+        }
+
+        return Result::PARSED;
+    }
+}

--- a/input/dpdk.h
+++ b/input/dpdk.h
@@ -4,7 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
-
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 #include <config.h>
 #ifdef WITH_DPDK
 

--- a/input/dpdk.h
+++ b/input/dpdk.h
@@ -1,0 +1,85 @@
+/**
+ * \file dpdk.h
+ * \brief DPDK input interface for ipfixprobe.
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
+
+#include <config.h>
+#ifdef WITH_DPDK
+
+#ifndef IPXP_DPDK_READER_H
+#define IPXP_DPDK_READER_H
+
+#include <ipfixprobe/input.hpp>
+#include <ipfixprobe/utils.hpp>
+
+#include <rte_mbuf.h>
+#include <memory>
+
+namespace ipxp
+{
+    class DpdkOptParser : public OptionsParser
+    {
+    private:
+        static constexpr size_t DEFAULT_MBUF_BURST_SIZE = 64;
+        static constexpr size_t DEFAULT_MBUF_POOL_SIZE = 8191; // (2 ^ 13) - 1
+        size_t pkt_buffer_size_;
+        size_t pkt_mempool_size_;
+        std::uint16_t port_num_;
+    public:
+        DpdkOptParser() : OptionsParser("dpdk", "Input plugin for reading packets using DPDK interface"), pkt_buffer_size_(DEFAULT_MBUF_BURST_SIZE), pkt_mempool_size_(DEFAULT_MBUF_POOL_SIZE)
+        {
+            register_option("b",
+                            "bsize",
+                            "SIZE",
+                            "Size of the MBUF packet buffer. Default: " + std::to_string(DEFAULT_MBUF_BURST_SIZE),
+                            [this](const char* arg){try{pkt_buffer_size_ = str2num<decltype(pkt_buffer_size_)>(arg);} catch (std::invalid_argument&){return false;} return true;},
+                            RequiredArgument);
+            register_option("p",
+                            "port",
+                            "PORT",
+                            "DPDK port to be used as an input interface",
+                            [this](const char* arg){try{port_num_ = str2num<decltype(port_num_)>(arg);} catch (std::invalid_argument&){return false;} return true;},
+                            RequiredArgument);
+            register_option("m",
+                            "mem",
+                            "SIZE",
+                            "Size of the memory pool for received packets. Default: " + std::to_string(DEFAULT_MBUF_POOL_SIZE),
+                            [this](const char* arg){try{pkt_mempool_size_ = str2num<decltype(pkt_mempool_size_)>(arg);} catch (std::invalid_argument&){return false;} return true;},
+                            RequiredArgument);
+        }
+
+        size_t pkt_buffer_size() const { return pkt_buffer_size_; }
+
+        size_t pkt_mempool_size() const { return pkt_mempool_size_; }
+
+        std::uint16_t port_num() const { return port_num_; }
+    };
+
+    class DpdkReader : public InputPlugin
+    {
+    private:
+        size_t port_id_;
+        rte_mempool* mpool_;
+        std::vector<rte_mbuf*> mbufs_;
+
+    public:
+        Result get(PacketBlock& packets) override;
+
+        void init(const char *params) override;
+
+        OptionsParser *get_parser() const override
+        {
+            return new DpdkOptParser();
+        }
+
+        std::string get_name() const override
+        {
+            return "dpdk";
+        }
+    };
+}
+
+#endif //IPXP_DPDK_READER_H
+#endif

--- a/input/stem.cpp
+++ b/input/stem.cpp
@@ -1,0 +1,199 @@
+/**
+ * \file stem.cpp
+ * \brief Plugin for reading stem specific data from hw
+ * \author Jiri Havranek <havranek@cesnet.cz>
+ * \date 2021
+ */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
+
+#include <config.h>
+#include <string>
+
+#include <packet-reader.h>
+
+#include "stem.hpp"
+
+namespace ipxp {
+
+
+__attribute__((constructor)) static void register_this_plugin()
+{
+   static PluginRecord rec = PluginRecord("stem", [](){return new StemPacketReader();});
+   register_plugin(&rec);
+}
+
+StemPacketReader::StemPacketReader() : m_reader(nullptr)
+{
+}
+
+StemPacketReader::~StemPacketReader()
+{
+   close();
+}
+
+void StemPacketReader::init(const char *params)
+{
+   StemOptParser parser;
+   try {
+      parser.parse(params);
+   } catch (ParserError &e) {
+      throw PluginError(e.what());
+   }
+
+   if (parser.m_dev.empty()) {
+      throw PluginError("specify device path");
+   }
+
+   open_dev(parser.m_dev);
+}
+
+void StemPacketReader::close()
+{
+   if (m_reader != nullptr) {
+      delete m_reader;
+      m_reader = nullptr;
+   }
+}
+
+void StemPacketReader::open_dev(const std::string &file)
+{
+   try {
+      m_reader = new Stem::StemInterface<Stem::PcapReader>(file); // TODO: change reader
+   } catch (Stem::Exceptions::Readers::ReaderSetupError &e) {
+      throw PluginError(e.what());
+   }
+}
+
+bool StemPacketReader::convert(Stem::StatisticsPacket &stem_pkt, Packet &pkt)
+{
+   Stem::StadeHardwareData hwdata = stem_pkt.hw_data();
+   if (hwdata.size() > pkt.buffer_size) {
+      return false;
+   }
+
+   pkt.ts = {hwdata.arrived_at.sec, hwdata.arrived_at.nsec / 1000};
+
+   memset(pkt.dst_mac, 0, sizeof(pkt.dst_mac));
+   memset(pkt.src_mac, 0, sizeof(pkt.src_mac));
+   pkt.ethertype = 0;
+
+   size_t vlan_cnt = (hwdata.vlan_0 ? 1 : 0) + (hwdata.vlan_1 ? 1 : 0);
+   size_t ip_offset = 14 + vlan_cnt * 4;
+
+   pkt.ip_len = hwdata.frame_len - ip_offset; // this should be done better
+   pkt.ip_version = hwdata.ip_version; // Get ip version
+   pkt.ip_ttl = 0;
+   pkt.ip_proto = hwdata.protocol;
+   pkt.ip_tos = 0;
+   pkt.ip_flags = 0;
+   if (pkt.ip_version == IP::v4) {
+      pkt.src_ip.v4 = *reinterpret_cast<uint32_t*>(hwdata.src_ip.data());
+      pkt.dst_ip.v4 = *reinterpret_cast<uint32_t*>(hwdata.dst_ip.data());
+      pkt.ip_payload_len = pkt.ip_len - 20;
+   } else {
+      memcpy(pkt.src_ip.v6, reinterpret_cast<uint8_t*>(hwdata.src_ip.data()), 16);
+      memcpy(pkt.dst_ip.v6, reinterpret_cast<uint8_t*>(hwdata.dst_ip.data()), 16);
+      pkt.ip_payload_len = pkt.ip_len - 40;
+   }
+
+   pkt.src_port = ntohs(hwdata.src_port);
+   pkt.dst_port = ntohs(hwdata.dst_port);
+   pkt.tcp_flags = hwdata.l4_flags;
+   pkt.tcp_window = 0;
+   pkt.tcp_options = 0;
+   pkt.tcp_mss = 0;
+   pkt.tcp_seq = hwdata.tcp_seq;
+   pkt.tcp_ack = hwdata.tcp_ack;
+
+   auto &raw_hwdata = stem_pkt.serialized();
+   uint16_t datalen = raw_hwdata->size();
+   if (datalen > pkt.buffer_size) {
+      datalen = pkt.buffer_size;
+   }
+   memcpy(pkt.buffer, raw_hwdata->data(), datalen);
+
+   pkt.packet = pkt.buffer;
+   pkt.packet_len = 0;
+   pkt.packet_len_wire = hwdata.frame_len;
+
+   pkt.custom = pkt.buffer;
+   pkt.custom_len = hwdata.size();
+
+   pkt.payload = pkt.buffer + hwdata.size();
+   pkt.payload_len = datalen - hwdata.size();
+   if (datalen < hwdata.size()) {
+      pkt.payload_len = 0;
+   }
+   pkt.payload_len_wire = raw_hwdata->size() - hwdata.size();
+
+   return true;
+}
+
+InputPlugin::Result StemPacketReader::get(PacketBlock &packets)
+{
+   packets.cnt = 0;
+   packets.bytes = 0;
+   while (packets.cnt < packets.size) {
+      try {
+         auto pkt = m_reader->next_packet();
+         if (!pkt.has_value()) {
+            if (packets.cnt) {
+               return Result::PARSED;
+            }
+            return Result::TIMEOUT;
+         } else {
+            Stem::StatisticsPacket spkt = std::move(pkt.value());
+            bool status = convert(spkt, packets.pkts[packets.cnt]);
+            packets.bytes += packets.pkts[packets.cnt].packet_len_wire;
+
+            m_processed += 1;
+            if (!status) {
+               continue;
+            }
+            packets.cnt++;
+            m_parsed += 1;
+         }
+      } catch (Stem::Exceptions::Readers::ReadError &e) {
+         throw PluginError(e.what());
+      }
+   }
+
+   return packets.cnt ? Result::PARSED : Result::NOT_PARSED;
+ }
+
+}

--- a/input/stem.hpp
+++ b/input/stem.hpp
@@ -1,0 +1,92 @@
+/**
+ * \file stem.hpp
+ * \brief Plugin for reading stem specific data from hw
+ * \author Jiri Havranek <havranek@cesnet.cz>
+ * \date 2021
+ */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
+
+#ifndef IPXP_INPUT_STEM_HPP
+#define IPXP_INPUT_STEM_HPP
+
+#include <config.h>
+
+#include <stem-interface.h>
+#include <statistics-packet.h>
+#include <pcap-reader.h>
+
+#include <ipfixprobe/input.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/utils.hpp>
+
+namespace ipxp {
+
+class StemOptParser : public OptionsParser
+{
+public:
+   std::string m_dev;
+
+   StemOptParser() : OptionsParser("stem", "Input plugin for reading packets"), // TODO: better info
+      m_dev("")
+   {
+      register_option("d", "dev", "PATH", "Path to a device file", [this](const char *arg){m_dev = arg; return true;}, OptionFlags::RequiredArgument);
+   }
+};
+
+class StemPacketReader : public InputPlugin
+{
+public:
+   StemPacketReader();
+   ~StemPacketReader();
+
+   void init(const char *params);
+   void close();
+   OptionsParser *get_parser() const { return new StemOptParser(); }
+   std::string get_name() const { return "stem"; }
+   InputPlugin::Result get(PacketBlock &packets);
+
+private:
+   Stem::StemInterface<Stem::PcapReader> *m_reader; //TODO: change reader
+
+   bool convert(Stem::StatisticsPacket &stem_pkt, Packet &pkt);
+   void open_dev(const std::string &file);
+};
+
+}
+#endif /* IPXP_INPUT_STEM_HPP */

--- a/process/flexprobe-data-processing.cpp
+++ b/process/flexprobe-data-processing.cpp
@@ -1,6 +1,9 @@
-//
-// Created by ivrana on 8/10/21.
-//
+/**
+ * \file flexprobe-data-processing.cpp
+ * \brief Data processing for Flexprobe -- HW accelerated network probe
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
 
 #include "flexprobe-data-processing.h"
 

--- a/process/flexprobe-data-processing.cpp
+++ b/process/flexprobe-data-processing.cpp
@@ -1,0 +1,18 @@
+//
+// Created by ivrana on 8/10/21.
+//
+
+#include "flexprobe-data-processing.h"
+
+namespace ipxp {
+
+int FrameSignature::REGISTERED_ID = -1;
+
+__attribute__((constructor)) static void register_this_plugin()
+{
+   static PluginRecord rec = PluginRecord("flexprobe-data", [](){return new FlexprobeDataProcessing();});
+   register_plugin(&rec);
+   FrameSignature::REGISTERED_ID = register_extension();
+}
+
+}

--- a/process/flexprobe-data-processing.cpp
+++ b/process/flexprobe-data-processing.cpp
@@ -4,6 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 
 #include "flexprobe-data-processing.h"
 

--- a/process/flexprobe-data-processing.h
+++ b/process/flexprobe-data-processing.h
@@ -1,6 +1,9 @@
-//
-// Created by ivrana on 8/10/21.
-//
+/**
+ * \file flexprobe-data-processing.h
+ * \brief Data processing for Flexprobe -- HW accelerated network probe
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
 
 #ifndef IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H
 #define IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H
@@ -24,6 +27,9 @@ struct FrameSignature : public RecordExt, public std::array<unsigned char, 18> {
 
    virtual int fill_ipfix(uint8_t *buffer, int size)
    {
+       if (sizeof(Flexprobe::FrameSignature) > size) {
+           return -1;
+       }
        std::copy(begin(), end(), buffer);
 
        return sizeof(Flexprobe::FrameSignature);
@@ -44,10 +50,10 @@ class FlexprobeDataProcessing : public ProcessPlugin
 public:
     FlexprobeDataProcessing() = default;
 
-    void init(const char *params) {} // TODO
-    void close() {} // TODO
+    void init(const char *params) {}
+    void close() {}
     RecordExt *get_ext() const { return new FrameSignature(); }
-    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-data", "Parse flexprobe data"); }
+    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-data", "Parse flexprobe data (Flexprobe HW only)"); }
     std::string get_name() const { return "flexprobe-data"; }
     FlexprobeDataProcessing *copy() override
     {

--- a/process/flexprobe-data-processing.h
+++ b/process/flexprobe-data-processing.h
@@ -4,7 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
-
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 #ifndef IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H
 #define IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H
 

--- a/process/flexprobe-data-processing.h
+++ b/process/flexprobe-data-processing.h
@@ -1,0 +1,74 @@
+//
+// Created by ivrana on 8/10/21.
+//
+
+#ifndef IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H
+#define IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H
+
+#include <array>
+
+#include <ipfixprobe/process.hpp>
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include "flexprobe-data.h"
+
+namespace ipxp {
+
+struct FrameSignature : public RecordExt, public std::array<unsigned char, 18> {
+   static int REGISTERED_ID;
+
+   FrameSignature() : RecordExt(REGISTERED_ID), std::array<unsigned char, 18>()
+   {
+   }
+
+   virtual int fill_ipfix(uint8_t *buffer, int size)
+   {
+       std::copy(begin(), end(), buffer);
+
+       return sizeof(Flexprobe::FrameSignature);
+   }
+
+   const char **get_ipfix_tmplt() const
+   {
+      static const char *ipfix_template[] = {
+         IPFIX_FLEXPROBE_DATA_TEMPLATE(IPFIX_FIELD_NAMES)
+         nullptr
+      };
+      return ipfix_template;
+   }
+};
+
+class FlexprobeDataProcessing : public ProcessPlugin
+{
+public:
+    FlexprobeDataProcessing() = default;
+
+    void init(const char *params) {} // TODO
+    void close() {} // TODO
+    RecordExt *get_ext() const { return new FrameSignature(); }
+    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-data", "Parse flexprobe data"); }
+    std::string get_name() const { return "flexprobe-data"; }
+    FlexprobeDataProcessing *copy() override
+    {
+        return new FlexprobeDataProcessing(*this);
+    }
+
+    int post_create(Flow &rec, const Packet &pkt) override
+    {
+        if (!pkt.custom) {
+            return 0;
+        }
+
+        if (!rec.get_extension(FrameSignature::REGISTERED_ID)) {
+            auto *fs = new FrameSignature();
+            auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData*>(pkt.custom);
+            std::copy(data_view->frame_signature.begin(), data_view->frame_signature.end(), fs->begin());
+            rec.add_extension(fs);
+        }
+        return 0;
+    }
+};
+
+}
+#endif //IPFIXPROBE_FLEXPROBE_DATA_PROCESSING_H

--- a/process/flexprobe-data.h
+++ b/process/flexprobe-data.h
@@ -1,11 +1,17 @@
-//
-// Created by ivrana on 9/1/21.
-//
+/**
+ * \file flexprobe-data.h
+ * \brief Data structures for Flexprobe -- HW accelerated network probe
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
+
 
 #ifndef IPFIXPROBE_FLEXPROBE_DATA_H
 #define IPFIXPROBE_FLEXPROBE_DATA_H
 
+#include <cstdint>
 #include <limits>
+#include <array>
 
 namespace ipxp
 {
@@ -37,13 +43,6 @@ namespace ipxp
             {
                 sec = std::numeric_limits<seconds_type>::max();
                 nsec = std::numeric_limits<nanoseconds_type>::max();
-            }
-
-            // flip endianness for export
-            void to_export()
-            {
-                sec = htonl(sec);
-                nsec = htonl(nsec);
             }
         };
 
@@ -94,6 +93,7 @@ namespace ipxp
             std::uint16_t packet_size;
             std::uint16_t payload_size;
             std::uint32_t tcp_sequence_no;
+            std::uint32_t tcp_acknowledge_no;
             EncryptionData encr_data;
             std::uint16_t dyn_item_count;
             std::uint16_t dyn_payload_length;
@@ -114,6 +114,7 @@ namespace ipxp
                        + sizeof(packet_size)
                        + sizeof(payload_size)
                        + sizeof(tcp_sequence_no)
+                       + sizeof(tcp_acknowledge_no)
                        + sizeof(encr_data)
                        + sizeof(dyn_item_count)
                        + sizeof(dyn_payload_length);

--- a/process/flexprobe-data.h
+++ b/process/flexprobe-data.h
@@ -4,7 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
-
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 
 #ifndef IPFIXPROBE_FLEXPROBE_DATA_H
 #define IPFIXPROBE_FLEXPROBE_DATA_H

--- a/process/flexprobe-data.h
+++ b/process/flexprobe-data.h
@@ -1,0 +1,131 @@
+//
+// Created by ivrana on 9/1/21.
+//
+
+#ifndef IPFIXPROBE_FLEXPROBE_DATA_H
+#define IPFIXPROBE_FLEXPROBE_DATA_H
+
+#include <limits>
+
+namespace ipxp
+{
+    namespace Flexprobe
+    {
+
+        using FrameSignature = std::array<unsigned char, 18>;
+        using ip_type = std::array<unsigned char, 16>;
+
+        struct Timestamp {
+            using seconds_type = std::uint32_t;
+            using nanoseconds_type = std::uint32_t;
+            using DecimalTimestamp = double;
+
+            seconds_type sec;
+            nanoseconds_type nsec;
+
+            DecimalTimestamp to_decimal() const {
+                return static_cast<DecimalTimestamp>(sec) + static_cast<DecimalTimestamp>(nsec) * 1e-9f;
+            }
+
+            void reset()
+            {
+                sec = 0;
+                nsec = 0;
+            }
+
+            void to_max()
+            {
+                sec = std::numeric_limits<seconds_type>::max();
+                nsec = std::numeric_limits<nanoseconds_type>::max();
+            }
+
+            // flip endianness for export
+            void to_export()
+            {
+                sec = htonl(sec);
+                nsec = htonl(nsec);
+            }
+        };
+
+        struct MpeData
+        {
+            std::uint16_t expected_count;
+            std::uint16_t difference;
+        };
+
+        struct [[gnu::packed]] EncryptionData
+        {
+            std::uint8_t encr_pattern_id;
+            union {
+                struct {
+                    std::uint8_t match_found : 1;
+                    std::uint8_t pm_mult_pos : 1;
+                    std::uint8_t pm_mult_pattern : 1;
+                    std::uint8_t reserved : 5;
+                } items;
+                std::uint8_t all;
+            } pm_flags;
+            std::uint16_t pattern_offset;
+            MpeData mpe_8bit;
+            MpeData mpe_4bit;
+        };
+
+        struct DynamicPayloadHeader {
+            std::uint16_t dyn_type   :  4;
+            std::uint16_t dyn_offset : 12;
+            std::uint16_t dyn_length;
+        };
+
+        struct [[gnu::packed]] FlexprobeData
+        {
+            std::uint32_t flow_hash;
+            ip_type src_ip;
+            ip_type dst_ip;
+            std::uint16_t src_port;
+            std::uint16_t dst_port;
+            std::uint8_t l4_protocol;
+            std::uint8_t l4_flags;
+            FrameSignature frame_signature;
+            std::uint32_t ip_version: 4;
+            std::uint32_t interface_in: 4;
+            std::uint32_t vlan_0: 12;
+            std::uint32_t vlan_1: 12;
+            Timestamp arrival_time;
+            std::uint16_t packet_size;
+            std::uint16_t payload_size;
+            std::uint32_t tcp_sequence_no;
+            EncryptionData encr_data;
+            std::uint16_t dyn_item_count;
+            std::uint16_t dyn_payload_length;
+
+            [[nodiscard]]
+            size_t static_size() const
+            {
+                return sizeof(flow_hash)
+                       + src_ip.size()
+                       + dst_ip.size()
+                       + sizeof(src_port)
+                       + sizeof(dst_port)
+                       + sizeof(l4_protocol)
+                       + sizeof(l4_flags)
+                       + frame_signature.size()
+                       + sizeof(std::uint32_t) // ip_version + interface_in + vlan_0 + vlan_1
+                       + sizeof(arrival_time)
+                       + sizeof(packet_size)
+                       + sizeof(payload_size)
+                       + sizeof(tcp_sequence_no)
+                       + sizeof(encr_data)
+                       + sizeof(dyn_item_count)
+                       + sizeof(dyn_payload_length);
+            }
+
+            [[nodiscard]]
+            size_t size() const
+            {
+                return static_size() + (dyn_item_count * sizeof(DynamicPayloadHeader));
+            }
+        };
+    }
+}
+
+#endif //IPFIXPROBE_FLEXPROBE_DATA_H

--- a/process/flexprobe-encryption-processing.cpp
+++ b/process/flexprobe-encryption-processing.cpp
@@ -1,6 +1,9 @@
-//
-// Created by ivrana on 8/12/21.
-//
+/**
+ * \file flexprobe-encryption-processing.cpp
+ * \brief Traffic feature processing for encryption analysis for Flexprobe -- HW accelerated network probe
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
 
 #include "flexprobe-encryption-processing.h"
 #include "flexprobe-data.h"

--- a/process/flexprobe-encryption-processing.cpp
+++ b/process/flexprobe-encryption-processing.cpp
@@ -1,0 +1,61 @@
+//
+// Created by ivrana on 8/12/21.
+//
+
+#include "flexprobe-encryption-processing.h"
+#include "flexprobe-data.h"
+
+namespace ipxp {
+
+int FlexprobeEncryptionData::REGISTERED_ID = -1;
+
+__attribute__((constructor)) static void register_this_plugin()
+{
+   static PluginRecord rec = PluginRecord("flexprobe-encrypt", [](){return new FlexprobeEncryptionProcessing();});
+   register_plugin(&rec);
+   FlexprobeEncryptionData::REGISTERED_ID = register_extension();
+}
+
+int FlexprobeEncryptionProcessing::post_create(Flow& rec, const Packet& pkt)
+{
+    if (!rec.get_extension(FlexprobeEncryptionData::REGISTERED_ID)) {
+        auto ext = new FlexprobeEncryptionData();
+        rec.add_extension(ext);
+    }
+
+    return 0;
+}
+
+int FlexprobeEncryptionProcessing::post_update(Flow& rec, const Packet& pkt)
+{
+    if (!pkt.custom) {
+        return 0;
+    }
+
+    // convert timestamp to decimal
+    auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData*>(pkt.custom);
+
+    auto arrival = data_view->arrival_time.to_decimal();
+    Flexprobe::Timestamp::DecimalTimestamp flow_end = static_cast<Flexprobe::Timestamp::DecimalTimestamp>(rec.time_last.tv_sec) + static_cast<Flexprobe::Timestamp::DecimalTimestamp>(rec.time_last.tv_usec) * 1e-6f;
+    auto encr_data = dynamic_cast<FlexprobeEncryptionData*>(rec.get_extension(FlexprobeEncryptionData::REGISTERED_ID));
+    auto total_packets = rec.src_packets + rec.dst_packets;
+
+    encr_data->time_interpacket.update(arrival - flow_end, total_packets);
+    encr_data->payload_size.update(data_view->payload_size, total_packets);
+
+    if (data_view->payload_size >= 256) {
+        encr_data->mpe8_valid_count += 1;
+        //TODO: update value
+        encr_data->mpe_8bit.update(1, encr_data->mpe8_valid_count);
+    }
+
+    if (data_view->payload_size >= 16) {
+        encr_data->mpe4_valid_count += 1;
+        //TODO: update value
+        encr_data->mpe_4bit.update(1, encr_data->mpe4_valid_count);
+    }
+
+    return 0;
+}
+
+}

--- a/process/flexprobe-encryption-processing.cpp
+++ b/process/flexprobe-encryption-processing.cpp
@@ -4,6 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 
 #include "flexprobe-encryption-processing.h"
 #include "flexprobe-data.h"

--- a/process/flexprobe-encryption-processing.h
+++ b/process/flexprobe-encryption-processing.h
@@ -4,6 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 
 #ifndef IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H
 #define IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H

--- a/process/flexprobe-encryption-processing.h
+++ b/process/flexprobe-encryption-processing.h
@@ -1,0 +1,156 @@
+//
+// Created by ivrana on 8/12/21.
+//
+
+#ifndef IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H
+#define IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H
+
+#include <limits>
+#include <cmath>
+
+#include <ipfixprobe/process.hpp>
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+
+#include "flexprobe-data.h"
+
+namespace ipxp {
+
+template<typename T> class RtStats
+{
+protected:
+    // helper variables for variance calculation
+//    T prev_average_;
+    T delta_sq_sum_;
+
+    T mean_;
+    T variance_;
+    T deviation_;
+
+    T minimum_;
+    T maximum_;
+
+public:
+    T mean() const {
+        return mean_;
+    }
+
+    T variance() const {
+        return variance_;
+    }
+
+    T deviation() const {
+        return deviation_;
+    }
+
+    T minimum() const {
+        return minimum_;
+    }
+
+    T maximum() const {
+        return maximum_;
+    }
+
+protected:
+    // running average
+    T running_average_(T next_value, std::uint64_t packets)
+    {
+//        prev_average_ = mean_;
+        auto p_delta = next_value - mean_;
+        mean_ = packets ? (next_value + static_cast<T>((packets - 1)) * mean_) / static_cast<T>(packets) : T();
+        auto delta = next_value - mean_;
+        delta_sq_sum_ += p_delta * delta;
+        return mean_;
+    }
+
+    // running variance calculated using Welford's algorithm
+    T running_variance_(std::uint64_t packets)
+    {
+        return (variance_ = packets ? delta_sq_sum_ / static_cast<T>(packets) : T()), variance_;
+    }
+
+    // running deviation
+    T comp_deviation_()
+    {
+        return deviation_ = std::sqrt(variance_), deviation_;
+    }
+
+    T comp_minimum_(T next_val) {
+        return minimum_ = std::min(minimum_, next_val), minimum_;
+    }
+
+    T comp_maximum_(T next_val) {
+        return maximum_ = std::max(maximum_, next_val), maximum_;
+    }
+
+public:
+    explicit RtStats(T init_min = std::numeric_limits<T>::max(), T init_max = std::numeric_limits<T>::min())
+    : delta_sq_sum_(0),
+      mean_(0),
+      variance_(0),
+      deviation_(0),
+      minimum_(init_min),
+      maximum_(init_max)
+    {}
+
+    void update(T next_val, const size_t count)
+    {
+        running_average_(next_val, count);
+        running_variance_(count);
+        comp_deviation_();
+        comp_minimum_(next_val);
+        comp_maximum_(next_val);
+    }
+};
+
+struct FlexprobeEncryptionData : public RecordExt {
+    static int REGISTERED_ID;
+
+    std::uint64_t mpe8_valid_count;
+    std::uint64_t mpe4_valid_count;
+    RtStats<float> time_interpacket;
+    RtStats<std::uint16_t> payload_size;
+    RtStats<float> mpe_8bit;
+    RtStats<float> mpe_4bit;
+
+    FlexprobeEncryptionData() : RecordExt(REGISTERED_ID), mpe8_valid_count(), mpe4_valid_count() {}
+
+    virtual int fill_ipfix(uint8_t *buffer, int size)
+    {
+       // TODO: fill fields in correct order
+       return 0;
+    }
+
+    const char **get_ipfix_tmplt() const
+    {
+       static const char *ipfix_template[] = {
+             IPFIX_FLEXPROBE_ENCR_TEMPLATE(IPFIX_FIELD_NAMES)
+             nullptr
+       };
+       return ipfix_template;
+    }
+};
+
+class FlexprobeEncryptionProcessing : public ProcessPlugin
+{
+public:
+    FlexprobeEncryptionProcessing() = default;
+
+    void init(const char *params) {} // TODO
+    void close() {} // TODO
+    RecordExt *get_ext() const { return new FlexprobeEncryptionData(); }
+    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-encrypt", "Parse flexprobe data"); }
+    std::string get_name() const { return "flexprobe-encrypt"; }
+    FlexprobeEncryptionProcessing *copy() override
+    {
+        return new FlexprobeEncryptionProcessing(*this);
+    }
+
+    int post_create(Flow &rec, const Packet &pkt) override;
+
+    int post_update(Flow& rec, const Packet& pkt) override;
+};
+
+}
+#endif //IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H

--- a/process/flexprobe-encryption-processing.h
+++ b/process/flexprobe-encryption-processing.h
@@ -1,6 +1,9 @@
-//
-// Created by ivrana on 8/12/21.
-//
+/**
+ * \file flexprobe-encryption-processing.h
+ * \brief Traffic feature processing for encryption analysis for Flexprobe -- HW accelerated network probe
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
 
 #ifndef IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H
 #define IPFIXPROBE_FLEXPROBE_ENCRYPTION_PROCESSING_H

--- a/process/flexprobe-tcp-tracking.cpp
+++ b/process/flexprobe-tcp-tracking.cpp
@@ -1,0 +1,120 @@
+//
+// Created by ivrana on 8/10/21.
+//
+
+#include "flexprobe-tcp-tracking.h"
+#include "flexprobe-data.h"
+
+namespace ipxp
+{
+    int TcpTrackingData::REGISTERED_ID = -1;
+
+    __attribute__((constructor)) static void register_this_plugin()
+    {
+        static PluginRecord rec = PluginRecord("flexprobe-tcp", []()
+        { return new FlexprobeTcpTracking(); });
+        register_plugin(&rec);
+        TcpTrackingData::REGISTERED_ID = register_extension();
+    }
+
+    std::uint32_t
+    FlexprobeTcpTracking::advance_expected_seq_(std::uint32_t current_seq, std::uint16_t payload_len, bool syn,
+                                                bool fin)
+    {
+        return current_seq + payload_len + (syn ? 1 : 0) + (fin ? 1 : 0);
+    }
+
+    FlowState FlexprobeTcpTracking::check_(TcpTrackingData& td, std::uint32_t tcp_seq, unsigned direction)
+    {
+        FlowState fs = FlowState::OK;
+
+        if (td.expected_seq[direction] > tcp_seq) {
+            if (td.tracker_state[direction] != TrackerState::INLINE) {
+                fs = FlowState::PACKET_LOSS;
+            }
+            td.tracker_state[direction] = TrackerState::AHEAD;
+        } else if (td.expected_seq[direction] < tcp_seq) {
+            if (td.tracker_state[direction] != TrackerState::INLINE) {
+                fs = FlowState::PACKET_LOSS;
+            }
+            td.tracker_state[direction] = TrackerState::BEHIND;
+        } else {
+            if (td.tracker_state[direction] == TrackerState::BEHIND) {
+                fs = FlowState::PACKET_LOSS;
+            }
+
+            td.tracker_state[direction] = TrackerState::INLINE;
+        }
+
+        return direction == 0 ? fs : FlowState::OK;
+    }
+
+    int FlexprobeTcpTracking::post_create(Flow& rec, const Packet& pkt)
+    {
+        if (!pkt.custom) {
+            return 0;
+        }
+
+        auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData *>(pkt.custom);
+
+        if (!rec.get_extension(TcpTrackingData::REGISTERED_ID)) {
+            auto *td = new TcpTrackingData();
+
+            auto direction = pkt.source_pkt ? 0 : 1;
+
+            td->expected_seq[direction] = advance_expected_seq_(ntohl(pkt.tcp_seq),
+                                                                data_view->payload_size,
+                                                                pkt.tcp_flags & 0x2,
+                                                                pkt.tcp_flags & 0x1);
+            direction = direction == 0 ? 1 : 0;
+            td->expected_seq[direction] = ntohl(pkt.tcp_ack); // TODO: add to HW
+            rec.add_extension(td);
+        }
+
+        return 0;
+    }
+
+    int FlexprobeTcpTracking::post_update(Flow& rec, const Packet& pkt)
+    {
+        if (!pkt.custom) {
+            return 0;
+        }
+
+        auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData *>(pkt.custom);
+
+        auto tcp_data = dynamic_cast<TcpTrackingData *>(rec.get_extension(TcpTrackingData::REGISTERED_ID));
+        auto next_tcp = ntohl(pkt.tcp_seq);
+        auto direction = pkt.source_pkt ? 0 : 1;
+
+        //skip check if SYN and ACK present and dst -> src at 0)
+        if ((pkt.tcp_flags & 0x12) && tcp_data->expected_seq[direction] == 0) {
+            tcp_data->expected_seq[direction] = advance_expected_seq_(next_tcp,
+                                                                      data_view->payload_size,
+                                                                      pkt.tcp_flags & 0x2,
+                                                                      pkt.tcp_flags & 0x1);
+            return 0;
+        }
+        auto check_result = check_(*tcp_data, next_tcp, direction);
+        if (check_result == FlowState::PACKET_LOSS) {
+            tcp_data->result = TcpResult::INCOMPLETE;
+        }
+
+        switch (tcp_data->tracker_state[direction]) {
+            case TrackerState::INLINE:
+                tcp_data->expected_seq[direction] = advance_expected_seq_(
+                        tcp_data->expected_seq[direction],
+                        data_view->payload_size,
+                        pkt.tcp_flags & 0x2,
+                        pkt.tcp_flags & 0x1);
+                break;
+            case TrackerState::BEHIND:
+                tcp_data->expected_seq[direction] = next_tcp;
+                break;
+            default:
+                break;
+        }
+
+        return 0;
+    }
+
+}

--- a/process/flexprobe-tcp-tracking.cpp
+++ b/process/flexprobe-tcp-tracking.cpp
@@ -4,6 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 
 #include "flexprobe-tcp-tracking.h"
 #include "flexprobe-data.h"

--- a/process/flexprobe-tcp-tracking.h
+++ b/process/flexprobe-tcp-tracking.h
@@ -4,7 +4,42 @@
  * \author Roman Vrana <ivrana@fit.vutbr.cz>
  * \date 2021
  */
-
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
 #ifndef IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H
 #define IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H
 

--- a/process/flexprobe-tcp-tracking.h
+++ b/process/flexprobe-tcp-tracking.h
@@ -1,6 +1,9 @@
-//
-// Created by ivrana on 8/10/21.
-//
+/**
+ * \file flexprobe-tcp-tracking.h
+ * \brief TCP tracking for Flexprobe -- HW accelerated network probe
+ * \author Roman Vrana <ivrana@fit.vutbr.cz>
+ * \date 2021
+ */
 
 #ifndef IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H
 #define IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H
@@ -44,6 +47,9 @@ struct TcpTrackingData : public RecordExt {
 
     virtual int fill_ipfix(uint8_t *buffer, int size)
     {
+        if (sizeof(std::uint8_t) > size) {
+            return -1;
+        }
         *buffer = std::underlying_type<TcpResult>::type(result);
         return sizeof(std::uint8_t);
     }
@@ -70,7 +76,7 @@ public:
     void init(const char *params) {} // TODO
     void close() {} // TODO
     RecordExt *get_ext() const { return new TcpTrackingData(); }
-    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-tcp", "Parse flexprobe data"); }
+    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-tcp", "Track TCP Sequence numbers using flexprobe format (Flexprobe HW only)"); }
     std::string get_name() const { return "flexprobe-tcp"; }
     FlexprobeTcpTracking *copy() override
     {

--- a/process/flexprobe-tcp-tracking.h
+++ b/process/flexprobe-tcp-tracking.h
@@ -1,0 +1,86 @@
+//
+// Created by ivrana on 8/10/21.
+//
+
+#ifndef IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H
+#define IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H
+
+#include <ipfixprobe/process.hpp>
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+
+namespace ipxp {
+
+enum class TrackerState {
+    BEHIND,
+    INLINE,
+    AHEAD
+};
+
+enum class FlowState {
+    OK,
+    PACKET_LOSS
+};
+
+enum class TcpResult {
+    OK,
+    INCOMPLETE
+};
+
+struct TcpTrackingData : public RecordExt {
+    static int REGISTERED_ID;
+
+    TrackerState tracker_state[2];
+    TcpResult result;
+    std::uint32_t expected_seq[2];
+
+    TcpTrackingData()
+        : RecordExt(REGISTERED_ID),
+          tracker_state{TrackerState::INLINE, TrackerState::INLINE},
+          result(TcpResult::OK),
+          expected_seq{0, 0}
+    {}
+
+    virtual int fill_ipfix(uint8_t *buffer, int size)
+    {
+        *buffer = std::underlying_type<TcpResult>::type(result);
+        return sizeof(std::uint8_t);
+    }
+
+    const char **get_ipfix_tmplt() const
+    {
+       static const char *ipfix_template[] = {
+             IPFIX_FLEXPROBE_TCP_TEMPLATE(IPFIX_FIELD_NAMES)
+             nullptr
+       };
+       return ipfix_template;
+    }
+};
+
+class FlexprobeTcpTracking : public ProcessPlugin
+{
+private:
+    FlowState check_(TcpTrackingData& td, std::uint32_t tcp_seq, unsigned direction);
+
+    std::uint32_t advance_expected_seq_(std::uint32_t current_seq, std::uint16_t payload_len, bool syn, bool fin);
+public:
+    FlexprobeTcpTracking() = default;
+
+    void init(const char *params) {} // TODO
+    void close() {} // TODO
+    RecordExt *get_ext() const { return new TcpTrackingData(); }
+    OptionsParser *get_parser() const { return new OptionsParser("flexprobe-tcp", "Parse flexprobe data"); }
+    std::string get_name() const { return "flexprobe-tcp"; }
+    FlexprobeTcpTracking *copy() override
+    {
+        return new FlexprobeTcpTracking(*this);
+    }
+
+    int post_create(Flow &rec, const Packet &pkt) override;
+
+    int post_update(Flow &rec, const Packet &pkt) override;
+};
+
+}
+#endif //IPFIXPROBE_FLEXPROBE_TCP_TRACKING_H


### PR DESCRIPTION
Branch implements DPDK interface support for ipfixprobe. This will allow for running the probe with any DPDK-supported NIC. Branch also adds support for FlexProbe HW accelerated probe for monitoring network traffic.