### PR TITLE
pcap: add support for DLT_LINUX_SLL2 datalink layer

### DIFF
--- a/input/parser.hpp
+++ b/input/parser.hpp
@@ -46,6 +46,11 @@
 
 #include <ipfixprobe/packet.hpp>
 
+#ifdef WITH_PCAP
+#include <pcap/pcap.h>
+#include <pcap/sll.h>
+#endif /* WITH_PCAP */
+
 #ifndef DLT_EN10MB
 #define DLT_EN10MB 1
 #endif

--- a/input/pcap.cpp
+++ b/input/pcap.cpp
@@ -186,6 +186,15 @@ void PcapReader::open_ifc(const std::string &ifc)
 void PcapReader::check_datalink(int datalink)
 {
    if (m_datalink != DLT_EN10MB && m_datalink != DLT_LINUX_SLL && m_datalink != DLT_RAW) {
+#ifdef DLT_LINUX_SLL2
+      if (m_datalink == DLT_LINUX_SLL2) {
+         // DLT_LINUX_SLL2 is also supported
+         return;
+      } else {
+         close();
+         throw PluginError("unsupported link type detected, supported types are: DLT_EN10MB, DLT_LINUX_SLL, DLT_LINUX_SLL2, and DLT_RAW");
+      }
+#endif
       close();
       throw PluginError("unsupported link type detected, supported types are DLT_EN10MB and DLT_LINUX_SLL and DLT_RAW");
    }


### PR DESCRIPTION
DLT_LINUX_SLL2 is a new version of Linux cooked sockets (v2) in PCAP.
It has slightly extended header compared to the v1.