### PR TITLE
DPDK ring reader

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -155,7 +155,9 @@ endif
 if WITH_DPDK
 ipfixprobe_input_src+=\
         input/dpdk.cpp \
-        input/dpdk.h
+        input/dpdk.h \
+	input/dpdk-ring.cpp \
+	input/dpdk-ring.h
 endif
 
 ipfixprobe_headers_src=\

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ Here are the examples of various plugins usage:
 # The following `dpdk` interfaces are given without parameters; their configuration is inherited from the first one.
 # Example for the queue of 3 DPDK input plugins (q=3):
 `./ipfixprobe -i "dpdk;p=0;q=3;e=-c 0x1 -a  <[domain:]bus:devid.func>" -i dpdk -i dpdk -p http "-p" bstats -p tls -o "ipfix;h=127.0.0.1"`
+
+# Read packets using DPDK input interface as secondary process with shared memory (DPDK rings) - in this case, 4 DPDK rings are used
+`./ipfixprobe -i 'dpdk-ring;r=rx_ipfixprobe_0;e= --proc-type=secondary' -i 'dpdk-ring;r=rx_ipfixprobe_1' -i 'dpdk-ring;r=rx_ipfixprobe_2' -i 'dpdk-ring;r=rx_ipfixprobe_3' -o 'text'`
 ```
 
 ## Flow Data Extension - Processing Plugins

--- a/input/dpdk-ring.cpp
+++ b/input/dpdk-ring.cpp
@@ -1,0 +1,208 @@
+/**
+ * \file dpdk-ring.cpp
+ * \brief DPDK ring input interface for ipfixprobe (secondary DPDK app).
+ * \author Jaroslav Pesek <pesek@cesnet.cz>
+ * \date 2023
+ */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
+#include <cstring>
+#include <mutex>
+#include <rte_ethdev.h>
+#include <rte_version.h>
+#include <unistd.h>
+#include <rte_eal.h>
+#include <rte_errno.h>
+
+#include "dpdk-ring.h"
+#include "parser.hpp"
+
+namespace ipxp {
+__attribute__((constructor)) static void register_this_plugin()
+{
+    static PluginRecord rec = PluginRecord("dpdk-ring", []() { return new DpdkRingReader(); });
+    register_plugin(&rec);
+}
+
+DpdkRingCore* DpdkRingCore::m_instance = nullptr;
+
+DpdkRingCore& DpdkRingCore::getInstance()
+{
+    if (!m_instance) {
+        m_instance = new DpdkRingCore();
+    }
+    return *m_instance;
+}
+
+DpdkRingCore::~DpdkRingCore()
+{
+    rte_eal_cleanup();
+    m_instance = nullptr;
+}
+
+void DpdkRingCore::deinit()
+{
+    if (m_instance) {
+        delete m_instance;
+        m_instance = nullptr;
+    }
+}
+
+void DpdkRingCore::configure(const char* params) {
+    if (isConfigured) {
+        return;
+    }
+
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
+
+    configureEal(parser.eal_params());
+    isConfigured = true;
+}
+
+std::vector<char *> DpdkRingCore::convertStringToArgvFormat(const std::string& ealParams)
+{
+    // set first value as program name (argv[0])
+    std::vector<char *> args = {"ipfixprobe"};
+    std::istringstream iss(ealParams);
+    std::string token;
+
+    while(iss >> token) {
+        char *arg = new char[token.size() + 1];
+        copy(token.begin(), token.end(), arg);
+        arg[token.size()] = '\0';
+        args.push_back(arg);
+    }
+    return args;
+}
+
+void DpdkRingCore::configureEal(const std::string& ealParams)
+{
+    std::vector<char *> args = convertStringToArgvFormat(ealParams);
+
+    if (rte_eal_init(args.size(), args.data()) < 0) {
+        rte_exit(EXIT_FAILURE, "Cannot initialize RTE_EAL: %s\n", rte_strerror(rte_errno));
+    }
+}
+
+DpdkRingReader::DpdkRingReader()
+    : m_dpdkRingCore(DpdkRingCore::getInstance())
+{
+    pkts_read_ = 0;
+}
+
+DpdkRingReader::~DpdkRingReader()
+{
+    m_dpdkRingCore.deinit();
+}
+
+void DpdkRingReader::createRteMbufs(uint16_t mbufsSize)
+{
+    try {
+        mbufs_.resize(mbufsSize);
+    } catch (const std::exception& e) {
+        throw PluginError(e.what());
+    }
+}
+
+void DpdkRingReader::init(const char* params)
+{
+    m_dpdkRingCore.configure(params);
+    DpdkRingOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
+    createRteMbufs(m_dpdkRingCore.parser.pkt_buffer_size());
+    m_ring = rte_ring_lookup(parser.ring_name().c_str());
+    if (!m_ring) {
+        throw PluginError("Cannot find ring with name: " + parser.ring_name());
+    } else {
+        is_reader_ready = true;
+    }
+}
+
+struct timeval DpdkRingReader::getTimestamp(rte_mbuf* mbuf)
+{
+	struct timeval tv;
+    auto now = std::chrono::system_clock::now();
+    auto now_t = std::chrono::system_clock::to_time_t(now);
+
+    auto dur = now - std::chrono::system_clock::from_time_t(now_t);
+    auto micros = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+
+    tv.tv_sec = now_t;
+    tv.tv_usec = micros;
+    return tv;
+}
+
+InputPlugin::Result DpdkRingReader::get(PacketBlock& packets) 
+{
+    while (is_reader_ready == false) {
+        usleep(1000);
+    }
+
+    parser_opt_t opt {&packets, false, false, 0};
+
+    packets.cnt = 0;
+    for (auto i = 0; i < pkts_read_; i++) {
+        rte_pktmbuf_free(mbufs_[i]);
+    }
+    pkts_read_ = rte_ring_dequeue_burst(
+        m_ring,
+        reinterpret_cast<void**>(mbufs_.data()),
+        mbufs_.capacity(),
+        nullptr);
+    if (pkts_read_ == 0) {
+        return Result::TIMEOUT;
+    }
+    for (auto i = 0; i < pkts_read_; i++) {
+        parse_packet(&opt,
+            getTimestamp(mbufs_[i]),
+            rte_pktmbuf_mtod(mbufs_[i], const std::uint8_t*),
+            rte_pktmbuf_data_len(mbufs_[i]),
+            rte_pktmbuf_data_len(mbufs_[i]));
+        m_seen++;
+        m_parsed++;
+    }
+    return Result::PARSED;
+}
+} // namespace ipxp

--- a/input/dpdk-ring.cpp
+++ b/input/dpdk-ring.cpp
@@ -5,7 +5,7 @@
  * \date 2023
  */
 /*
- * Copyright (C) 2021 CESNET
+ * Copyright (C) 2023 CESNET
  *
  * LICENSE TERMS
  *
@@ -21,23 +21,6 @@
  * 3. Neither the name of the Company nor the names of its contributors
  *    may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- *
- * ALTERNATIVELY, provided that this notice is retained in full, this
- * product may be distributed under the terms of the GNU General Public
- * License (GPL) version 2 or later, in which case the provisions
- * of the GPL apply INSTEAD OF those given above.
- *
- * This software is provided ``as is'', and any express or implied
- * warranties, including, but not limited to, the implied warranties of
- * merchantability and fitness for a particular purpose are disclaimed.
- * In no event shall the company or contributors be liable for any
- * direct, indirect, incidental, special, exemplary, or consequential
- * damages (including, but not limited to, procurement of substitute
- * goods or services; loss of use, data, or profits; or business
- * interruption) however caused and on any theory of liability, whether
- * in contract, strict liability, or tort (including negligence or
- * otherwise) arising in any way out of the use of this software, even
- * if advised of the possibility of such damage.
  *
  */
 #include <cstring>

--- a/input/dpdk-ring.cpp
+++ b/input/dpdk-ring.cpp
@@ -41,9 +41,9 @@ __attribute__((constructor)) static void register_this_plugin()
     register_plugin(&rec);
 }
 
-DpdkRingCore* DpdkRingCore::m_instance = nullptr;
+DpdkRingCore *DpdkRingCore::m_instance = nullptr;
 
-DpdkRingCore& DpdkRingCore::getInstance()
+DpdkRingCore &DpdkRingCore::getInstance()
 {
     if (!m_instance) {
         m_instance = new DpdkRingCore();
@@ -145,7 +145,7 @@ void DpdkRingReader::init(const char* params)
 
 struct timeval DpdkRingReader::getTimestamp(rte_mbuf* mbuf)
 {
-	struct timeval tv;
+    struct timeval tv;
     auto now = std::chrono::system_clock::now();
     auto now_t = std::chrono::system_clock::to_time_t(now);
 

--- a/input/dpdk-ring.h
+++ b/input/dpdk-ring.h
@@ -1,0 +1,158 @@
+/**
+ * \file dpdk-ring.h
+ * \brief DPDK ring input interface for ipfixprobe (secondary DPDK app).
+ * \author Jaroslav Pesek <pesek@cesnet.cz>
+ * \date 2023
+ */
+/*
+ * Copyright (C) 2021 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * ALTERNATIVELY, provided that this notice is retained in full, this
+ * product may be distributed under the terms of the GNU General Public
+ * License (GPL) version 2 or later, in which case the provisions
+ * of the GPL apply INSTEAD OF those given above.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+ *
+ */
+#include <config.h>
+#ifdef WITH_DPDK
+
+#ifndef IPXP_DPDK_RING_READER_H
+#define IPXP_DPDK_RING_READER_H
+
+#include <ipfixprobe/input.hpp>
+#include <ipfixprobe/utils.hpp>
+
+#include <memory>
+#include <rte_mbuf.h>
+#include <rte_ring.h>
+#include <sstream>
+
+namespace ipxp {
+class DpdkRingOptParser : public OptionsParser {
+private:
+    static constexpr size_t DEFAULT_MBUF_BURST_SIZE = 256;
+    size_t pkt_buffer_size_;
+
+    std::string ring_name_;
+    std::string eal_;
+public:
+    DpdkRingOptParser()
+        : OptionsParser("dpdk-ring", "DPDK ring input interface for ipfixprobe (secondary DPDK app).")
+        , pkt_buffer_size_(DEFAULT_MBUF_BURST_SIZE)
+    {
+        register_option(
+            "b",
+            "bsize",
+            "SIZE",
+            "Size of the MBUF packet buffer. Default: " + std::to_string(DEFAULT_MBUF_BURST_SIZE),
+            [this](const char* arg) {try{pkt_buffer_size_ = str2num<decltype(pkt_buffer_size_)>(arg);} catch (std::invalid_argument&){return false;} return true; },
+            RequiredArgument);
+        register_option(
+            "r",
+            "ring",
+            "RING",
+            "Name of the ring to read packets from. Need to be specified explicitly thus no default provided.",
+            [this](const char* arg) {ring_name_ = arg; return true;},
+            OptionFlags::RequiredArgument);
+        register_option(
+            "e", 
+            "eal", 
+            "EAL", 
+            "DPDK eal", 
+            [this](const char *arg){eal_ = arg; return true;}, 
+            OptionFlags::RequiredArgument);
+
+    }
+    size_t pkt_buffer_size() const { return pkt_buffer_size_; }
+
+    std::string ring_name() const { return ring_name_; }
+
+    std::string eal_params() const { return eal_; }
+};
+
+class DpdkRingCore {
+public:
+    /**
+     * @brief Configure DPDK secondary process.
+     * 
+     * @param eal_params DPDK EAL parameters.
+    */
+   void configure(const char* params);
+
+    /**
+     * @brief Get the singleton dpdk core instance
+     */
+    static DpdkRingCore& getInstance();
+    void deinit();
+
+    DpdkRingOptParser parser;
+
+private:
+    std::vector<char *> convertStringToArgvFormat(const std::string& ealParams);
+    void configureEal(const std::string& ealParams);
+    ~DpdkRingCore();
+    bool isConfigured = false;
+    static DpdkRingCore* m_instance;
+};
+
+class DpdkRingReader : public InputPlugin {
+public:
+    Result get(PacketBlock& packets) override;
+
+    void init(const char* params) override;
+
+    OptionsParser* get_parser() const override
+    {
+        return new DpdkRingOptParser();
+    }
+
+    std::string get_name() const override
+    {
+        return "dpdk-ring";
+    }
+
+    ~DpdkRingReader();
+    DpdkRingReader();
+private:
+    std::vector<rte_mbuf*> mbufs_;
+    std::uint16_t pkts_read_;
+
+    void createRteMbufs(uint16_t mbufsSize);
+    struct timeval getTimestamp(rte_mbuf* mbuf);
+    DpdkRingCore& m_dpdkRingCore;
+    rte_ring* m_ring;
+    bool is_reader_ready = false;
+
+
+};
+} // namespace ipxp
+
+#endif // IPXP_DPDK_RING_READER_H
+#endif

--- a/input/dpdk-ring.h
+++ b/input/dpdk-ring.h
@@ -5,7 +5,7 @@
  * \date 2023
  */
 /*
- * Copyright (C) 2021 CESNET
+ * Copyright (C) 2023 CESNET
  *
  * LICENSE TERMS
  *
@@ -21,23 +21,6 @@
  * 3. Neither the name of the Company nor the names of its contributors
  *    may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- *
- * ALTERNATIVELY, provided that this notice is retained in full, this
- * product may be distributed under the terms of the GNU General Public
- * License (GPL) version 2 or later, in which case the provisions
- * of the GPL apply INSTEAD OF those given above.
- *
- * This software is provided ``as is'', and any express or implied
- * warranties, including, but not limited to, the implied warranties of
- * merchantability and fitness for a particular purpose are disclaimed.
- * In no event shall the company or contributors be liable for any
- * direct, indirect, incidental, special, exemplary, or consequential
- * damages (including, but not limited to, procurement of substitute
- * goods or services; loss of use, data, or profits; or business
- * interruption) however caused and on any theory of liability, whether
- * in contract, strict liability, or tort (including negligence or
- * otherwise) arising in any way out of the use of this software, even
- * if advised of the possibility of such damage.
  *
  */
 #include <config.h>

--- a/input/dpdk-ring.h
+++ b/input/dpdk-ring.h
@@ -87,27 +87,27 @@ public:
      * 
      * @param eal_params DPDK EAL parameters.
     */
-   void configure(const char* params);
+   void configure(const char *params);
 
     /**
      * @brief Get the singleton dpdk core instance
      */
-    static DpdkRingCore& getInstance();
+    static DpdkRingCore &getInstance();
     void deinit();
 
     DpdkRingOptParser parser;
 
 private:
-    std::vector<char *> convertStringToArgvFormat(const std::string& ealParams);
-    void configureEal(const std::string& ealParams);
+    std::vector<char *> convertStringToArgvFormat(const std::string &ealParams);
+    void configureEal(const std::string &ealParams);
     ~DpdkRingCore();
     bool isConfigured = false;
-    static DpdkRingCore* m_instance;
+    static DpdkRingCore *m_instance;
 };
 
 class DpdkRingReader : public InputPlugin {
 public:
-    Result get(PacketBlock& packets) override;
+    Result get(PacketBlock &packets) override;
 
     void init(const char* params) override;
 
@@ -124,13 +124,13 @@ public:
     ~DpdkRingReader();
     DpdkRingReader();
 private:
-    std::vector<rte_mbuf*> mbufs_;
+    std::vector<rte_mbuf *> mbufs_;
     std::uint16_t pkts_read_;
 
     void createRteMbufs(uint16_t mbufsSize);
-    struct timeval getTimestamp(rte_mbuf* mbuf);
-    DpdkRingCore& m_dpdkRingCore;
-    rte_ring* m_ring;
+    struct timeval getTimestamp(rte_mbuf *mbuf);
+    DpdkRingCore &m_dpdkRingCore;
+    rte_ring *m_ring;
     bool is_reader_ready = false;
 
 


### PR DESCRIPTION
Added a new input plugin, `dpdk-ring`, which enables ipfixprobe reading from shared memory as a consumer so that ipfixprobe can play the role of DPDK secondary process. See Examples in README.md for checking mandatory parameters.