### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,10 @@ tests/*.log
 tests/*.trs
 tests/output/
 
+# Mac Finder metafile
+**/.DS_Store
+
+# vscode settings files
+.vscode
+
 


### PR DESCRIPTION
do not track vscode settings or MacOS finder metafiles