### PR TITLE
Added InterfaceIn for Flexprobe data

### DIFF
--- a/include/ipfixprobe/ipfix-elements.hpp
+++ b/include/ipfixprobe/ipfix-elements.hpp
@@ -264,6 +264,7 @@ namespace ipxp {
 
 #ifdef WITH_FLEXPROBE
 #define FX_FRAME_SIGNATURE(F)         F(5715,   1010,  18,   nullptr)
+#define FX_INPUT_INTERFACE(F)         F(5715,   1015,   1,   nullptr)
 #define FX_TCP_TRACKING(F)            F(5715,   1020,   1,   nullptr)
 #endif
 
@@ -498,7 +499,7 @@ namespace ipxp {
    F(OSQUERY_SYSTEM_HOSTNAME)
 
 #ifdef WITH_FLEXPROBE
-#define IPFIX_FLEXPROBE_DATA_TEMPLATE(F) F(FX_FRAME_SIGNATURE)
+#define IPFIX_FLEXPROBE_DATA_TEMPLATE(F) F(FX_FRAME_SIGNATURE) F(FX_INPUT_INTERFACE)
 #define IPFIX_FLEXPROBE_TCP_TEMPLATE(F) F(FX_TCP_TRACKING)
 #define IPFIX_FLEXPROBE_ENCR_TEMPLATE(F)
 #else

--- a/process/flexprobe-data-processing.cpp
+++ b/process/flexprobe-data-processing.cpp
@@ -45,13 +45,13 @@
 
 namespace ipxp {
 
-int FrameSignature::REGISTERED_ID = -1;
+int FlexprobeData::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
    static PluginRecord rec = PluginRecord("flexprobe-data", [](){return new FlexprobeDataProcessing();});
    register_plugin(&rec);
-   FrameSignature::REGISTERED_ID = register_extension();
+    FlexprobeData::REGISTERED_ID = register_extension();
 }
 
 }


### PR DESCRIPTION
Default input interface item is sourced from a field that doesn't match the information needed by Flexprobe.