### PR TITLE
dpdk: check capabilities and skip unsupported features

### DIFF
--- a/input/dpdk.h
+++ b/input/dpdk.h
@@ -177,6 +177,8 @@ private:
     uint16_t m_currentRxId;
     int m_rxTimestampOffset;
     bool m_isNfbDpdkDriver;
+    bool m_supportedRSS;
+    bool m_supportedHWTimestamp;
     
     bool isConfigured = false;
     static DpdkCore* m_instance;


### PR DESCRIPTION
Skip RSS setting or HW timestamps when they are not supported by
hardware of ipfixprobe.

This PR fixes the use in virtual machine with uio_pci_generic driver.
It was tested with Ubuntu jammy in VirtualBox.
