### PR TITLE
dpdk: propose new variables to control init by ipfixprobed

### DIFF
--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -1,5 +1,5 @@
 pkgsysconfdir=$(sysconfdir)/ipfixprobe
-dist_pkgsysconf_DATA=link0.conf.example
+dist_pkgsysconf_DATA=link0.conf.example dpdk_direct.conf.example dpdk_mring.conf.example
 bin_SCRIPTS=ipfixprobed
 dist_systemdsystemunit_DATA=ipfixprobe@.service ipfixprobe-monitoring.target
 

--- a/init/dpdk_direct.conf.example
+++ b/init/dpdk_direct.conf.example
@@ -1,0 +1,20 @@
+# See link0.conf.example for description of the options
+#######################################################
+
+USE_DPDK=1
+DPDK_QUEUES_COUNT=8
+DPDK_LCORES="(0-7)@(0,2,4,6,8,10,12,14)"
+DPDK_EXTRA_EAL="--file-prefix 0000:17:00.0"
+DPDK_OPTS="m=2000;b=2048"
+DPDK_DEVICE="0000:17:00.0,rxhdr_dynfield=1,reta_index_global=1,queue_driver=native"
+DPDK_PORT=0
+PROCESS=(pstats tls http ssdp "dnssd;txt")
+CACHE_SIZE=17
+ACTIVE_TIMEOUT=300
+INACTIVE_TIMEOUT=65
+LINK=0
+DIR=0
+HOST=127.0.0.1
+PORT=4739
+UDP=yes
+

--- a/init/dpdk_mring.conf.example
+++ b/init/dpdk_mring.conf.example
@@ -1,0 +1,21 @@
+# See link0.conf.example for description of the options
+#######################################################
+
+USE_DPDK=1
+DPDK_RING=1
+DPDK_QUEUES_COUNT=8
+DPDK_LCORES="(0-7)@(0,2,4,6,8,10,12,14)"
+DPDK_EXTRA_EAL="--proc-type=secondary"
+DPDK_OPTS="b=2048"
+DPDK_RING_PATTERN="ipfixprobe_in_%i"
+DPDK_RING_STARTIDX=0
+PROCESS=(basicplus pstats tls quic http")
+CACHE_SIZE=17
+ACTIVE_TIMEOUT=300
+INACTIVE_TIMEOUT=65
+LINK=0
+DIR=0
+HOST=127.0.0.1
+PORT=4739
+UDP=yes
+

--- a/init/ipfixprobed
+++ b/init/ipfixprobed
@@ -7,11 +7,38 @@ if [ -e "$CONFFILE" ]; then
    input=""
    dpdkinput=""
    if [ "$USE_DPDK" = "1" ]; then
+      # check
+      if [ -z "$DPDK_QUEUES_COUNT" ]; then
+         echo "Missing DPDK_QUEUES_COUNT in configuration of DPDK mode."
+         exit 1
+      fi
+
       # set up DPDK interface(s)
-      dpdkinput=("-i" "dpdk;p=$DPDK_PORT;q=$DPDK_QUEUES_COUNT;e=--lcores $DPDK_LCORES -a $DPDK_DEVICE")
-      for ((ifc=1; ifc<$DPDK_QUEUES_COUNT;ifc++)); do
-         dpdkinput+=("-i" "dpdk")
-      done
+      if [ "$DPDK_RING" = "1" ]; then
+         # checks
+         if [ -z "$DPDK_RING_PATTERN" ]; then
+            echo "Missing DPDK_RING_PATTERN in configuration of DPDK_RING mode."
+            exit 1
+         fi
+         if [ -z "$DPDK_RING_STARTIDX" ]; then
+            echo "Missing DPDK_RING_STARTIDX in configuration of DPDK_RING mode, using 0."
+            DPDK_RING_STARTIDX=0
+         fi
+         # mring interfaces
+         dpdkinput=("-i" "dpdk-ring;r=$(printf "$DPDK_RING_PATTERN" "$DPDK_RING_STARTIDX");e=--lcores $DPDK_LCORES $DPDK_EXTRA_EAL")
+         for ((ifc=($DPDK_RING_STARTIDX+1); ifc<($DPDK_RING_STARTIDX + $DPDK_QUEUES_COUNT);ifc++)); do
+            dpdkinput+=("-i" "dpdk-ring;r=$(printf "$DPDK_RING_PATTERN" "$ifc")")
+         done
+      else
+         # DPDK port interface
+         if [ -n "$DPDK_PORTOPTS" -a "${DPDK_PORTOPTS:0:1}" != ";" ]; then
+            DPDK_PORTOPTS=";$DPDK_PORTOPTS"
+         fi
+         dpdkinput=("-i" "dpdk;p=${DPDK_PORT}${DPDK_PORTOPTS};q=$DPDK_QUEUES_COUNT;e=--lcores $DPDK_LCORES $DPDK_EXTRA_EAL -a $DPDK_DEVICE")
+         for ((ifc=1; ifc<$DPDK_QUEUES_COUNT;ifc++)); do
+            dpdkinput+=("-i" "dpdk")
+         done
+      fi
    fi
    if `declare -p INPUT > /dev/null 2>/dev/null`; then
       # list of input plugins

--- a/init/link0.conf.example
+++ b/init/link0.conf.example
@@ -58,21 +58,54 @@
 
 #USE_DPDK=1
 
-# Set PCIe address in the format <[domain:]bus:devid.func> for example:
-
-#DPDK_DEVICE=0000:43:00.0
+# Required: Set number of parallel queues (RSS feature):
+#DPDK_QUEUES_COUNT=8
 
 # Set mapping of DPDK lcores to threads:
+#DPDK_LCORES="(0-7)@(0,2,4,6,8,10,12,14)"
 
-#DPDK_LCORES="(0-7)@(0-7)"
+# Extra options for DPDK EAL, passed to e= option of `dpdk` or `dpdk-ring` plugin.
+# * Use --file-prefix to separate DPDK application into new namespace.
+# * Use --proc-type=secondary for Option B) to receive packets via mrings created
+#   by some other primary DPDK application.
+#DPDK_EXTRA_EAL="--file-prefix 0000:17:00.0_0 --proc-type=secondary"
 
-# Set network device port:
+# Additional options of DPDK plugin separated by `;`
+#    m ~ Size of the memory pool for received packets (only for Option A)
+#    b ~ Size of the MBUF packet buffer
+#DPDK_OPTS="m=2000;b=2048"
 
+#----------------------------------------
+# Option A) DPDK direct device
+#----------------------------------------
+
+# Required: Set PCIe address in the format <[domain:]bus:devid.func> for example:
+#DPDK_DEVICE="0000:43:00.0"
+
+# Note that DPDK_DEVICE can be extended by driver-specific parameters, e.g.:
+#
+#DPDK_DEVICE=0000:17:00.0,rxhdr_dynfield=1,reta_index_global=1,queue_driver=native
+#
+# this example shows parameters for FPGA firmware by CESNET:
+#  rxhdr_dynfield=1 ~ memory allocation
+#  reta_index_global=1 ~ enable redirection table to enhance RSS among multiple ports
+#  queue_driver=native ~ DPDK driver mode
+
+# Required: Set network device port, can be a list separated by comma:
 #DPDK_PORT=0
 
-# Set number of parallel queues (RSS feature)
+#----------------------------------------
+# Option B) DPDK mring input instead of DPDK_DEVICE
+#----------------------------------------
 
-#DPDK_QUEUES_COUNT=8
+# Enable option B) instead of A), receive packets via DPDK mrings
+#DPDK_RING=1
+
+# Required: set pattern to generate mring identifiers, use %i of printf format to place index:
+#DPDK_RING_PATTERN="rx_ipfixprobe_%i"
+
+# set starting index to generate mring identifiers (e.g., startidx=8 with DPDK_QUEUES_COUNT=4 makes indexes 8, 9, 10, 11)
+#DPDK_RING_STARTIDX=0
 
 #===================================================
 

--- a/ipfixprobe.spec.in
+++ b/ipfixprobe.spec.in
@@ -124,6 +124,8 @@ This package contains header file for liburfilter.
 %attr(0755, root, nemead) %{_bindir}/ipfixprobed
 %{_sysconfdir}/bash_completion.d/ipfixprobe.bash
 %{_sysconfdir}/ipfixprobe/link0.conf.example
+%{_sysconfdir}/ipfixprobe/dpdk_direct.conf.example
+%{_sysconfdir}/ipfixprobe/dpdk_mring.conf.example
 %{_docdir}/ipfixprobe/README.md
 %if %{with ndp}
 %{_libdir}/libndpRI.so.0


### PR DESCRIPTION
The description of new variables was added into link0.conf.example:
   DPDK_RING, DPDK_RING_PATTERN, DPDK_RING_STARTIDX
also, there is new DPDK_OPTS variable to set mem and mbuf.

There are new examples dpdk_direct.conf.example and
dpdk_mring.conf.example.
