### PR TITLE
Dpdk ifc update

### DIFF
--- a/input/dpdk.cpp
+++ b/input/dpdk.cpp
@@ -43,6 +43,7 @@
 
 #include <cstring>
 #include <rte_ethdev.h>
+#include <rte_version.h>
 
 #include "dpdk.h"
 #include "parser.hpp"
@@ -126,7 +127,11 @@ namespace ipxp
     void DpdkReader::init(const char *params)
     {
         DpdkOptParser parser;
+#if RTE_VERSION >= RTE_VERSION_NUM(21,11,0,0)
+        rte_eth_conf port_conf{.rxmode = {.mtu = RTE_ETHER_MAX_LEN}};
+#else
         rte_eth_conf port_conf{.rxmode = {.max_rx_pkt_len = RTE_ETHER_MAX_LEN}};
+#endif
 
         try {
             parser.parse(params);

--- a/input/dpdk.cpp
+++ b/input/dpdk.cpp
@@ -167,16 +167,16 @@ namespace ipxp
         parser_opt_t opt{&packets, false, false, DLT_EN10MB};
 #endif
         packets.cnt = 0;
-        for (auto M : mbufs_) {
-            rte_pktmbuf_free(M);
+        for (auto i = 0; i < pkts_read_; i++) {
+            rte_pktmbuf_free(mbufs_[i]);
         }
 
-        auto pkts_read = rte_eth_rx_burst(port_id_, 0, mbufs_.data(), mbufs_.size());
-        if (pkts_read == 0) {
+        pkts_read_ = rte_eth_rx_burst(port_id_, 0, mbufs_.data(), mbufs_.size());
+        if (pkts_read_ == 0) {
             return Result::NOT_PARSED;
         }
 
-        for (auto i = 0; i < pkts_read; i++) {
+        for (auto i = 0; i < pkts_read_; i++) {
 #ifdef WITH_FLEXPROBE
             // Convert Flexprobe pre-parsed packet into IPFIXPROBE packet
             auto conv_result = convert_from_flexprobe(mbufs_[i], packets.pkts[packets.cnt]);

--- a/input/dpdk.h
+++ b/input/dpdk.h
@@ -98,7 +98,7 @@ namespace ipxp
         size_t port_id_;
         rte_mempool* mpool_;
         std::vector<rte_mbuf*> mbufs_;
-
+        std::uint16_t pkts_read_;
     public:
         Result get(PacketBlock& packets) override;
 


### PR DESCRIPTION
Update for DPDK interface

Fixes an issue with double-free on used mbufs and adds version check for MTU settings since these changed with new version of DPDK.