### PR TITLE
tls: BUGFIX replaced unknown uint with size_t, add missing header file

### DIFF
--- a/process/quic_parser.cpp
+++ b/process/quic_parser.cpp
@@ -660,7 +660,7 @@ inline void QUICParser::quic_skip_ack1(uint8_t *start, uint64_t &offset)
 
    quic_get_variable_length(start, offset);
 
-   for (uint x = 0; x < quic_ack_range_count; x++) {
+   for (uint64_t x = 0; x < quic_ack_range_count; x++) {
       quic_get_variable_length(start, offset);
       quic_get_variable_length(start, offset);
    }
@@ -677,7 +677,7 @@ inline void QUICParser::quic_skip_ack2(uint8_t *start, uint64_t &offset)
 
    quic_get_variable_length(start, offset);
 
-   for (uint x = 0; x < quic_ack_range_count; x++) {
+   for (uint64_t x = 0; x < quic_ack_range_count; x++) {
       quic_get_variable_length(start, offset);
       quic_get_variable_length(start, offset);
    }

--- a/process/tls_parser.cpp
+++ b/process/tls_parser.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "tls_parser.hpp"
+#include <endian.h>
 
 namespace ipxp {
 TLSParser::TLSParser()
@@ -61,7 +62,7 @@ bool TLSParser::tls_is_grease_value(uint16_t val)
    return false;
 }
 
-void TLSParser::tls_get_quic_user_agent(TLSData &data, char *buffer, uint buffer_size)
+void TLSParser::tls_get_quic_user_agent(TLSData &data, char *buffer, size_t buffer_size)
 {
    // compute end of quic_transport_parameters
    const uint16_t quic_transport_params_len = ntohs(*(uint16_t *) data.start);
@@ -92,12 +93,12 @@ void TLSParser::tls_get_quic_user_agent(TLSData &data, char *buffer, uint buffer
    return;
 }
 
-void TLSParser::tls_get_server_name(TLSData &data, char *buffer, uint buffer_size)
+void TLSParser::tls_get_server_name(TLSData &data, char *buffer, size_t buffer_size)
 {
    uint16_t list_len       = ntohs(*(uint16_t *) data.start);
    uint16_t offset         = sizeof(list_len);
    const uint8_t *list_end = data.start + list_len + offset;
-   uint buff_offset        = 0;
+   size_t buff_offset      = 0;
 
    if (list_end > data.end) {
       // data.valid = false;
@@ -125,7 +126,7 @@ void TLSParser::tls_get_server_name(TLSData &data, char *buffer, uint buffer_siz
    return;
 }
 
-void TLSParser::tls_get_alpn(TLSData &data, char *buffer, uint buffer_size)
+void TLSParser::tls_get_alpn(TLSData &data, char *buffer, size_t buffer_size)
 {
    uint16_t list_len       = ntohs(*(uint16_t *) data.start);
    uint16_t offset         = sizeof(list_len);

--- a/process/tls_parser.hpp
+++ b/process/tls_parser.hpp
@@ -84,10 +84,10 @@ public:
    bool tls_skip_compression_met(TLSData&);
    bool tls_check_ext_len(TLSData&);
    bool tls_check_rec(TLSData&);
-   void tls_get_server_name(TLSData &, char *, uint);
-   void tls_get_alpn(TLSData &, char *, uint);
+   void tls_get_server_name(TLSData &, char *, size_t);
+   void tls_get_alpn(TLSData &, char *, size_t);
 
-   void tls_get_quic_user_agent(TLSData &, char *, uint);
+   void tls_get_quic_user_agent(TLSData &, char *, size_t);
    bool tls_check_handshake(TLSData&);
    bool tls_get_ja3_cipher_suites(std::string&, TLSData&);
 


### PR DESCRIPTION
OpenWrt build failed due to unknown uint type and missing include of <endian.h> in QUIC / TLS code.