### PR TITLE
Draft: Clang format - code reformatting

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -25,6 +25,8 @@ jobs:
       run: autoreconf -i
     - name: configure
       run: ./configure --with-raw --with-pcap --with-nemea --with-gtest
+    - name: make format-check
+      run: make format-check
     - name: make
       run: make
     - name: make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -275,6 +275,17 @@ clean-local:
 	fi
 endif
 
+SOURCE_DIR = .
+SOURCE_REGEX = '.*\.\(cpp\|hpp\)'
+
+.PHONY: format-check
+format-check:
+	find $(SOURCE_DIR) -type f -regex $(SOURCE_REGEX) -print0 | xargs -0 clang-format --dry-run
+
+.PHONY: format-fix
+format-fix:
+	find $(SOURCE_DIR) -type f -regex $(SOURCE_REGEX) -print0 | xargs -0 clang-format -i
+
 RPMDIR = RPMBUILD
 
 if MAKE_RPMS

--- a/include/ipfixprobe/flowifc.hpp
+++ b/include/ipfixprobe/flowifc.hpp
@@ -37,17 +37,18 @@
 #include <config.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string>
 #include <sys/time.h>
 
 #ifdef WITH_NEMEA
-#include <unirec/unirec.h>
 #include "fields.h"
+#include <unirec/unirec.h>
 #else
 #define UR_FIELDS(...)
 #endif
 
-#include <arpa/inet.h>
 #include "ipaddr.hpp"
+#include <arpa/inet.h>
 
 namespace ipxp {
 
@@ -60,126 +61,114 @@ int get_extension_cnt();
  * \brief Flow record extension base struct.
  */
 struct RecordExt {
-   RecordExt *m_next; /**< Pointer to next extension */
-   int m_ext_id; /**< Identifier of extension. */
+    RecordExt* m_next; /**< Pointer to next extension */
+    int m_ext_id; /**< Identifier of extension. */
 
-   /**
-    * \brief Constructor.
-    * \param [in] id ID of extension.
-    */
-   RecordExt(int id) : m_next(nullptr), m_ext_id(id)
-   {
-   }
+    /**
+     * \brief Constructor.
+     * \param [in] id ID of extension.
+     */
+    RecordExt(int id)
+        : m_next(nullptr)
+        , m_ext_id(id)
+    {
+    }
 
 #ifdef WITH_NEMEA
-   /**
-    * \brief Fill unirec record with stored extension data.
-    * \param [in] tmplt Unirec template.
-    * \param [out] record Pointer to the unirec record.
-    */
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-   }
+    /**
+     * \brief Fill unirec record with stored extension data.
+     * \param [in] tmplt Unirec template.
+     * \param [out] record Pointer to the unirec record.
+     */
+    virtual void fill_unirec(ur_template_t* tmplt, void* record) {}
 
-   /**
-    * \brief Get unirec template string.
-    * \return Unirec template string.
-    */
-   virtual const char *get_unirec_tmplt() const
-   {
-      return "";
-   }
+    /**
+     * \brief Get unirec template string.
+     * \return Unirec template string.
+     */
+    virtual const char* get_unirec_tmplt() const { return ""; }
 #endif
 
-   /**
-    * \brief Fill IPFIX record with stored extension data.
-    * \param [out] buffer IPFIX template record buffer.
-    * \param [in] size IPFIX template record buffer size.
-    * \return Number of bytes written to buffer or -1 if data cannot be written.
-    */
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      return 0;
-   }
+    /**
+     * \brief Fill IPFIX record with stored extension data.
+     * \param [out] buffer IPFIX template record buffer.
+     * \param [in] size IPFIX template record buffer size.
+     * \return Number of bytes written to buffer or -1 if data cannot be written.
+     */
+    virtual int fill_ipfix(uint8_t* buffer, int size) { return 0; }
 
-   /**
-    * \brief Get ipfix string fields.
-    * \return Return ipfix fields array.
-    */
-   virtual const char **get_ipfix_tmplt() const
-   {
-      return nullptr;
-   }
+    /**
+     * \brief Get ipfix string fields.
+     * \return Return ipfix fields array.
+     */
+    virtual const char** get_ipfix_tmplt() const { return nullptr; }
 
-   /**
-    * \brief Get text representation of exported elements
-    * \return Return fields converted to text
-    */
-   virtual std::string get_text() const
-   {
-      return "";
-   }
+    /**
+     * \brief Get text representation of exported elements
+     * \return Return fields converted to text
+     */
+    virtual std::string get_text() const { return ""; }
 
-   /**
-    * \brief Add extension at the end of linked list.
-    * \param [in] ext Extension to add.
-    */
-   void add_extension(RecordExt *ext)
-   {
-      RecordExt **tmp = &m_next;
-      while (*tmp) {
-         tmp = &(*tmp)->m_next;
-      }
-      *tmp = ext;
-   }
+    /**
+     * \brief Add extension at the end of linked list.
+     * \param [in] ext Extension to add.
+     */
+    void add_extension(RecordExt* ext)
+    {
+        RecordExt** tmp = &m_next;
+        while (*tmp) {
+            tmp = &(*tmp)->m_next;
+        }
+        *tmp = ext;
+    }
 
-   /**
-    * \brief Virtual destructor.
-    */
-   virtual ~RecordExt()
-   {
-      if (m_next != nullptr) {
-         delete m_next;
-      }
-   }
+    /**
+     * \brief Virtual destructor.
+     */
+    virtual ~RecordExt()
+    {
+        if (m_next != nullptr) {
+            delete m_next;
+        }
+    }
 };
 
 struct Record {
-   RecordExt *m_exts; /**< Extension headers. */
+    RecordExt* m_exts; /**< Extension headers. */
 
-   /**
-    * \brief Add new extension header.
-    * \param [in] ext Pointer to the extension header.
-    */
-   void add_extension(RecordExt* ext)
-   {
-      if (m_exts == nullptr) {
-         m_exts = ext;
-      } else {
-         RecordExt *ext_ptr = m_exts;
-         while (ext_ptr->m_next != nullptr) {
-            ext_ptr = ext_ptr->m_next;
-         }
-         ext_ptr->m_next = ext;
-      }
-   }
+    /**
+     * \brief Add new extension header.
+     * \param [in] ext Pointer to the extension header.
+     */
+    void add_extension(RecordExt* ext)
+    {
+        if (m_exts == nullptr) {
+            m_exts = ext;
+        } else {
+            RecordExt* ext_ptr = m_exts;
+            while (ext_ptr->m_next != nullptr) {
+                ext_ptr = ext_ptr->m_next;
+            }
+            ext_ptr->m_next = ext;
+        }
+    }
 
-   /**
-    * \brief Get given extension.
-    * \param [in] id Type of extension.
-    * \return Pointer to the requested extension or nullptr if extension is not present.
-    */
-   RecordExt *get_extension(int id) const
-   {
-      RecordExt *ext = m_exts;
-      while (ext != nullptr) {
-         if (ext->m_ext_id == id) {
-            return ext;
-         }
-         ext = ext->m_next;
-      }
-      return nullptr;
-   }
+    /**
+     * \brief Get given extension.
+     * \param [in] id Type of extension.
+     * \return Pointer to the requested extension or nullptr if extension is not present.
+     */
+    RecordExt* get_extension(int id) const
+    {
+        RecordExt* ext = m_exts;
+        while (ext != nullptr) {
+            if (ext->m_ext_id == id) {
+                return ext;
+            }
+            ext = ext->m_next;
+        }
+        return nullptr;
+    }
     /**
      * \brief Remove given extension.
      * \param [in] id Type of extension.
@@ -187,88 +176,86 @@ struct Record {
      */
     bool remove_extension(int id)
     {
-       RecordExt *ext      = m_exts;
-       RecordExt *prev_ext = nullptr;
+        RecordExt* ext = m_exts;
+        RecordExt* prev_ext = nullptr;
 
-       while (ext != nullptr) {
-          if (ext->m_ext_id == id) {
-             if (prev_ext == nullptr) { // at beginning
-                m_exts = ext->m_next;
-             } else if (ext->m_next == nullptr) { // at end
-                prev_ext->m_next = nullptr;
-             } else { // in middle
-                prev_ext->m_next = ext->m_next;
-             }
-             ext->m_next = nullptr;
-             delete ext;
-             return true;
-          }
-          prev_ext = ext;
-          ext      = ext->m_next;
-       }
-       return false;
+        while (ext != nullptr) {
+            if (ext->m_ext_id == id) {
+                if (prev_ext == nullptr) { // at beginning
+                    m_exts = ext->m_next;
+                } else if (ext->m_next == nullptr) { // at end
+                    prev_ext->m_next = nullptr;
+                } else { // in middle
+                    prev_ext->m_next = ext->m_next;
+                }
+                ext->m_next = nullptr;
+                delete ext;
+                return true;
+            }
+            prev_ext = ext;
+            ext = ext->m_next;
+        }
+        return false;
     }
 
-   /**
-    * \brief Remove extension headers.
-    */
-   void remove_extensions()
-   {
-      if (m_exts != nullptr) {
-         delete m_exts;
-         m_exts = nullptr;
-      }
-   }
+    /**
+     * \brief Remove extension headers.
+     */
+    void remove_extensions()
+    {
+        if (m_exts != nullptr) {
+            delete m_exts;
+            m_exts = nullptr;
+        }
+    }
 
-   /**
-    * \brief Constructor.
-    */
-   Record() : m_exts(nullptr)
-   {
-   }
+    /**
+     * \brief Constructor.
+     */
+    Record()
+        : m_exts(nullptr)
+    {
+    }
 
-   /**
-    * \brief Destructor.
-    */
-   virtual ~Record()
-   {
-      remove_extensions();
-   }
+    /**
+     * \brief Destructor.
+     */
+    virtual ~Record() { remove_extensions(); }
 };
 
 #define FLOW_END_INACTIVE 0x01
-#define FLOW_END_ACTIVE   0x02
-#define FLOW_END_EOF      0x03
-#define FLOW_END_FORCED   0x04
-#define FLOW_END_NO_RES   0x05
+#define FLOW_END_ACTIVE 0x02
+#define FLOW_END_EOF 0x03
+#define FLOW_END_FORCED 0x04
+#define FLOW_END_NO_RES 0x05
 
 /**
  * \brief Flow record struct constaining basic flow record data and extension headers.
  */
 struct Flow : public Record {
-   uint64_t flow_hash;
+    uint64_t flow_hash;
 
-   struct timeval time_first;
-   struct timeval time_last;
-   uint64_t src_bytes;
-   uint64_t dst_bytes;
-   uint32_t src_packets;
-   uint32_t dst_packets;
-   uint8_t  src_tcp_flags;
-   uint8_t  dst_tcp_flags;
+    struct timeval time_first;
+    struct timeval time_last;
+    uint64_t src_bytes;
+    uint64_t dst_bytes;
+    uint32_t src_packets;
+    uint32_t dst_packets;
+    uint8_t src_tcp_flags;
+    uint8_t dst_tcp_flags;
 
-   uint8_t  ip_version;
+    uint8_t ip_version;
 
-   uint8_t  ip_proto;
-   uint16_t src_port;
-   uint16_t dst_port;
-   ipaddr_t src_ip;
-   ipaddr_t dst_ip;
+    uint8_t ip_proto;
+    uint16_t src_port;
+    uint16_t dst_port;
+    ipaddr_t src_ip;
+    ipaddr_t dst_ip;
 
-   uint8_t src_mac[6];
-   uint8_t dst_mac[6];
-   uint8_t end_reason;
+    uint8_t src_mac[6];
+    uint8_t dst_mac[6];
+    uint8_t end_reason;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_FLOWIFC_HPP */

--- a/include/ipfixprobe/input.hpp
+++ b/include/ipfixprobe/input.hpp
@@ -32,34 +32,32 @@
 
 #include <string>
 
-#include "plugin.hpp"
 #include "packet.hpp"
+#include "plugin.hpp"
 
 namespace ipxp {
 
 /**
  * \brief Base class for packet receivers.
  */
-class InputPlugin : public Plugin
-{
+class InputPlugin : public Plugin {
 public:
-   enum class Result {
-      TIMEOUT = 0,
-      PARSED,
-      NOT_PARSED,
-      END_OF_FILE,
-      ERROR
-   };
+    enum class Result { TIMEOUT = 0, PARSED, NOT_PARSED, END_OF_FILE, ERROR };
 
-   uint64_t m_seen;
-   uint64_t m_parsed;
-   uint64_t m_dropped;
+    uint64_t m_seen;
+    uint64_t m_parsed;
+    uint64_t m_dropped;
 
-   InputPlugin() : m_seen(0), m_parsed(0), m_dropped(0) {}
-   virtual ~InputPlugin() {}
+    InputPlugin()
+        : m_seen(0)
+        , m_parsed(0)
+        , m_dropped(0)
+    {
+    }
+    virtual ~InputPlugin() {}
 
-   virtual Result get(PacketBlock &packets) = 0;
+    virtual Result get(PacketBlock& packets) = 0;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_TEMPLATE_HPP */

--- a/include/ipfixprobe/ipaddr.hpp
+++ b/include/ipfixprobe/ipaddr.hpp
@@ -31,18 +31,15 @@
 
 namespace ipxp {
 
-enum IP : uint8_t {
-   v4 = 4,
-   v6 = 6
-};
+enum IP : uint8_t { v4 = 4, v6 = 6 };
 
 /**
  * \brief Store IPv4 or IPv6 address.
  */
 typedef union ipaddr_u {
-   uint8_t  v6[16];  /**< IPv6 address. */
-   uint32_t v4;      /**< IPv4 address  */
+    uint8_t v6[16]; /**< IPv6 address. */
+    uint32_t v4; /**< IPv4 address  */
 } ipaddr_t;
 
-}
+} // namespace ipxp
 #endif /* IPXP_IPADDR_HPP */

--- a/include/ipfixprobe/ipfix-basiclist.hpp
+++ b/include/ipfixprobe/ipfix-basiclist.hpp
@@ -30,40 +30,40 @@
 #define IPFIXBASICLIST
 
 #include <arpa/inet.h>
-#include <sys/time.h>
 #include <cstring>
 #include <ipfixprobe/byte-utils.hpp>
+#include <sys/time.h>
 
 namespace ipxp {
 
 struct IpfixBasicList {
 public:
-   static const uint8_t IpfixBasicListRecordHdrSize = 12;
-   static const uint8_t IpfixBasicListHdrSize       = 9;
-   static const uint8_t flag        = 255; // Maximum size see rfc631;
-   static const uint8_t hdrSemantic = 3;
+    static const uint8_t IpfixBasicListRecordHdrSize = 12;
+    static const uint8_t IpfixBasicListHdrSize = 9;
+    static const uint8_t flag = 255; // Maximum size see rfc631;
+    static const uint8_t hdrSemantic = 3;
 
-   enum ePEMNumber {
-      CesnetPEM = 8057,
-   };
+    enum ePEMNumber {
+        CesnetPEM = 8057,
+    };
 
-   ePEMNumber hdrEnterpriseNum;
+    ePEMNumber hdrEnterpriseNum;
 
+    static uint64_t Tv2Ts(timeval input);
 
-   static uint64_t Tv2Ts(timeval input);
-
-   int32_t HeaderSize();
-   int32_t FillBuffer(uint8_t *buffer, uint16_t *values, uint16_t len, uint16_t fieldID);
-   int32_t FillBuffer(uint8_t *buffer, int16_t *values, uint16_t len, uint16_t fieldID);
-   int32_t FillBuffer(uint8_t *buffer, uint32_t *values, uint16_t len, uint16_t fieldID);
-   int32_t FillBuffer(uint8_t *buffer, int32_t *values, uint16_t len, uint16_t fieldID);
-   int32_t FillBuffer(uint8_t *buffer, struct timeval *values, uint16_t len, uint16_t fieldID);
-   int32_t FillBuffer(uint8_t *buffer, uint8_t *values, uint16_t len, uint16_t fieldID);
-   int32_t FillBuffer(uint8_t *buffer, int8_t *values, uint16_t len, uint16_t fieldID);
+    int32_t HeaderSize();
+    int32_t FillBuffer(uint8_t* buffer, uint16_t* values, uint16_t len, uint16_t fieldID);
+    int32_t FillBuffer(uint8_t* buffer, int16_t* values, uint16_t len, uint16_t fieldID);
+    int32_t FillBuffer(uint8_t* buffer, uint32_t* values, uint16_t len, uint16_t fieldID);
+    int32_t FillBuffer(uint8_t* buffer, int32_t* values, uint16_t len, uint16_t fieldID);
+    int32_t FillBuffer(uint8_t* buffer, struct timeval* values, uint16_t len, uint16_t fieldID);
+    int32_t FillBuffer(uint8_t* buffer, uint8_t* values, uint16_t len, uint16_t fieldID);
+    int32_t FillBuffer(uint8_t* buffer, int8_t* values, uint16_t len, uint16_t fieldID);
 
 private:
-   int32_t FillBufferHdr(uint8_t *buffer, uint16_t length, uint16_t elementLength, uint16_t fieldID);
+    int32_t
+    FillBufferHdr(uint8_t* buffer, uint16_t length, uint16_t elementLength, uint16_t fieldID);
 };
 
-}
+} // namespace ipxp
 #endif // ifndef IPFIXBASICLIST

--- a/include/ipfixprobe/ipfix-elements.hpp
+++ b/include/ipfixprobe/ipfix-elements.hpp
@@ -43,7 +43,6 @@ namespace ipxp {
  *   4. Source memory pointer (to copy value from)
  */
 
-
 /**
  * Difference between NTP and UNIX epoch in number of seconds.
  */
@@ -51,14 +50,16 @@ namespace ipxp {
 
 /**
  * Conversion from microseconds to NTP fraction (resolution 1/(2^32)s,  ~233 picoseconds).
- * Division by 1000000 would lead to wrong value when converting fraction back to microseconds, so 999999 is used.
+ * Division by 1000000 would lead to wrong value when converting fraction back to microseconds, so
+ * 999999 is used.
  */
 #define NTP_USEC_TO_FRAC(usec) (uint32_t)(((uint64_t) usec << 32) / 999999)
 
 /**
  * Create 64 bit NTP timestamp which consist of 32 bit seconds part and 32 bit fraction part.
  */
-#define MK_NTP_TS(ts) (((uint64_t) (ts.tv_sec + EPOCH_DIFF) << 32) | (uint64_t) NTP_USEC_TO_FRAC(ts.tv_usec))
+#define MK_NTP_TS(ts)                                                                              \
+    (((uint64_t) (ts.tv_sec + EPOCH_DIFF) << 32) | (uint64_t) NTP_USEC_TO_FRAC(ts.tv_usec))
 
 /**
  * Convert FIELD to its "attributes", i.e. BYTES(FIELD) used in the source code produces
@@ -68,217 +69,225 @@ namespace ipxp {
 #define FIELD(EN, ID, LEN, SRC) EN, ID, LEN, SRC
 
 /* The list of known IPFIX elements: */
-#define BYTES(F)                      F(0,        1,    8,   &flow.src_bytes)
-#define BYTES_REV(F)                  F(29305,    1,    8,   &flow.dst_bytes)
-#define PACKETS(F)                    F(0,        2,    8,   (temp = (uint64_t) flow.src_packets, &temp))
-#define PACKETS_REV(F)                F(29305,    2,    8,   (temp = (uint64_t) flow.dst_packets, &temp))
-#define FLOW_START_MSEC(F)            F(0,      152,    8,   (temp = ((uint64_t) flow.time_first.tv_sec) * 1000 + (flow.time_first.tv_usec / 1000), &temp))
-#define FLOW_END_MSEC(F)              F(0,      153,    8,   (temp = ((uint64_t) flow.time_last.tv_sec) * 1000 + (flow.time_last.tv_usec / 1000), &temp))
-#define FLOW_START_USEC(F)            F(0,      154,    8,   (temp = MK_NTP_TS(flow.time_first), &temp))
-#define FLOW_END_USEC(F)              F(0,      155,    8,   (temp = MK_NTP_TS(flow.time_last), &temp))
-#define OBSERVATION_MSEC(F)           F(0,      323,    8,   nullptr)
-#define INPUT_INTERFACE(F)            F(0,       10,    4,   &this->dir_bit_field)
-#define OUTPUT_INTERFACE(F)           F(0,       14,    2,   nullptr)
-#define FLOW_END_REASON(F)            F(0,      136,    1,   &flow.end_reason)
-#define FLOW_ID(F)                    F(0,      148,    8,   &flow.flow_hash)
+#define BYTES(F) F(0, 1, 8, &flow.src_bytes)
+#define BYTES_REV(F) F(29305, 1, 8, &flow.dst_bytes)
+#define PACKETS(F) F(0, 2, 8, (temp = (uint64_t) flow.src_packets, &temp))
+#define PACKETS_REV(F) F(29305, 2, 8, (temp = (uint64_t) flow.dst_packets, &temp))
+#define FLOW_START_MSEC(F)                                                                         \
+    F(0,                                                                                           \
+      152,                                                                                         \
+      8,                                                                                           \
+      (temp = ((uint64_t) flow.time_first.tv_sec) * 1000 + (flow.time_first.tv_usec / 1000),       \
+       &temp))
+#define FLOW_END_MSEC(F)                                                                           \
+    F(0,                                                                                           \
+      153,                                                                                         \
+      8,                                                                                           \
+      (temp = ((uint64_t) flow.time_last.tv_sec) * 1000 + (flow.time_last.tv_usec / 1000), &temp))
+#define FLOW_START_USEC(F) F(0, 154, 8, (temp = MK_NTP_TS(flow.time_first), &temp))
+#define FLOW_END_USEC(F) F(0, 155, 8, (temp = MK_NTP_TS(flow.time_last), &temp))
+#define OBSERVATION_MSEC(F) F(0, 323, 8, nullptr)
+#define INPUT_INTERFACE(F) F(0, 10, 4, &this->dir_bit_field)
+#define OUTPUT_INTERFACE(F) F(0, 14, 2, nullptr)
+#define FLOW_END_REASON(F) F(0, 136, 1, &flow.end_reason)
+#define FLOW_ID(F) F(0, 148, 8, &flow.flow_hash)
 
-#define ETHERTYPE(F)                  F(0,      256,    2,   nullptr)
+#define ETHERTYPE(F) F(0, 256, 2, nullptr)
 
-#define VLAN_ID(F)                    F(0,       58,    2,   nullptr)
+#define VLAN_ID(F) F(0, 58, 2, nullptr)
 
-#define L2_SRC_MAC(F)                 F(0,       56,    6,   flow.src_mac)
-#define L2_DST_MAC(F)                 F(0,       80,    6,   flow.dst_mac)
+#define L2_SRC_MAC(F) F(0, 56, 6, flow.src_mac)
+#define L2_DST_MAC(F) F(0, 80, 6, flow.dst_mac)
 
-#define L3_PROTO(F)                   F(0,       60,    1,   &flow.ip_version)
-#define L3_IPV4_ADDR_SRC(F)           F(0,        8,    4,   &flow.src_ip.v4)
-#define L3_IPV4_ADDR_DST(F)           F(0,       12,    4,   &flow.dst_ip.v4)
-#define L3_IPV4_TOS(F)                F(0,        5,    1,   nullptr)
-#define L3_IPV6_ADDR_SRC(F)           F(0,       27,   16,   &flow.src_ip.v6)
-#define L3_IPV6_ADDR_DST(F)           F(0,       28,   16,   &flow.dst_ip.v6)
-#define L3_IPV4_IDENTIFICATION(F)     F(0,       54,    2,   nullptr)
-#define L3_IPV4_FRAGMENT(F)           F(0,       88,    2,   nullptr)
-#define L3_IPV4_TTL(F)                F(0,      192,    1,   nullptr)
-#define L3_IPV6_TTL(F)                F(0,      192,    1,   nullptr)
-#define L3_TTL(F)                     F(0,      192,    1,   nullptr)
-#define L3_TTL_REV(F)                 F(29305,  192,    1,   nullptr)
-#define L3_FLAGS(F)                   F(0,      197,    1,   nullptr)
-#define L3_FLAGS_REV(F)               F(29305,  197,    1,   nullptr)
+#define L3_PROTO(F) F(0, 60, 1, &flow.ip_version)
+#define L3_IPV4_ADDR_SRC(F) F(0, 8, 4, &flow.src_ip.v4)
+#define L3_IPV4_ADDR_DST(F) F(0, 12, 4, &flow.dst_ip.v4)
+#define L3_IPV4_TOS(F) F(0, 5, 1, nullptr)
+#define L3_IPV6_ADDR_SRC(F) F(0, 27, 16, &flow.src_ip.v6)
+#define L3_IPV6_ADDR_DST(F) F(0, 28, 16, &flow.dst_ip.v6)
+#define L3_IPV4_IDENTIFICATION(F) F(0, 54, 2, nullptr)
+#define L3_IPV4_FRAGMENT(F) F(0, 88, 2, nullptr)
+#define L3_IPV4_TTL(F) F(0, 192, 1, nullptr)
+#define L3_IPV6_TTL(F) F(0, 192, 1, nullptr)
+#define L3_TTL(F) F(0, 192, 1, nullptr)
+#define L3_TTL_REV(F) F(29305, 192, 1, nullptr)
+#define L3_FLAGS(F) F(0, 197, 1, nullptr)
+#define L3_FLAGS_REV(F) F(29305, 197, 1, nullptr)
 
-#define L4_PROTO(F)                   F(0,        4,    1,   &flow.ip_proto)
-#define L4_TCP_FLAGS(F)               F(0,        6,    1,   &flow.src_tcp_flags)
-#define L4_TCP_FLAGS_REV(F)           F(29305,    6,    1,   &flow.dst_tcp_flags)
-#define L4_PORT_SRC(F)                F(0,        7,    2,   &flow.src_port)
-#define L4_PORT_DST(F)                F(0,       11,    2,   &flow.dst_port)
-#define L4_ICMP_TYPE_CODE(F)          F(0,       32,    2,   nullptr)
-#define L4_TCP_WIN(F)                 F(0,       186,   2,   nullptr)
-#define L4_TCP_WIN_REV(F)             F(29305,   186,   2,   nullptr)
-#define L4_TCP_OPTIONS(F)             F(0,       209,   8,   nullptr)
-#define L4_TCP_OPTIONS_REV(F)         F(29305,   209,   8,   nullptr)
+#define L4_PROTO(F) F(0, 4, 1, &flow.ip_proto)
+#define L4_TCP_FLAGS(F) F(0, 6, 1, &flow.src_tcp_flags)
+#define L4_TCP_FLAGS_REV(F) F(29305, 6, 1, &flow.dst_tcp_flags)
+#define L4_PORT_SRC(F) F(0, 7, 2, &flow.src_port)
+#define L4_PORT_DST(F) F(0, 11, 2, &flow.dst_port)
+#define L4_ICMP_TYPE_CODE(F) F(0, 32, 2, nullptr)
+#define L4_TCP_WIN(F) F(0, 186, 2, nullptr)
+#define L4_TCP_WIN_REV(F) F(29305, 186, 2, nullptr)
+#define L4_TCP_OPTIONS(F) F(0, 209, 8, nullptr)
+#define L4_TCP_OPTIONS_REV(F) F(29305, 209, 8, nullptr)
 
+#define L4_TCP_MSS(F) F(8057, 900, 4, nullptr)
+#define L4_TCP_MSS_REV(F) F(8057, 901, 4, nullptr)
+#define L4_TCP_SYN_SIZE(F) F(8057, 902, 2, nullptr)
 
-#define L4_TCP_MSS(F)                 F(8057,   900,   4,   nullptr)
-#define L4_TCP_MSS_REV(F)             F(8057,   901,   4,   nullptr)
-#define L4_TCP_SYN_SIZE(F)            F(8057,   902,   2,   nullptr)
+#define HTTP_DOMAIN(F) F(39499, 1, -1, nullptr)
+#define HTTP_REFERER(F) F(39499, 3, -1, nullptr)
+#define HTTP_URI(F) F(39499, 2, -1, nullptr)
+#define HTTP_CONTENT_TYPE(F) F(39499, 10, -1, nullptr)
+#define HTTP_STATUS(F) F(39499, 12, 2, nullptr)
+#define HTTP_USERAGENT(F) F(39499, 20, -1, nullptr)
+#define HTTP_METHOD(F) F(8057, 200, -1, nullptr)
+#define HTTP_SERVER(F) F(8057, 201, -1, nullptr)
+#define HTTP_SET_COOKIE_NAMES(F) F(8057, 202, -1, nullptr)
 
-#define HTTP_DOMAIN(F)                F(39499,    1,   -1,   nullptr)
-#define HTTP_REFERER(F)               F(39499,    3,   -1,   nullptr)
-#define HTTP_URI(F)                   F(39499,    2,   -1,   nullptr)
-#define HTTP_CONTENT_TYPE(F)          F(39499,   10,   -1,   nullptr)
-#define HTTP_STATUS(F)                F(39499,   12,    2,   nullptr)
-#define HTTP_USERAGENT(F)             F(39499,   20,   -1,   nullptr)
-#define HTTP_METHOD(F)                F(8057,   200,   -1,   nullptr)
-#define HTTP_SERVER(F)                F(8057,   201,   -1,   nullptr)
-#define HTTP_SET_COOKIE_NAMES(F)      F(8057,   202,   -1,   nullptr)
+#define RTSP_METHOD(F) F(16982, 600, -1, nullptr)
+#define RTSP_USERAGENT(F) F(16982, 601, -1, nullptr)
+#define RTSP_URI(F) F(16982, 602, -1, nullptr)
+#define RTSP_STATUS(F) F(16982, 603, 2, nullptr)
+#define RTSP_CONTENT_TYPE(F) F(16982, 604, -1, nullptr)
+#define RTSP_SERVER(F) F(16982, 605, -1, nullptr)
 
-#define RTSP_METHOD(F)                F(16982,  600,   -1,   nullptr)
-#define RTSP_USERAGENT(F)             F(16982,  601,   -1,   nullptr)
-#define RTSP_URI(F)                   F(16982,  602,   -1,   nullptr)
-#define RTSP_STATUS(F)                F(16982,  603,    2,   nullptr)
-#define RTSP_CONTENT_TYPE(F)          F(16982,  604,   -1,   nullptr)
-#define RTSP_SERVER(F)                F(16982,  605,   -1,   nullptr)
+#define DNS_RCODE(F) F(8057, 1, 1, nullptr)
+#define DNS_NAME(F) F(8057, 2, -1, nullptr)
+#define DNS_QTYPE(F) F(8057, 3, 2, nullptr)
+#define DNS_CLASS(F) F(8057, 4, 2, nullptr)
+#define DNS_RR_TTL(F) F(8057, 5, 4, nullptr)
+#define DNS_RLENGTH(F) F(8057, 6, 2, nullptr)
+#define DNS_RDATA(F) F(8057, 7, -1, nullptr)
+#define DNS_PSIZE(F) F(8057, 8, 2, nullptr)
+#define DNS_DO(F) F(8057, 9, 1, nullptr)
+#define DNS_ID(F) F(8057, 10, 2, nullptr)
+#define DNS_ATYPE(F) F(8057, 11, 2, nullptr)
+#define DNS_ANSWERS(F) F(8057, 14, 2, nullptr)
 
-#define DNS_RCODE(F)                  F(8057,     1,    1,   nullptr)
-#define DNS_NAME(F)                   F(8057,     2,   -1,   nullptr)
-#define DNS_QTYPE(F)                  F(8057,     3,    2,   nullptr)
-#define DNS_CLASS(F)                  F(8057,     4,    2,   nullptr)
-#define DNS_RR_TTL(F)                 F(8057,     5,    4,   nullptr)
-#define DNS_RLENGTH(F)                F(8057,     6,    2,   nullptr)
-#define DNS_RDATA(F)                  F(8057,     7,   -1,   nullptr)
-#define DNS_PSIZE(F)                  F(8057,     8,    2,   nullptr)
-#define DNS_DO(F)                     F(8057,     9,    1,   nullptr)
-#define DNS_ID(F)                     F(8057,    10,    2,   nullptr)
-#define DNS_ATYPE(F)                  F(8057,    11,    2,   nullptr)
-#define DNS_ANSWERS(F)                F(8057,    14,    2,   nullptr)
+#define SIP_MSG_TYPE(F) F(8057, 100, 2, nullptr)
+#define SIP_STATUS_CODE(F) F(8057, 101, 2, nullptr)
+#define SIP_CALL_ID(F) F(8057, 102, -1, nullptr)
+#define SIP_CALLING_PARTY(F) F(8057, 103, -1, nullptr)
+#define SIP_CALLED_PARTY(F) F(8057, 104, -1, nullptr)
+#define SIP_VIA(F) F(8057, 105, -1, nullptr)
+#define SIP_USER_AGENT(F) F(8057, 106, -1, nullptr)
+#define SIP_REQUEST_URI(F) F(8057, 107, -1, nullptr)
+#define SIP_CSEQ(F) F(8057, 108, -1, nullptr)
 
-#define SIP_MSG_TYPE(F)               F(8057,   100,    2,   nullptr)
-#define SIP_STATUS_CODE(F)            F(8057,   101,    2,   nullptr)
-#define SIP_CALL_ID(F)                F(8057,   102,   -1,   nullptr)
-#define SIP_CALLING_PARTY(F)          F(8057,   103,   -1,   nullptr)
-#define SIP_CALLED_PARTY(F)           F(8057,   104,   -1,   nullptr)
-#define SIP_VIA(F)                    F(8057,   105,   -1,   nullptr)
-#define SIP_USER_AGENT(F)             F(8057,   106,   -1,   nullptr)
-#define SIP_REQUEST_URI(F)            F(8057,   107,   -1,   nullptr)
-#define SIP_CSEQ(F)                   F(8057,   108,   -1,   nullptr)
+#define NTP_LEAP(F) F(8057, 18, 1, nullptr)
+#define NTP_VERSION(F) F(8057, 19, 1, nullptr)
+#define NTP_MODE(F) F(8057, 20, 1, nullptr)
+#define NTP_STRATUM(F) F(8057, 21, 1, nullptr)
+#define NTP_POLL(F) F(8057, 22, 1, nullptr)
+#define NTP_PRECISION(F) F(8057, 23, 1, nullptr)
+#define NTP_DELAY(F) F(8057, 24, 4, nullptr)
+#define NTP_DISPERSION(F) F(8057, 25, 4, nullptr)
+#define NTP_REF_ID(F) F(8057, 26, -1, nullptr)
+#define NTP_REF(F) F(8057, 27, -1, nullptr)
+#define NTP_ORIG(F) F(8057, 28, -1, nullptr)
+#define NTP_RECV(F) F(8057, 29, -1, nullptr)
+#define NTP_SENT(F) F(8057, 30, -1, nullptr)
 
-#define NTP_LEAP(F)                   F(8057,    18,    1,   nullptr)
-#define NTP_VERSION(F)                F(8057,    19,    1,   nullptr)
-#define NTP_MODE(F)                   F(8057,    20,    1,   nullptr)
-#define NTP_STRATUM(F)                F(8057,    21,    1,   nullptr)
-#define NTP_POLL(F)                   F(8057,    22,    1,   nullptr)
-#define NTP_PRECISION(F)              F(8057,    23,    1,   nullptr)
-#define NTP_DELAY(F)                  F(8057,    24,    4,   nullptr)
-#define NTP_DISPERSION(F)             F(8057,    25,    4,   nullptr)
-#define NTP_REF_ID(F)                 F(8057,    26,   -1,   nullptr)
-#define NTP_REF(F)                    F(8057,    27,   -1,   nullptr)
-#define NTP_ORIG(F)                   F(8057,    28,   -1,   nullptr)
-#define NTP_RECV(F)                   F(8057,    29,   -1,   nullptr)
-#define NTP_SENT(F)                   F(8057,    30,   -1,   nullptr)
+#define ARP_HA_FORMAT(F) F(8057, 31, 2, nullptr)
+#define ARP_PA_FORMAT(F) F(8057, 32, 2, nullptr)
+#define ARP_OPCODE(F) F(8057, 33, 2, nullptr)
+#define ARP_SRC_HA(F) F(8057, 34, -1, nullptr)
+#define ARP_SRC_PA(F) F(8057, 35, -1, nullptr)
+#define ARP_DST_HA(F) F(8057, 36, -1, nullptr)
+#define ARP_DST_PA(F) F(8057, 37, -1, nullptr)
 
-#define ARP_HA_FORMAT(F)              F(8057,    31,    2,   nullptr)
-#define ARP_PA_FORMAT(F)              F(8057,    32,    2,   nullptr)
-#define ARP_OPCODE(F)                 F(8057,    33,    2,   nullptr)
-#define ARP_SRC_HA(F)                 F(8057,    34,   -1,   nullptr)
-#define ARP_SRC_PA(F)                 F(8057,    35,   -1,   nullptr)
-#define ARP_DST_HA(F)                 F(8057,    36,   -1,   nullptr)
-#define ARP_DST_PA(F)                 F(8057,    37,   -1,   nullptr)
+#define TLS_SNI(F) F(8057, 808, -1, nullptr)
+#define TLS_VERSION(F) F(39499, 333, 2, nullptr)
+#define TLS_ALPN(F) F(39499, 337, -1, nullptr)
+#define TLS_JA3(F) F(39499, 357, -1, nullptr)
 
-#define TLS_SNI(F)                    F(8057,   808,   -1,   nullptr)
-#define TLS_VERSION(F)                F(39499,  333,    2,   nullptr)
-#define TLS_ALPN(F)                   F(39499,  337,   -1,   nullptr)
-#define TLS_JA3(F)                    F(39499,  357,   -1,   nullptr)
+#define SMTP_COMMANDS(F) F(8057, 810, 4, nullptr)
+#define SMTP_MAIL_COUNT(F) F(8057, 811, 4, nullptr)
+#define SMTP_RCPT_COUNT(F) F(8057, 812, 4, nullptr)
+#define SMTP_SENDER(F) F(8057, 813, -1, nullptr)
+#define SMTP_RECIPIENT(F) F(8057, 814, -1, nullptr)
+#define SMTP_STATUS_CODES(F) F(8057, 815, 4, nullptr)
+#define SMTP_CODE_2XX_COUNT(F) F(8057, 816, 4, nullptr)
+#define SMTP_CODE_3XX_COUNT(F) F(8057, 817, 4, nullptr)
+#define SMTP_CODE_4XX_COUNT(F) F(8057, 818, 4, nullptr)
+#define SMTP_CODE_5XX_COUNT(F) F(8057, 819, 4, nullptr)
+#define SMTP_DOMAIN(F) F(8057, 820, -1, nullptr)
 
-#define SMTP_COMMANDS(F)              F(8057,    810,   4,   nullptr)
-#define SMTP_MAIL_COUNT(F)            F(8057,    811,   4,   nullptr)
-#define SMTP_RCPT_COUNT(F)            F(8057,    812,   4,   nullptr)
-#define SMTP_SENDER(F)                F(8057,    813,  -1,   nullptr)
-#define SMTP_RECIPIENT(F)             F(8057,    814,  -1,   nullptr)
-#define SMTP_STATUS_CODES(F)          F(8057,    815,   4,   nullptr)
-#define SMTP_CODE_2XX_COUNT(F)        F(8057,    816,   4,   nullptr)
-#define SMTP_CODE_3XX_COUNT(F)        F(8057,    817,   4,   nullptr)
-#define SMTP_CODE_4XX_COUNT(F)        F(8057,    818,   4,   nullptr)
-#define SMTP_CODE_5XX_COUNT(F)        F(8057,    819,   4,   nullptr)
-#define SMTP_DOMAIN(F)                F(8057,    820,  -1,   nullptr)
+#define SSDP_LOCATION_PORT(F) F(8057, 821, 2, nullptr)
+#define SSDP_SERVER(F) F(8057, 822, -1, nullptr)
+#define SSDP_USER_AGENT(F) F(8057, 823, -1, nullptr)
+#define SSDP_NT(F) F(8057, 824, -1, nullptr)
+#define SSDP_ST(F) F(8057, 825, -1, nullptr)
 
-#define SSDP_LOCATION_PORT(F)         F(8057,    821,   2,   nullptr)
-#define SSDP_SERVER(F)                F(8057,    822,  -1,   nullptr)
-#define SSDP_USER_AGENT(F)            F(8057,    823,  -1,   nullptr)
-#define SSDP_NT(F)                    F(8057,    824,  -1,   nullptr)
-#define SSDP_ST(F)                    F(8057,    825,  -1,   nullptr)
+#define DNSSD_QUERIES(F) F(8057, 826, -1, nullptr)
+#define DNSSD_RESPONSES(F) F(8057, 827, -1, nullptr)
 
-#define DNSSD_QUERIES(F)              F(8057,    826,  -1,   nullptr)
-#define DNSSD_RESPONSES(F)            F(8057,    827,  -1,   nullptr)
+#define OVPN_CONF_LEVEL(F) F(8057, 828, 1, nullptr)
+#define SSA_CONF_LEVEL(F) F(8057, 903, 1, nullptr)
 
-#define OVPN_CONF_LEVEL(F)            F(8057,    828,   1,   nullptr)
-#define SSA_CONF_LEVEL(F)             F(8057,    903,   1,   nullptr)
+#define NB_NAME(F) F(8057, 831, -1, nullptr)
+#define NB_SUFFIX(F) F(8057, 832, 1, nullptr)
 
-#define NB_NAME(F)                    F(8057,    831,  -1,   nullptr)
-#define NB_SUFFIX(F)                  F(8057,    832,   1,   nullptr)
+#define IDP_CONTENT(F) F(8057, 850, -1, nullptr)
+#define IDP_CONTENT_REV(F) F(8057, 851, -1, nullptr)
 
+#define STATS_PCKT_SIZES(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1013 (uint16*)
+#define STATS_PCKT_TIMESTAMPS(F)                                                                   \
+    F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1014 (time*)
+#define STATS_PCKT_TCPFLGS(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1015 (uint8*)
+#define STATS_PCKT_DIRECTIONS(F)                                                                   \
+    F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1016 (int8*)
 
-#define IDP_CONTENT(F)                F(8057,   850,   -1,   nullptr)
-#define IDP_CONTENT_REV(F)            F(8057,   851,   -1,   nullptr)
+#define SBI_BRST_PACKETS(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1050 (uint16*)
+#define SBI_BRST_BYTES(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1051 (uint16*)
+#define SBI_BRST_TIME_START(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1052 (time*)
+#define SBI_BRST_TIME_STOP(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1053 (time*)
+#define DBI_BRST_PACKETS(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1054 (uint16*)
+#define DBI_BRST_BYTES(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1055 (uint16*)
+#define DBI_BRST_TIME_START(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1056 (time*)
+#define DBI_BRST_TIME_STOP(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1057 (time*)
 
-#define STATS_PCKT_SIZES(F)           F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1013 (uint16*)
-#define STATS_PCKT_TIMESTAMPS(F)      F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1014 (time*)
-#define STATS_PCKT_TCPFLGS(F)         F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1015 (uint8*)
-#define STATS_PCKT_DIRECTIONS(F)      F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1016 (int8*)
+#define D_PHISTS_IPT(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1063 (uint32*)
+#define D_PHISTS_SIZES(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1062 (uint32*)
+#define S_PHISTS_SIZES(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1060 (uint32*)
+#define S_PHISTS_IPT(F) F(0, 291, -1, nullptr) // BASIC LIST -- FIELD IS e8057id1061 (uint32*)
 
-#define SBI_BRST_PACKETS(F)           F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1050 (uint16*)
-#define SBI_BRST_BYTES(F)             F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1051 (uint16*)
-#define SBI_BRST_TIME_START(F)        F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1052 (time*)
-#define SBI_BRST_TIME_STOP(F)         F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1053 (time*)
-#define DBI_BRST_PACKETS(F)           F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1054 (uint16*)
-#define DBI_BRST_BYTES(F)             F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1055 (uint16*)
-#define DBI_BRST_TIME_START(F)        F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1056 (time*)
-#define DBI_BRST_TIME_STOP(F)         F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1057 (time*)
+#define QUIC_SNI(F) F(8057, 890, -1, nullptr)
+#define QUIC_USER_AGENT(F) F(8057, 891, -1, nullptr)
+#define QUIC_VERSION(F) F(8057, 892, 4, nullptr)
 
-#define D_PHISTS_IPT(F)               F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1063 (uint32*)
-#define D_PHISTS_SIZES(F)             F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1062 (uint32*)
-#define S_PHISTS_SIZES(F)             F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1060 (uint32*)
-#define S_PHISTS_IPT(F)               F(0,       291,  -1,   nullptr) // BASIC LIST -- FIELD IS e8057id1061 (uint32*)
-
-#define QUIC_SNI(F)                   F(8057,    890,  -1,   nullptr)
-#define QUIC_USER_AGENT(F)            F(8057,    891,  -1,   nullptr)
-#define QUIC_VERSION(F)               F(8057,    892,   4,   nullptr)
-
-#define OSQUERY_PROGRAM_NAME(F)       F(8057,    852,  -1,   nullptr)
-#define OSQUERY_USERNAME(F)           F(8057,    853,  -1,   nullptr)
-#define OSQUERY_OS_NAME(F)            F(8057,    854,  -1,   nullptr)
-#define OSQUERY_OS_MAJOR(F)           F(8057,    855,   2,   nullptr)
-#define OSQUERY_OS_MINOR(F)           F(8057,    856,   2,   nullptr)
-#define OSQUERY_OS_BUILD(F)           F(8057,    857,  -1,   nullptr)
-#define OSQUERY_OS_PLATFORM(F)        F(8057,    858,  -1,   nullptr)
-#define OSQUERY_OS_PLATFORM_LIKE(F)   F(8057,    859,  -1,   nullptr)
-#define OSQUERY_OS_ARCH(F)            F(8057,    860,  -1,   nullptr)
-#define OSQUERY_KERNEL_VERSION(F)     F(8057,    861,  -1,   nullptr)
-#define OSQUERY_SYSTEM_HOSTNAME(F)    F(8057,    862,  -1,   nullptr)
+#define OSQUERY_PROGRAM_NAME(F) F(8057, 852, -1, nullptr)
+#define OSQUERY_USERNAME(F) F(8057, 853, -1, nullptr)
+#define OSQUERY_OS_NAME(F) F(8057, 854, -1, nullptr)
+#define OSQUERY_OS_MAJOR(F) F(8057, 855, 2, nullptr)
+#define OSQUERY_OS_MINOR(F) F(8057, 856, 2, nullptr)
+#define OSQUERY_OS_BUILD(F) F(8057, 857, -1, nullptr)
+#define OSQUERY_OS_PLATFORM(F) F(8057, 858, -1, nullptr)
+#define OSQUERY_OS_PLATFORM_LIKE(F) F(8057, 859, -1, nullptr)
+#define OSQUERY_OS_ARCH(F) F(8057, 860, -1, nullptr)
+#define OSQUERY_KERNEL_VERSION(F) F(8057, 861, -1, nullptr)
+#define OSQUERY_SYSTEM_HOSTNAME(F) F(8057, 862, -1, nullptr)
 
 #ifdef WITH_FLEXPROBE
-#define FX_FRAME_SIGNATURE(F)         F(5715,   1010,  18,   nullptr)
-#define FX_INPUT_INTERFACE(F)         F(5715,   1015,   1,   nullptr)
-#define FX_TCP_TRACKING(F)            F(5715,   1020,   1,   nullptr)
+#define FX_FRAME_SIGNATURE(F) F(5715, 1010, 18, nullptr)
+#define FX_INPUT_INTERFACE(F) F(5715, 1015, 1, nullptr)
+#define FX_TCP_TRACKING(F) F(5715, 1020, 1, nullptr)
 #endif
 
-#define WG_CONF_LEVEL(F)              F(8057,    1100,   1,   nullptr)
-#define WG_SRC_PEER(F)                F(8057,    1101,   4,   nullptr)
-#define WG_DST_PEER(F)                F(8057,    1102,   4,   nullptr)
+#define WG_CONF_LEVEL(F) F(8057, 1100, 1, nullptr)
+#define WG_SRC_PEER(F) F(8057, 1101, 4, nullptr)
+#define WG_DST_PEER(F) F(8057, 1102, 4, nullptr)
 
-#define NTS_MEAN(F)                   F(8057,    1020,  4,    nullptr)
-#define NTS_MIN(F)                    F(8057,    1021,  2,    nullptr)
-#define NTS_MAX(F)                    F(8057,    1022,  2,    nullptr)
-#define NTS_STDEV(F)                  F(8057,    1023,  4,    nullptr)
-#define NTS_KURTOSIS(F)               F(8057,    1024,  4,    nullptr)
-#define NTS_ROOT_MEAN_SQUARE(F)       F(8057,    1025,  4,    nullptr)
-#define NTS_AVERAGE_DISPERSION(F)     F(8057,    1026,  4,    nullptr)
-#define NTS_MEAN_SCALED_TIME(F)       F(8057,    1027,  4,    nullptr)
-#define NTS_MEAN_DIFFTIMES(F)         F(8057,    1028,  4,    nullptr)
-#define NTS_MIN_DIFFTIMES(F)          F(8057,    1029,  4,    nullptr)
-#define NTS_MAX_DIFFTIMES(F)          F(8057,    1030,  4,    nullptr)
-#define NTS_TIME_DISTRIBUTION(F)      F(8057,    1031,  4,    nullptr)
-#define NTS_SWITCHING_RATIO(F)        F(8057,    1032,  4,    nullptr)
+#define NTS_MEAN(F) F(8057, 1020, 4, nullptr)
+#define NTS_MIN(F) F(8057, 1021, 2, nullptr)
+#define NTS_MAX(F) F(8057, 1022, 2, nullptr)
+#define NTS_STDEV(F) F(8057, 1023, 4, nullptr)
+#define NTS_KURTOSIS(F) F(8057, 1024, 4, nullptr)
+#define NTS_ROOT_MEAN_SQUARE(F) F(8057, 1025, 4, nullptr)
+#define NTS_AVERAGE_DISPERSION(F) F(8057, 1026, 4, nullptr)
+#define NTS_MEAN_SCALED_TIME(F) F(8057, 1027, 4, nullptr)
+#define NTS_MEAN_DIFFTIMES(F) F(8057, 1028, 4, nullptr)
+#define NTS_MIN_DIFFTIMES(F) F(8057, 1029, 4, nullptr)
+#define NTS_MAX_DIFFTIMES(F) F(8057, 1030, 4, nullptr)
+#define NTS_TIME_DISTRIBUTION(F) F(8057, 1031, 4, nullptr)
+#define NTS_SWITCHING_RATIO(F) F(8057, 1032, 4, nullptr)
 
-#define MPLS_TOP_LABEL_STACK_SECTION  F(0,         70,  -1,    nullptr)
-
+#define MPLS_TOP_LABEL_STACK_SECTION F(0, 70, -1, nullptr)
 
 /**
  * IPFIX Templates - list of elements
@@ -292,252 +301,244 @@ namespace ipxp {
  */
 
 #ifdef IPXP_TS_MSEC
-#define FLOW_START   FLOW_START_MSEC
-#define FLOW_END     FLOW_END_MSEC
+#define FLOW_START FLOW_START_MSEC
+#define FLOW_END FLOW_END_MSEC
 #else
-#define FLOW_START   FLOW_START_USEC
-#define FLOW_END     FLOW_END_USEC
+#define FLOW_START FLOW_START_USEC
+#define FLOW_END FLOW_END_USEC
 #endif
 
+#define BASIC_TMPLT_V4(F)                                                                          \
+    F(FLOW_END_REASON)                                                                             \
+    F(BYTES)                                                                                       \
+    F(BYTES_REV)                                                                                   \
+    F(PACKETS)                                                                                     \
+    F(PACKETS_REV)                                                                                 \
+    F(FLOW_START)                                                                                  \
+    F(FLOW_END)                                                                                    \
+    F(L3_PROTO)                                                                                    \
+    F(L4_PROTO)                                                                                    \
+    F(L4_TCP_FLAGS)                                                                                \
+    F(L4_TCP_FLAGS_REV)                                                                            \
+    F(L4_PORT_SRC)                                                                                 \
+    F(L4_PORT_DST)                                                                                 \
+    F(INPUT_INTERFACE)                                                                             \
+    F(L3_IPV4_ADDR_SRC)                                                                            \
+    F(L3_IPV4_ADDR_DST)                                                                            \
+    F(L2_SRC_MAC)                                                                                  \
+    F(L2_DST_MAC)
 
-#define BASIC_TMPLT_V4(F) \
-   F(FLOW_END_REASON) \
-   F(BYTES) \
-   F(BYTES_REV) \
-   F(PACKETS) \
-   F(PACKETS_REV) \
-   F(FLOW_START) \
-   F(FLOW_END) \
-   F(L3_PROTO) \
-   F(L4_PROTO) \
-   F(L4_TCP_FLAGS) \
-   F(L4_TCP_FLAGS_REV) \
-   F(L4_PORT_SRC) \
-   F(L4_PORT_DST) \
-   F(INPUT_INTERFACE) \
-   F(L3_IPV4_ADDR_SRC) \
-   F(L3_IPV4_ADDR_DST) \
-   F(L2_SRC_MAC) \
-   F(L2_DST_MAC)
+#define BASIC_TMPLT_V6(F)                                                                          \
+    F(FLOW_END_REASON)                                                                             \
+    F(BYTES)                                                                                       \
+    F(BYTES_REV)                                                                                   \
+    F(PACKETS)                                                                                     \
+    F(PACKETS_REV)                                                                                 \
+    F(FLOW_START)                                                                                  \
+    F(FLOW_END)                                                                                    \
+    F(L3_PROTO)                                                                                    \
+    F(L4_PROTO)                                                                                    \
+    F(L4_TCP_FLAGS)                                                                                \
+    F(L4_TCP_FLAGS_REV)                                                                            \
+    F(L4_PORT_SRC)                                                                                 \
+    F(L4_PORT_DST)                                                                                 \
+    F(INPUT_INTERFACE)                                                                             \
+    F(L3_IPV6_ADDR_SRC)                                                                            \
+    F(L3_IPV6_ADDR_DST)                                                                            \
+    F(L2_SRC_MAC)                                                                                  \
+    F(L2_DST_MAC)
 
-#define BASIC_TMPLT_V6(F) \
-   F(FLOW_END_REASON) \
-   F(BYTES) \
-   F(BYTES_REV) \
-   F(PACKETS) \
-   F(PACKETS_REV) \
-   F(FLOW_START) \
-   F(FLOW_END) \
-   F(L3_PROTO) \
-   F(L4_PROTO) \
-   F(L4_TCP_FLAGS) \
-   F(L4_TCP_FLAGS_REV) \
-   F(L4_PORT_SRC) \
-   F(L4_PORT_DST) \
-   F(INPUT_INTERFACE) \
-   F(L3_IPV6_ADDR_SRC) \
-   F(L3_IPV6_ADDR_DST) \
-   F(L2_SRC_MAC) \
-   F(L2_DST_MAC)
+#define IPFIX_HTTP_TEMPLATE(F)                                                                     \
+    F(HTTP_USERAGENT)                                                                              \
+    F(HTTP_METHOD)                                                                                 \
+    F(HTTP_DOMAIN)                                                                                 \
+    F(HTTP_REFERER)                                                                                \
+    F(HTTP_URI)                                                                                    \
+    F(HTTP_CONTENT_TYPE)                                                                           \
+    F(HTTP_SERVER)                                                                                 \
+    F(HTTP_SET_COOKIE_NAMES)                                                                       \
+    F(HTTP_STATUS)
 
-#define IPFIX_HTTP_TEMPLATE(F) \
-   F(HTTP_USERAGENT) \
-   F(HTTP_METHOD) \
-   F(HTTP_DOMAIN) \
-   F(HTTP_REFERER) \
-   F(HTTP_URI) \
-   F(HTTP_CONTENT_TYPE) \
-   F(HTTP_SERVER) \
-   F(HTTP_SET_COOKIE_NAMES) \
-   F(HTTP_STATUS)
+#define IPFIX_RTSP_TEMPLATE(F)                                                                     \
+    F(RTSP_METHOD)                                                                                 \
+    F(RTSP_USERAGENT)                                                                              \
+    F(RTSP_URI)                                                                                    \
+    F(RTSP_STATUS)                                                                                 \
+    F(RTSP_SERVER)                                                                                 \
+    F(RTSP_CONTENT_TYPE)
 
-#define IPFIX_RTSP_TEMPLATE(F) \
-   F(RTSP_METHOD) \
-   F(RTSP_USERAGENT) \
-   F(RTSP_URI) \
-   F(RTSP_STATUS)\
-   F(RTSP_SERVER) \
-   F(RTSP_CONTENT_TYPE)
+#define IPFIX_TLS_TEMPLATE(F)                                                                      \
+    F(TLS_VERSION)                                                                                 \
+    F(TLS_SNI)                                                                                     \
+    F(TLS_ALPN)                                                                                    \
+    F(TLS_JA3)
 
-#define IPFIX_TLS_TEMPLATE(F) \
-   F(TLS_VERSION) \
-   F(TLS_SNI) \
-   F(TLS_ALPN) \
-   F(TLS_JA3)
+#define IPFIX_NTP_TEMPLATE(F)                                                                      \
+    F(NTP_LEAP)                                                                                    \
+    F(NTP_VERSION)                                                                                 \
+    F(NTP_MODE)                                                                                    \
+    F(NTP_STRATUM)                                                                                 \
+    F(NTP_POLL)                                                                                    \
+    F(NTP_PRECISION)                                                                               \
+    F(NTP_DELAY)                                                                                   \
+    F(NTP_DISPERSION)                                                                              \
+    F(NTP_REF_ID)                                                                                  \
+    F(NTP_REF)                                                                                     \
+    F(NTP_ORIG)                                                                                    \
+    F(NTP_RECV)                                                                                    \
+    F(NTP_SENT)
 
-#define IPFIX_NTP_TEMPLATE(F) \
-   F(NTP_LEAP) \
-   F(NTP_VERSION) \
-   F(NTP_MODE) \
-   F(NTP_STRATUM) \
-   F(NTP_POLL) \
-   F(NTP_PRECISION) \
-   F(NTP_DELAY) \
-   F(NTP_DISPERSION) \
-   F(NTP_REF_ID) \
-   F(NTP_REF) \
-   F(NTP_ORIG) \
-   F(NTP_RECV) \
-   F(NTP_SENT)
+#define IPFIX_DNS_TEMPLATE(F)                                                                      \
+    F(DNS_ANSWERS)                                                                                 \
+    F(DNS_RCODE)                                                                                   \
+    F(DNS_QTYPE)                                                                                   \
+    F(DNS_CLASS)                                                                                   \
+    F(DNS_RR_TTL)                                                                                  \
+    F(DNS_RLENGTH)                                                                                 \
+    F(DNS_PSIZE)                                                                                   \
+    F(DNS_DO)                                                                                      \
+    F(DNS_ID)                                                                                      \
+    F(DNS_NAME)                                                                                    \
+    F(DNS_RDATA)
 
-#define IPFIX_DNS_TEMPLATE(F) \
-   F(DNS_ANSWERS) \
-   F(DNS_RCODE) \
-   F(DNS_QTYPE) \
-   F(DNS_CLASS) \
-   F(DNS_RR_TTL) \
-   F(DNS_RLENGTH) \
-   F(DNS_PSIZE) \
-   F(DNS_DO) \
-   F(DNS_ID) \
-   F(DNS_NAME) \
-   F(DNS_RDATA)
+#define IPFIX_PASSIVEDNS_TEMPLATE(F)                                                               \
+    F(DNS_ID)                                                                                      \
+    F(DNS_RR_TTL)                                                                                  \
+    F(DNS_ATYPE)                                                                                   \
+    F(DNS_RDATA)                                                                                   \
+    F(DNS_NAME)
 
-#define IPFIX_PASSIVEDNS_TEMPLATE(F) \
-   F(DNS_ID) \
-   F(DNS_RR_TTL) \
-   F(DNS_ATYPE) \
-   F(DNS_RDATA) \
-   F(DNS_NAME)
+#define IPFIX_SMTP_TEMPLATE(F)                                                                     \
+    F(SMTP_COMMANDS)                                                                               \
+    F(SMTP_MAIL_COUNT)                                                                             \
+    F(SMTP_RCPT_COUNT)                                                                             \
+    F(SMTP_STATUS_CODES)                                                                           \
+    F(SMTP_CODE_2XX_COUNT)                                                                         \
+    F(SMTP_CODE_3XX_COUNT)                                                                         \
+    F(SMTP_CODE_4XX_COUNT)                                                                         \
+    F(SMTP_CODE_5XX_COUNT)                                                                         \
+    F(SMTP_DOMAIN)                                                                                 \
+    F(SMTP_SENDER)                                                                                 \
+    F(SMTP_RECIPIENT)
 
-#define IPFIX_SMTP_TEMPLATE(F) \
-   F(SMTP_COMMANDS) \
-   F(SMTP_MAIL_COUNT) \
-   F(SMTP_RCPT_COUNT) \
-   F(SMTP_STATUS_CODES) \
-   F(SMTP_CODE_2XX_COUNT) \
-   F(SMTP_CODE_3XX_COUNT) \
-   F(SMTP_CODE_4XX_COUNT) \
-   F(SMTP_CODE_5XX_COUNT) \
-   F(SMTP_DOMAIN) \
-   F(SMTP_SENDER) \
-   F(SMTP_RECIPIENT)
+#define IPFIX_SIP_TEMPLATE(F)                                                                      \
+    F(SIP_MSG_TYPE)                                                                                \
+    F(SIP_STATUS_CODE)                                                                             \
+    F(SIP_CSEQ)                                                                                    \
+    F(SIP_CALLING_PARTY)                                                                           \
+    F(SIP_CALLED_PARTY)                                                                            \
+    F(SIP_CALL_ID)                                                                                 \
+    F(SIP_USER_AGENT)                                                                              \
+    F(SIP_REQUEST_URI)                                                                             \
+    F(SIP_VIA)
 
-#define IPFIX_SIP_TEMPLATE(F) \
-   F(SIP_MSG_TYPE) \
-   F(SIP_STATUS_CODE) \
-   F(SIP_CSEQ) \
-   F(SIP_CALLING_PARTY) \
-   F(SIP_CALLED_PARTY) \
-   F(SIP_CALL_ID) \
-   F(SIP_USER_AGENT) \
-   F(SIP_REQUEST_URI) \
-   F(SIP_VIA)
+#define IPFIX_PSTATS_TEMPLATE(F)                                                                   \
+    F(STATS_PCKT_SIZES)                                                                            \
+    F(STATS_PCKT_TIMESTAMPS)                                                                       \
+    F(STATS_PCKT_TCPFLGS)                                                                          \
+    F(STATS_PCKT_DIRECTIONS)
 
-#define IPFIX_PSTATS_TEMPLATE(F) \
-   F(STATS_PCKT_SIZES) \
-   F(STATS_PCKT_TIMESTAMPS) \
-   F(STATS_PCKT_TCPFLGS) \
-   F(STATS_PCKT_DIRECTIONS)
+#define IPFIX_OVPN_TEMPLATE(F) F(OVPN_CONF_LEVEL)
 
-#define IPFIX_OVPN_TEMPLATE(F) \
-   F(OVPN_CONF_LEVEL)
+#define IPFIX_SSADETECTOR_TEMPLATE(F) F(SSA_CONF_LEVEL)
 
-#define IPFIX_SSADETECTOR_TEMPLATE(F) \
-   F(SSA_CONF_LEVEL)
+#define IPFIX_SSDP_TEMPLATE(F)                                                                     \
+    F(SSDP_LOCATION_PORT)                                                                          \
+    F(SSDP_NT)                                                                                     \
+    F(SSDP_USER_AGENT)                                                                             \
+    F(SSDP_ST)                                                                                     \
+    F(SSDP_SERVER)
 
-#define IPFIX_SSDP_TEMPLATE(F) \
-   F(SSDP_LOCATION_PORT) \
-   F(SSDP_NT) \
-   F(SSDP_USER_AGENT)\
-   F(SSDP_ST) \
-   F(SSDP_SERVER)
+#define IPFIX_DNSSD_TEMPLATE(F)                                                                    \
+    F(DNSSD_QUERIES)                                                                               \
+    F(DNSSD_RESPONSES)
 
-#define IPFIX_DNSSD_TEMPLATE(F) \
-   F(DNSSD_QUERIES) \
-   F(DNSSD_RESPONSES)
+#define IPFIX_IDPCONTENT_TEMPLATE(F)                                                               \
+    F(IDP_CONTENT)                                                                                 \
+    F(IDP_CONTENT_REV)
 
-#define IPFIX_IDPCONTENT_TEMPLATE(F) \
-  F(IDP_CONTENT) \
-  F(IDP_CONTENT_REV)
+#define IPFIX_BSTATS_TEMPLATE(F)                                                                   \
+    F(SBI_BRST_PACKETS)                                                                            \
+    F(SBI_BRST_BYTES)                                                                              \
+    F(SBI_BRST_TIME_START)                                                                         \
+    F(SBI_BRST_TIME_STOP)                                                                          \
+    F(DBI_BRST_PACKETS)                                                                            \
+    F(DBI_BRST_BYTES)                                                                              \
+    F(DBI_BRST_TIME_START)                                                                         \
+    F(DBI_BRST_TIME_STOP)
 
-#define IPFIX_BSTATS_TEMPLATE(F) \
-  F(SBI_BRST_PACKETS) \
-  F(SBI_BRST_BYTES) \
-  F(SBI_BRST_TIME_START) \
-  F(SBI_BRST_TIME_STOP) \
-  F(DBI_BRST_PACKETS) \
-  F(DBI_BRST_BYTES) \
-  F(DBI_BRST_TIME_START) \
-  F(DBI_BRST_TIME_STOP)
+#define IPFIX_NETBIOS_TEMPLATE(F)                                                                  \
+    F(NB_SUFFIX)                                                                                   \
+    F(NB_NAME)
 
-#define IPFIX_NETBIOS_TEMPLATE(F) \
-   F(NB_SUFFIX) \
-   F(NB_NAME)
+#define IPFIX_NETBIOS_TEMPLATE(F)                                                                  \
+    F(NB_SUFFIX)                                                                                   \
+    F(NB_NAME)
 
-#define IPFIX_NETBIOS_TEMPLATE(F) \
-   F(NB_SUFFIX) \
-   F(NB_NAME)
+#define IPFIX_BASICPLUS_TEMPLATE(F)                                                                \
+    F(L3_TTL)                                                                                      \
+    F(L3_TTL_REV)                                                                                  \
+    F(L3_FLAGS)                                                                                    \
+    F(L3_FLAGS_REV)                                                                                \
+    F(L4_TCP_WIN)                                                                                  \
+    F(L4_TCP_WIN_REV)                                                                              \
+    F(L4_TCP_OPTIONS)                                                                              \
+    F(L4_TCP_OPTIONS_REV)                                                                          \
+    F(L4_TCP_MSS)                                                                                  \
+    F(L4_TCP_MSS_REV)                                                                              \
+    F(L4_TCP_SYN_SIZE)
 
-#define IPFIX_BASICPLUS_TEMPLATE(F) \
-   F(L3_TTL) \
-   F(L3_TTL_REV) \
-   F(L3_FLAGS) \
-   F(L3_FLAGS_REV) \
-   F(L4_TCP_WIN) \
-   F(L4_TCP_WIN_REV) \
-   F(L4_TCP_OPTIONS) \
-   F(L4_TCP_OPTIONS_REV) \
-   F(L4_TCP_MSS) \
-   F(L4_TCP_MSS_REV) \
-   F(L4_TCP_SYN_SIZE)
+#define IPFIX_PHISTS_TEMPLATE(F)                                                                   \
+    F(S_PHISTS_SIZES)                                                                              \
+    F(S_PHISTS_IPT)                                                                                \
+    F(D_PHISTS_SIZES)                                                                              \
+    F(D_PHISTS_IPT)
 
-#define IPFIX_PHISTS_TEMPLATE(F) \
-  F(S_PHISTS_SIZES) \
-  F(S_PHISTS_IPT) \
-  F(D_PHISTS_SIZES) \
-  F(D_PHISTS_IPT)
+#define IPFIX_WG_TEMPLATE(F)                                                                       \
+    F(WG_CONF_LEVEL)                                                                               \
+    F(WG_SRC_PEER)                                                                                 \
+    F(WG_DST_PEER)
 
-#define IPFIX_WG_TEMPLATE(F) \
-  F(WG_CONF_LEVEL) \
-  F(WG_SRC_PEER) \
-  F(WG_DST_PEER)
+#define IPFIX_QUIC_TEMPLATE(F)                                                                     \
+    F(QUIC_SNI)                                                                                    \
+    F(QUIC_USER_AGENT)                                                                             \
+    F(QUIC_VERSION)
 
-#define IPFIX_QUIC_TEMPLATE(F) \
-  F(QUIC_SNI) \
-  F(QUIC_USER_AGENT) \
-  F(QUIC_VERSION)
+#define IPFIX_OSQUERY_TEMPLATE(F)                                                                  \
+    F(OSQUERY_PROGRAM_NAME)                                                                        \
+    F(OSQUERY_USERNAME)                                                                            \
+    F(OSQUERY_OS_NAME)                                                                             \
+    F(OSQUERY_OS_MAJOR)                                                                            \
+    F(OSQUERY_OS_MINOR)                                                                            \
+    F(OSQUERY_OS_BUILD)                                                                            \
+    F(OSQUERY_OS_PLATFORM)                                                                         \
+    F(OSQUERY_OS_PLATFORM_LIKE)                                                                    \
+    F(OSQUERY_OS_ARCH)                                                                             \
+    F(OSQUERY_KERNEL_VERSION)                                                                      \
+    F(OSQUERY_SYSTEM_HOSTNAME)
 
-#define IPFIX_OSQUERY_TEMPLATE(F) \
-   F(OSQUERY_PROGRAM_NAME) \
-   F(OSQUERY_USERNAME) \
-   F(OSQUERY_OS_NAME) \
-   F(OSQUERY_OS_MAJOR) \
-   F(OSQUERY_OS_MINOR) \
-   F(OSQUERY_OS_BUILD) \
-   F(OSQUERY_OS_PLATFORM) \
-   F(OSQUERY_OS_PLATFORM_LIKE) \
-   F(OSQUERY_OS_ARCH) \
-   F(OSQUERY_KERNEL_VERSION) \
-   F(OSQUERY_SYSTEM_HOSTNAME)
+#define IPFIX_ICMP_TEMPLATE(F) F(L4_ICMP_TYPE_CODE)
 
-#define IPFIX_ICMP_TEMPLATE(F) \
-   F(L4_ICMP_TYPE_CODE)
+#define IPFIX_VLAN_TEMPLATE(F) F(VLAN_ID)
 
-#define IPFIX_VLAN_TEMPLATE(F) \
-   F(VLAN_ID)
+#define IPFIX_NETTISA_TEMPLATE(F)                                                                  \
+    F(NTS_MEAN)                                                                                    \
+    F(NTS_MIN)                                                                                     \
+    F(NTS_MAX)                                                                                     \
+    F(NTS_STDEV)                                                                                   \
+    F(NTS_KURTOSIS)                                                                                \
+    F(NTS_ROOT_MEAN_SQUARE)                                                                        \
+    F(NTS_AVERAGE_DISPERSION)                                                                      \
+    F(NTS_MEAN_SCALED_TIME)                                                                        \
+    F(NTS_MEAN_DIFFTIMES)                                                                          \
+    F(NTS_MIN_DIFFTIMES)                                                                           \
+    F(NTS_MAX_DIFFTIMES)                                                                           \
+    F(NTS_TIME_DISTRIBUTION)                                                                       \
+    F(NTS_SWITCHING_RATIO)
 
-#define IPFIX_NETTISA_TEMPLATE(F) \
-  F(NTS_MEAN) \
-  F(NTS_MIN) \
-  F(NTS_MAX) \
-  F(NTS_STDEV) \
-  F(NTS_KURTOSIS) \
-  F(NTS_ROOT_MEAN_SQUARE) \
-  F(NTS_AVERAGE_DISPERSION) \
-  F(NTS_MEAN_SCALED_TIME) \
-  F(NTS_MEAN_DIFFTIMES) \
-  F(NTS_MIN_DIFFTIMES) \
-  F(NTS_MAX_DIFFTIMES) \
-  F(NTS_TIME_DISTRIBUTION) \
-  F(NTS_SWITCHING_RATIO)
+#define IPFIX_FLOW_HASH_TEMPLATE(F) F(FLOW_ID)
 
-
-#define IPFIX_FLOW_HASH_TEMPLATE(F) \
-   F(FLOW_ID)
-
-#define IPFIX_MPLS_TEMPLATE(F) \
-   F(MPLS_TOP_LABEL_STACK_SECTION)
+#define IPFIX_MPLS_TEMPLATE(F) F(MPLS_TOP_LABEL_STACK_SECTION)
 
 #ifdef WITH_FLEXPROBE
 #define IPFIX_FLEXPROBE_DATA_TEMPLATE(F) F(FX_FRAME_SIGNATURE) F(FX_INPUT_INTERFACE)
@@ -555,37 +556,37 @@ namespace ipxp {
  * This macro is define in order to use all elements of all defined
  * templates at once.
  */
-#define IPFIX_ENABLED_TEMPLATES(F) \
-   BASIC_TMPLT_V4(F) \
-   BASIC_TMPLT_V6(F) \
-   IPFIX_HTTP_TEMPLATE(F) \
-   IPFIX_RTSP_TEMPLATE(F) \
-   IPFIX_TLS_TEMPLATE(F) \
-   IPFIX_NTP_TEMPLATE(F) \
-   IPFIX_SIP_TEMPLATE(F) \
-   IPFIX_DNS_TEMPLATE(F) \
-   IPFIX_PASSIVEDNS_TEMPLATE(F) \
-   IPFIX_PSTATS_TEMPLATE(F) \
-   IPFIX_OVPN_TEMPLATE(F) \
-   IPFIX_SMTP_TEMPLATE(F) \
-   IPFIX_SSDP_TEMPLATE(F) \
-   IPFIX_DNSSD_TEMPLATE(F) \
-   IPFIX_IDPCONTENT_TEMPLATE(F) \
-   IPFIX_NETBIOS_TEMPLATE(F) \
-   IPFIX_BASICPLUS_TEMPLATE(F) \
-   IPFIX_BSTATS_TEMPLATE(F) \
-   IPFIX_PHISTS_TEMPLATE(F) \
-   IPFIX_WG_TEMPLATE(F) \
-   IPFIX_QUIC_TEMPLATE(F) \
-   IPFIX_OSQUERY_TEMPLATE(F) \
-   IPFIX_FLEXPROBE_DATA_TEMPLATE(F) \
-   IPFIX_FLEXPROBE_TCP_TEMPLATE(F) \
-   IPFIX_FLEXPROBE_ENCR_TEMPLATE(F) \
-   IPFIX_SSADETECTOR_TEMPLATE(F) \
-   IPFIX_ICMP_TEMPLATE(F) \
-   IPFIX_VLAN_TEMPLATE(F) \
-   IPFIX_NETTISA_TEMPLATE(F) \
-   IPFIX_FLOW_HASH_TEMPLATE(F)
+#define IPFIX_ENABLED_TEMPLATES(F)                                                                 \
+    BASIC_TMPLT_V4(F)                                                                              \
+    BASIC_TMPLT_V6(F)                                                                              \
+    IPFIX_HTTP_TEMPLATE(F)                                                                         \
+    IPFIX_RTSP_TEMPLATE(F)                                                                         \
+    IPFIX_TLS_TEMPLATE(F)                                                                          \
+    IPFIX_NTP_TEMPLATE(F)                                                                          \
+    IPFIX_SIP_TEMPLATE(F)                                                                          \
+    IPFIX_DNS_TEMPLATE(F)                                                                          \
+    IPFIX_PASSIVEDNS_TEMPLATE(F)                                                                   \
+    IPFIX_PSTATS_TEMPLATE(F)                                                                       \
+    IPFIX_OVPN_TEMPLATE(F)                                                                         \
+    IPFIX_SMTP_TEMPLATE(F)                                                                         \
+    IPFIX_SSDP_TEMPLATE(F)                                                                         \
+    IPFIX_DNSSD_TEMPLATE(F)                                                                        \
+    IPFIX_IDPCONTENT_TEMPLATE(F)                                                                   \
+    IPFIX_NETBIOS_TEMPLATE(F)                                                                      \
+    IPFIX_BASICPLUS_TEMPLATE(F)                                                                    \
+    IPFIX_BSTATS_TEMPLATE(F)                                                                       \
+    IPFIX_PHISTS_TEMPLATE(F)                                                                       \
+    IPFIX_WG_TEMPLATE(F)                                                                           \
+    IPFIX_QUIC_TEMPLATE(F)                                                                         \
+    IPFIX_OSQUERY_TEMPLATE(F)                                                                      \
+    IPFIX_FLEXPROBE_DATA_TEMPLATE(F)                                                               \
+    IPFIX_FLEXPROBE_TCP_TEMPLATE(F)                                                                \
+    IPFIX_FLEXPROBE_ENCR_TEMPLATE(F)                                                               \
+    IPFIX_SSADETECTOR_TEMPLATE(F)                                                                  \
+    IPFIX_ICMP_TEMPLATE(F)                                                                         \
+    IPFIX_VLAN_TEMPLATE(F)                                                                         \
+    IPFIX_NETTISA_TEMPLATE(F)                                                                      \
+    IPFIX_FLOW_HASH_TEMPLATE(F)
 
 /**
  * Helper macro, convert FIELD into its name as a C literal.
@@ -595,5 +596,5 @@ namespace ipxp {
  */
 #define IPFIX_FIELD_NAMES(F) #F,
 
-}
+} // namespace ipxp
 #endif /* IPXP_IPFIX_ELEMENTS_HPP */

--- a/include/ipfixprobe/options.hpp
+++ b/include/ipfixprobe/options.hpp
@@ -29,63 +29,65 @@
 #ifndef IPXP_OPTIONS_HPP
 #define IPXP_OPTIONS_HPP
 
-#include <vector>
-#include <map>
+#include <cstdint>
 #include <functional>
+#include <iostream>
+#include <map>
 #include <stdexcept>
 #include <string>
-#include <iostream>
-#include <cstdint>
+#include <vector>
 
 namespace ipxp {
 
-class OptionsParser
-{
+class OptionsParser {
 public:
-   static const char DELIM = ';';
-   typedef std::function<bool(const char *opt)> OptionParserFunc;
-   enum OptionFlags : uint32_t {
-      RequiredArgument = 1,
-      OptionalArgument = 2,
-      NoArgument = 4
-   };
+    static const char DELIM = ';';
+    typedef std::function<bool(const char* opt)> OptionParserFunc;
+    enum OptionFlags : uint32_t { RequiredArgument = 1, OptionalArgument = 2, NoArgument = 4 };
 
-   OptionsParser();
-   OptionsParser(const std::string &name, const std::string &info);
-   ~OptionsParser();
-   OptionsParser(OptionsParser &p) = delete;
-   OptionsParser(OptionsParser &&p) = delete;
-   void operator=(OptionsParser &p) = delete;
-   void operator=(OptionsParser &&p) = delete;
-   void parse(const char *args) const;
-   void parse(int argc, const char **argv) const;
-   void usage(std::ostream &os, int indentation = 0, std::string mod_name = "") const;
+    OptionsParser();
+    OptionsParser(const std::string& name, const std::string& info);
+    ~OptionsParser();
+    OptionsParser(OptionsParser& p) = delete;
+    OptionsParser(OptionsParser&& p) = delete;
+    void operator=(OptionsParser& p) = delete;
+    void operator=(OptionsParser&& p) = delete;
+    void parse(const char* args) const;
+    void parse(int argc, const char** argv) const;
+    void usage(std::ostream& os, int indentation = 0, std::string mod_name = "") const;
 
 protected:
-   std::string m_name;
-   std::string m_info;
-   char m_delim;
-   struct Option {
-      std::string m_short;
-      std::string m_long;
-      std::string m_hint;
-      std::string m_description;
-      OptionParserFunc m_parser;
-      OptionFlags m_flags;
-   };
-   std::vector<Option *> m_options;
-   std::map<std::string, Option *> m_long;
-   std::map<std::string, Option *> m_short;
+    std::string m_name;
+    std::string m_info;
+    char m_delim;
+    struct Option {
+        std::string m_short;
+        std::string m_long;
+        std::string m_hint;
+        std::string m_description;
+        OptionParserFunc m_parser;
+        OptionFlags m_flags;
+    };
+    std::vector<Option*> m_options;
+    std::map<std::string, Option*> m_long;
+    std::map<std::string, Option*> m_short;
 
-   void register_option(std::string arg_short, std::string arg_long, std::string arg_hint, std::string description, OptionParserFunc parser, OptionFlags flags=OptionFlags::RequiredArgument);
+    void register_option(
+        std::string arg_short,
+        std::string arg_long,
+        std::string arg_hint,
+        std::string description,
+        OptionParserFunc parser,
+        OptionFlags flags = OptionFlags::RequiredArgument);
 };
 
-class ParserError : public std::runtime_error
-{
+class ParserError : public std::runtime_error {
 public:
-   explicit ParserError(const std::string &msg) : std::runtime_error(msg) {};
-   explicit ParserError(const char *msg) : std::runtime_error(msg) {};
+    explicit ParserError(const std::string& msg)
+        : std::runtime_error(msg) {};
+    explicit ParserError(const char* msg)
+        : std::runtime_error(msg) {};
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_OPTIONS_HPP */

--- a/include/ipfixprobe/output.hpp
+++ b/include/ipfixprobe/output.hpp
@@ -30,9 +30,9 @@
 #ifndef IPXP_OUTPUT_HPP
 #define IPXP_OUTPUT_HPP
 
+#include "flowifc.hpp"
 #include "plugin.hpp"
 #include "process.hpp"
-#include "flowifc.hpp"
 
 namespace ipxp {
 
@@ -41,36 +41,34 @@ namespace ipxp {
 /**
  * \brief Base class for flow exporters.
  */
-class OutputPlugin : public Plugin
-{
+class OutputPlugin : public Plugin {
 public:
-   typedef std::vector<std::pair<std::string, ProcessPlugin *>> Plugins;
-   uint64_t m_flows_seen; /**< Number of flows received to export. */
-   uint64_t m_flows_dropped; /**< Number of flows that could not be exported. */
+    typedef std::vector<std::pair<std::string, ProcessPlugin*>> Plugins;
+    uint64_t m_flows_seen; /**< Number of flows received to export. */
+    uint64_t m_flows_dropped; /**< Number of flows that could not be exported. */
 
-   OutputPlugin() : m_flows_seen(0), m_flows_dropped(0) {}
-   virtual ~OutputPlugin() {}
+    OutputPlugin()
+        : m_flows_seen(0)
+        , m_flows_dropped(0)
+    {
+    }
+    virtual ~OutputPlugin() {}
 
-   virtual void init(const char *params, Plugins &plugins) = 0;
+    virtual void init(const char* params, Plugins& plugins) = 0;
 
-   enum class Result {
-      EXPORTED = 0,
-      DROPPED
-   };
-   /**
-    * \brief Send flow record to output interface.
-    * \param [in] flow Flow to send.
-    * \return 0 on success
-    */
-   virtual int export_flow(const Flow &flow) = 0;
+    enum class Result { EXPORTED = 0, DROPPED };
+    /**
+     * \brief Send flow record to output interface.
+     * \param [in] flow Flow to send.
+     * \return 0 on success
+     */
+    virtual int export_flow(const Flow& flow) = 0;
 
-   /**
-    * \brief Force exporter to flush flows to collector.
-    */
-   virtual void flush()
-   {
-   }
+    /**
+     * \brief Force exporter to flush flows to collector.
+     */
+    virtual void flush() {}
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_OUTPUT_HPP */

--- a/include/ipfixprobe/packet.hpp
+++ b/include/ipfixprobe/packet.hpp
@@ -35,8 +35,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <ipfixprobe/ipaddr.hpp>
 #include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipaddr.hpp>
 
 namespace ipxp {
 
@@ -44,96 +44,118 @@ namespace ipxp {
  * \brief Structure for storing parsed packet fields
  */
 struct Packet : public Record {
-   struct timeval ts;
+    struct timeval ts;
 
-   uint8_t     dst_mac[6];
-   uint8_t     src_mac[6];
-   uint16_t    ethertype;
+    uint8_t dst_mac[6];
+    uint8_t src_mac[6];
+    uint16_t ethertype;
 
-   uint16_t    ip_len; /**< Length of IP header + its payload */
-   uint16_t    ip_payload_len; /**< Length of IP payload */
-   uint8_t     ip_version;
-   uint8_t     ip_ttl;
-   uint8_t     ip_proto;
-   uint8_t     ip_tos;
-   uint8_t     ip_flags;
-   ipaddr_t    src_ip;
-   ipaddr_t    dst_ip;
-   uint32_t    vlan_id;
+    uint16_t ip_len; /**< Length of IP header + its payload */
+    uint16_t ip_payload_len; /**< Length of IP payload */
+    uint8_t ip_version;
+    uint8_t ip_ttl;
+    uint8_t ip_proto;
+    uint8_t ip_tos;
+    uint8_t ip_flags;
+    ipaddr_t src_ip;
+    ipaddr_t dst_ip;
+    uint32_t vlan_id;
 
-   uint16_t    src_port;
-   uint16_t    dst_port;
-   uint8_t     tcp_flags;
-   uint16_t    tcp_window;
-   uint64_t    tcp_options;
-   uint32_t    tcp_mss;
-   uint32_t    tcp_seq;
-   uint32_t    tcp_ack;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t tcp_flags;
+    uint16_t tcp_window;
+    uint64_t tcp_options;
+    uint32_t tcp_mss;
+    uint32_t tcp_seq;
+    uint32_t tcp_ack;
 
-   /**
-    * @brief The top level mpls
-    *
-    * Contents are (from MSb to LSb):
-    *   20-bit - Label,
-    *   3-bit  - Traffic class / EXP,
-    *   1-bit  - Bottom of stack (true if last),
-    *   8-bit  - TTL (Time To Live)
-    */
-   uint32_t    mplsTop;
+    /**
+     * @brief The top level mpls
+     *
+     * Contents are (from MSb to LSb):
+     *   20-bit - Label,
+     *   3-bit  - Traffic class / EXP,
+     *   1-bit  - Bottom of stack (true if last),
+     *   8-bit  - TTL (Time To Live)
+     */
+    uint32_t mplsTop;
 
-   const uint8_t *packet; /**< Pointer to begin of packet, if available */
-   uint16_t    packet_len; /**< Length of data in packet buffer, packet_len <= packet_len_wire */
-   uint16_t    packet_len_wire; /**< Original packet length on wire */
+    const uint8_t* packet; /**< Pointer to begin of packet, if available */
+    uint16_t packet_len; /**< Length of data in packet buffer, packet_len <= packet_len_wire */
+    uint16_t packet_len_wire; /**< Original packet length on wire */
 
-   const uint8_t *payload; /**< Pointer to begin of payload, if available */
-   uint16_t    payload_len; /**< Length of data in payload buffer, payload_len <= payload_len_wire */
-   uint16_t    payload_len_wire; /**< Original payload length computed from headers */
+    const uint8_t* payload; /**< Pointer to begin of payload, if available */
+    uint16_t payload_len; /**< Length of data in payload buffer, payload_len <= payload_len_wire */
+    uint16_t payload_len_wire; /**< Original payload length computed from headers */
 
-   uint8_t     *custom; /**< Pointer to begin of custom data, if available */
-   uint16_t    custom_len; /**< Length of data in custom buffer */
+    uint8_t* custom; /**< Pointer to begin of custom data, if available */
+    uint16_t custom_len; /**< Length of data in custom buffer */
 
-   // TODO REMOVE
-   uint8_t     *buffer; /**< Buffer for packet, payload and custom data */
-   uint16_t    buffer_size; /**< Size of buffer */
+    // TODO REMOVE
+    uint8_t* buffer; /**< Buffer for packet, payload and custom data */
+    uint16_t buffer_size; /**< Size of buffer */
 
-   bool        source_pkt; /**< Direction of packet from flow point of view */
+    bool source_pkt; /**< Direction of packet from flow point of view */
 
-   /**
-    * \brief Constructor.
-    */
-   Packet() :
-      ts({0}),
-      dst_mac(), src_mac(), ethertype(0),
-      ip_len(0), ip_payload_len(0), ip_version(0), ip_ttl(0),
-      ip_proto(0), ip_tos(0), ip_flags(0), src_ip({0}), dst_ip({0}), vlan_id(0),
-      src_port(0), dst_port(0), tcp_flags(0), tcp_window(0),
-      tcp_options(0), tcp_mss(0), tcp_seq(0), tcp_ack(0), mplsTop(0),
-      packet(nullptr), packet_len(0), packet_len_wire(0),
-      payload(nullptr), payload_len(0), payload_len_wire(0),
-      custom(nullptr), custom_len(0),
-      buffer(nullptr), buffer_size(0),
-      source_pkt(true)
-   {
-   }
+    /**
+     * \brief Constructor.
+     */
+    Packet()
+        : ts({0})
+        , dst_mac()
+        , src_mac()
+        , ethertype(0)
+        , ip_len(0)
+        , ip_payload_len(0)
+        , ip_version(0)
+        , ip_ttl(0)
+        , ip_proto(0)
+        , ip_tos(0)
+        , ip_flags(0)
+        , src_ip({0})
+        , dst_ip({0})
+        , vlan_id(0)
+        , src_port(0)
+        , dst_port(0)
+        , tcp_flags(0)
+        , tcp_window(0)
+        , tcp_options(0)
+        , tcp_mss(0)
+        , tcp_seq(0)
+        , tcp_ack(0)
+        , mplsTop(0)
+        , packet(nullptr)
+        , packet_len(0)
+        , packet_len_wire(0)
+        , payload(nullptr)
+        , payload_len(0)
+        , payload_len_wire(0)
+        , custom(nullptr)
+        , custom_len(0)
+        , buffer(nullptr)
+        , buffer_size(0)
+        , source_pkt(true)
+    {
+    }
 };
 
 struct PacketBlock {
-   Packet *pkts;
-   size_t cnt;
-   size_t bytes;
-   size_t size;
+    Packet* pkts;
+    size_t cnt;
+    size_t bytes;
+    size_t size;
 
-   PacketBlock(size_t pkts_size) :
-      cnt(0), bytes(0), size(pkts_size)
-   {
-      pkts = new Packet[pkts_size];
-   }
+    PacketBlock(size_t pkts_size)
+        : cnt(0)
+        , bytes(0)
+        , size(pkts_size)
+    {
+        pkts = new Packet[pkts_size];
+    }
 
-   ~PacketBlock()
-   {
-      delete[] pkts;
-   }
+    ~PacketBlock() { delete[] pkts; }
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PACKET_HPP */

--- a/include/ipfixprobe/plugin.hpp
+++ b/include/ipfixprobe/plugin.hpp
@@ -36,55 +36,74 @@
 namespace ipxp {
 
 class Plugin;
-typedef std::function<Plugin *()> PluginGetter;
+typedef std::function<Plugin*()> PluginGetter;
 
 struct PluginRecord {
-   std::string m_name;
-   PluginGetter m_getter;
-   PluginRecord *m_next;
+    std::string m_name;
+    PluginGetter m_getter;
+    PluginRecord* m_next;
 
-   PluginRecord(const std::string &name, PluginGetter getter)
-      : m_name(name), m_getter(getter), m_next(nullptr)
-   {
-   }
+    PluginRecord(const std::string& name, PluginGetter getter)
+        : m_name(name)
+        , m_getter(getter)
+        , m_next(nullptr)
+    {
+    }
 };
 
-void register_plugin(PluginRecord *rec);
+void register_plugin(PluginRecord* rec);
 
-class Plugin
-{
+class Plugin {
 public:
-   Plugin() {}
-   virtual ~Plugin() {}
+    Plugin() {}
+    virtual ~Plugin() {}
 
-   virtual void init(const char *params) {}
-   virtual void close() {}
+    virtual void init(const char* params) {}
+    virtual void close() {}
 
-   virtual OptionsParser *get_parser() const = 0;
-   virtual std::string get_name() const = 0;
+    virtual OptionsParser* get_parser() const = 0;
+    virtual std::string get_name() const = 0;
 };
 
-class PluginException : public std::runtime_error
-{
+class PluginException : public std::runtime_error {
 public:
-   explicit PluginException(const std::string &msg) : std::runtime_error(msg) {}
-   explicit PluginException(const char *msg) : std::runtime_error(msg) {}
+    explicit PluginException(const std::string& msg)
+        : std::runtime_error(msg)
+    {
+    }
+    explicit PluginException(const char* msg)
+        : std::runtime_error(msg)
+    {
+    }
 };
 
-class PluginError : public PluginException
-{
+class PluginError : public PluginException {
 public:
-   explicit PluginError(const std::string &msg) : PluginException(msg) {}
-   explicit PluginError(const char *msg) : PluginException(msg) {}
+    explicit PluginError(const std::string& msg)
+        : PluginException(msg)
+    {
+    }
+    explicit PluginError(const char* msg)
+        : PluginException(msg)
+    {
+    }
 };
 
-class PluginExit : public PluginException
-{
+class PluginExit : public PluginException {
 public:
-   explicit PluginExit(const std::string &msg) : PluginException(msg) {}
-   explicit PluginExit(const char *msg) : PluginException(msg) {}
-   explicit PluginExit() : PluginException("") {}
+    explicit PluginExit(const std::string& msg)
+        : PluginException(msg)
+    {
+    }
+    explicit PluginExit(const char* msg)
+        : PluginException(msg)
+    {
+    }
+    explicit PluginExit()
+        : PluginException("")
+    {
+    }
 };
 
-}
+} // namespace ipxp
 #endif /* IPXE_PLUGIN_HPP */

--- a/include/ipfixprobe/process.hpp
+++ b/include/ipfixprobe/process.hpp
@@ -33,91 +33,75 @@
 #include <string>
 #include <vector>
 
-#include "plugin.hpp"
-#include "packet.hpp"
 #include "flowifc.hpp"
+#include "packet.hpp"
+#include "plugin.hpp"
 
 namespace ipxp {
 
 /**
  * \brief Tell storage plugin to flush (immediately export) current flow.
- * Behavior when called from post_create, pre_update and post_update: flush current Flow and erase FlowRecord.
+ * Behavior when called from post_create, pre_update and post_update: flush current Flow and erase
+ * FlowRecord.
  */
-#define FLOW_FLUSH                  0x1
+#define FLOW_FLUSH 0x1
 
 /**
  * \brief Tell storage plugin to flush (immediately export) current flow.
  * Behavior when called from post_create: flush current Flow and erase FlowRecord.
- * Behavior when called from pre_update and post_update: flush current Flow, erase FlowRecord and call post_create on packet.
+ * Behavior when called from pre_update and post_update: flush current Flow, erase FlowRecord and
+ * call post_create on packet.
  */
-#define FLOW_FLUSH_WITH_REINSERT    0x3
+#define FLOW_FLUSH_WITH_REINSERT 0x3
 
 /**
  * \brief Class template for flow cache plugins.
  */
-class ProcessPlugin : public Plugin
-{
+class ProcessPlugin : public Plugin {
 public:
-   ProcessPlugin() {}
-   virtual ~ProcessPlugin() {}
-   virtual ProcessPlugin *copy() = 0;
+    ProcessPlugin() {}
+    virtual ~ProcessPlugin() {}
+    virtual ProcessPlugin* copy() = 0;
 
-   virtual RecordExt *get_ext() const
-   {
-      return nullptr;
-   }
+    virtual RecordExt* get_ext() const { return nullptr; }
 
-   /**
-    * \brief Called before a new flow record is created.
-    * \param [in] pkt Parsed packet.
-    * \return 0 on success or FLOW_FLUSH option.
-    */
-   virtual int pre_create(Packet &pkt)
-   {
-      return 0;
-   }
+    /**
+     * \brief Called before a new flow record is created.
+     * \param [in] pkt Parsed packet.
+     * \return 0 on success or FLOW_FLUSH option.
+     */
+    virtual int pre_create(Packet& pkt) { return 0; }
 
-   /**
-    * \brief Called after a new flow record is created.
-    * \param [in,out] rec Reference to flow record.
-    * \param [in] pkt Parsed packet.
-    * \return 0 on success or FLOW_FLUSH option.
-    */
-   virtual int post_create(Flow &rec, const Packet &pkt)
-   {
-      return 0;
-   }
+    /**
+     * \brief Called after a new flow record is created.
+     * \param [in,out] rec Reference to flow record.
+     * \param [in] pkt Parsed packet.
+     * \return 0 on success or FLOW_FLUSH option.
+     */
+    virtual int post_create(Flow& rec, const Packet& pkt) { return 0; }
 
-   /**
-    * \brief Called before an existing record is update.
-    * \param [in,out] rec Reference to flow record.
-    * \param [in,out] pkt Parsed packet.
-    * \return 0 on success or FLOW_FLUSH option.
-    */
-   virtual int pre_update(Flow &rec, Packet &pkt)
-   {
-      return 0;
-   }
+    /**
+     * \brief Called before an existing record is update.
+     * \param [in,out] rec Reference to flow record.
+     * \param [in,out] pkt Parsed packet.
+     * \return 0 on success or FLOW_FLUSH option.
+     */
+    virtual int pre_update(Flow& rec, Packet& pkt) { return 0; }
 
-   /**
-    * \brief Called after an existing record is updated.
-    * \param [in,out] rec Reference to flow record.
-    * \param [in,out] pkt Parsed packet.
-    * \return 0 on success or FLOW_FLUSH option.
-    */
-   virtual int post_update(Flow &rec, const Packet &pkt)
-   {
-      return 0;
-   }
+    /**
+     * \brief Called after an existing record is updated.
+     * \param [in,out] rec Reference to flow record.
+     * \param [in,out] pkt Parsed packet.
+     * \return 0 on success or FLOW_FLUSH option.
+     */
+    virtual int post_update(Flow& rec, const Packet& pkt) { return 0; }
 
-   /**
-    * \brief Called before a flow record is exported from the cache.
-    * \param [in,out] rec Reference to flow record.
-    */
-   virtual void pre_export(Flow &rec)
-   {
-   }
+    /**
+     * \brief Called before a flow record is exported from the cache.
+     * \param [in,out] rec Reference to flow record.
+     */
+    virtual void pre_export(Flow& rec) {}
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_HPP */

--- a/include/ipfixprobe/utils.hpp
+++ b/include/ipfixprobe/utils.hpp
@@ -29,26 +29,31 @@
 #ifndef IPXP_UTILS_HPP
 #define IPXP_UTILS_HPP
 
-#include <type_traits>
-#include <set>
-#include <string>
-#include <limits>
-#include <cctype>
-#include <utility>
 #include <algorithm>
-#include <stdexcept>
+#include <cctype>
 #include <cstdint>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 namespace ipxp {
 
-void parse_range(const std::string &arg, std::string &from, std::string &to, const std::string &delim = "-");
+void parse_range(
+    const std::string& arg,
+    std::string& from,
+    std::string& to,
+    const std::string& delim = "-");
 bool str2bool(std::string str);
-void trim_str(std::string &str);
+void trim_str(std::string& str);
 uint32_t variable2ipfix_buffer(uint8_t* buffer2write, uint8_t* buffer2read, uint16_t len);
 
-template<typename T> constexpr
-T const& max(const T &a, const T &b) {
-  return a > b ? a : b;
+template<typename T>
+constexpr T const& max(const T& a, const T& b)
+{
+    return a > b ? a : b;
 }
 
 /*
@@ -59,91 +64,88 @@ T const& max(const T &a, const T &b) {
 template<typename T>
 static constexpr unsigned bitcount(T num)
 {
-   static_assert(!std::is_signed<T>(), "bitcount function is for unsigned types only");
-   return num == 0 ? 0 : (bitcount<T>(num >> 1) + (num & 1));
+    static_assert(!std::is_signed<T>(), "bitcount function is for unsigned types only");
+    return num == 0 ? 0 : (bitcount<T>(num >> 1) + (num & 1));
 }
 
-template <typename T>
+template<typename T>
 static constexpr bool is_fpoint()
 {
-   return std::is_floating_point<T>();
+    return std::is_floating_point<T>();
 }
 
-template <typename T>
+template<typename T>
 static constexpr bool is_uint()
 {
-   return std::is_integral<T>() && std::is_unsigned<T>();
+    return std::is_integral<T>() && std::is_unsigned<T>();
 }
 
-template <typename T>
+template<typename T>
 static constexpr bool is_sint()
 {
-   return std::is_integral<T>() && std::is_signed<T>();
+    return std::is_integral<T>() && std::is_signed<T>();
 }
 
 // Use of SFINAE to implement specific conversion function variants
 
-template <typename T>
-T str2num(std::string str, typename std::enable_if<is_fpoint<T>()>::type * = nullptr)
+template<typename T>
+T str2num(std::string str, typename std::enable_if<is_fpoint<T>()>::type* = nullptr)
 {
-   size_t pos;
-   double tmp;
+    size_t pos;
+    double tmp;
 
-   trim_str(str);
-   try {
-      tmp = std::stold(str, &pos);
-   } catch (std::out_of_range &e) {
-      throw std::invalid_argument(str);
-   }
-   if (pos != str.size() ||
-      tmp < std::numeric_limits<T>::min() ||
-      tmp > std::numeric_limits<T>::max()) {
-      throw std::invalid_argument(str);
-   }
+    trim_str(str);
+    try {
+        tmp = std::stold(str, &pos);
+    } catch (std::out_of_range& e) {
+        throw std::invalid_argument(str);
+    }
+    if (pos != str.size() || tmp < std::numeric_limits<T>::min()
+        || tmp > std::numeric_limits<T>::max()) {
+        throw std::invalid_argument(str);
+    }
 
-   return static_cast<T>(tmp);
+    return static_cast<T>(tmp);
 }
 
-template <typename T>
-T str2num(std::string str, typename std::enable_if<is_sint<T>()>::type * = nullptr)
+template<typename T>
+T str2num(std::string str, typename std::enable_if<is_sint<T>()>::type* = nullptr)
 {
-   long long tmp;
-   size_t pos;
+    long long tmp;
+    size_t pos;
 
-   trim_str(str);
-   try {
-      tmp = std::stoll(str, &pos, 0);
-   } catch (std::out_of_range &e) {
-      throw std::invalid_argument(str);
-   }
-   if (pos != str.size() ||
-      tmp < std::numeric_limits<T>::min() ||
-      tmp > std::numeric_limits<T>::max()) {
-      throw std::invalid_argument(str);
-   }
+    trim_str(str);
+    try {
+        tmp = std::stoll(str, &pos, 0);
+    } catch (std::out_of_range& e) {
+        throw std::invalid_argument(str);
+    }
+    if (pos != str.size() || tmp < std::numeric_limits<T>::min()
+        || tmp > std::numeric_limits<T>::max()) {
+        throw std::invalid_argument(str);
+    }
 
-   return static_cast<T>(tmp);
+    return static_cast<T>(tmp);
 }
 
-template <typename T>
-T str2num(std::string str, typename std::enable_if<is_uint<T>()>::type * = nullptr)
+template<typename T>
+T str2num(std::string str, typename std::enable_if<is_uint<T>()>::type* = nullptr)
 {
-   unsigned long long tmp;
-   size_t pos;
+    unsigned long long tmp;
+    size_t pos;
 
-   trim_str(str);
-   try {
-      tmp = std::stoull(str, &pos, 0);
-   } catch (std::out_of_range &e) {
-      throw std::invalid_argument(str);
-   }
-   if (pos != str.size() ||
-      tmp < std::numeric_limits<T>::min() ||
-      tmp > std::numeric_limits<T>::max()) {
-      throw std::invalid_argument(str);
-   }
+    trim_str(str);
+    try {
+        tmp = std::stoull(str, &pos, 0);
+    } catch (std::out_of_range& e) {
+        throw std::invalid_argument(str);
+    }
+    if (pos != str.size() || tmp < std::numeric_limits<T>::min()
+        || tmp > std::numeric_limits<T>::max()) {
+        throw std::invalid_argument(str);
+    }
 
-   return static_cast<T>(tmp);
+    return static_cast<T>(tmp);
 }
 
 /**
@@ -151,6 +153,6 @@ T str2num(std::string str, typename std::enable_if<is_uint<T>()>::type * = nullp
  */
 uint64_t timeval2usec(const struct timeval& tv);
 
-}
+} // namespace ipxp
 
 #endif /* IPXP_UTILS_HPP */

--- a/input/benchmark.cpp
+++ b/input/benchmark.cpp
@@ -26,191 +26,203 @@
  *
  */
 
-#include <random>
 #include <chrono>
 #include <cstdint>
+#include <random>
 #include <sys/time.h>
 
 #include "benchmark.hpp"
+#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/plugin.hpp>
 #include <ipfixprobe/utils.hpp>
-#include <ipfixprobe/packet.hpp>
 
 namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("benchmark", [](){return new Benchmark();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("benchmark", []() { return new Benchmark(); });
+    register_plugin(&rec);
 }
 
 Benchmark::Benchmark()
-   : m_generatePacketFunc(nullptr), m_flowMode(BenchmarkMode::FLOW_1), m_maxDuration(BENCHMARK_DEFAULT_DURATION), m_maxPktCnt(BENCHMARK_DEFAULT_PKT_CNT),
-     m_packetSizeFrom(BENCHMARK_DEFAULT_SIZE_FROM), m_packetSizeTo(BENCHMARK_DEFAULT_SIZE_TO), m_firstTs({0}), m_currentTs({0}), m_pktCnt(0)
+    : m_generatePacketFunc(nullptr)
+    , m_flowMode(BenchmarkMode::FLOW_1)
+    , m_maxDuration(BENCHMARK_DEFAULT_DURATION)
+    , m_maxPktCnt(BENCHMARK_DEFAULT_PKT_CNT)
+    , m_packetSizeFrom(BENCHMARK_DEFAULT_SIZE_FROM)
+    , m_packetSizeTo(BENCHMARK_DEFAULT_SIZE_TO)
+    , m_firstTs({0})
+    , m_currentTs({0})
+    , m_pktCnt(0)
 {
 }
 
 Benchmark::~Benchmark()
 {
-   close();
+    close();
 }
 
-void Benchmark::init(const char *params)
+void Benchmark::init(const char* params)
 {
-   BenchmarkOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    BenchmarkOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   if (parser.m_mode == "1f") {
-      generatePacket(&m_pkt);
-      m_flowMode = BenchmarkMode::FLOW_1;
-      m_generatePacketFunc = &Benchmark::generatePacketFlow1;
-   } else if (parser.m_mode == "nf") {
-      m_flowMode = BenchmarkMode::FLOW_N;
-      m_generatePacketFunc = &Benchmark::generatePacketFlowN;
-   } else {
-      throw PluginError("invalid benchmark mode specified");
-   }
+    if (parser.m_mode == "1f") {
+        generatePacket(&m_pkt);
+        m_flowMode = BenchmarkMode::FLOW_1;
+        m_generatePacketFunc = &Benchmark::generatePacketFlow1;
+    } else if (parser.m_mode == "nf") {
+        m_flowMode = BenchmarkMode::FLOW_N;
+        m_generatePacketFunc = &Benchmark::generatePacketFlowN;
+    } else {
+        throw PluginError("invalid benchmark mode specified");
+    }
 
-   m_maxDuration = parser.m_duration;
-   m_maxPktCnt = parser.m_pkt_cnt;
-   m_packetSizeFrom = parser.m_pkt_size;
-   m_packetSizeTo = parser.m_pkt_size;
-   if (m_packetSizeFrom < 64) {
-      throw PluginError("minimal packet size is 64 bytes");
-   }
+    m_maxDuration = parser.m_duration;
+    m_maxPktCnt = parser.m_pkt_cnt;
+    m_packetSizeFrom = parser.m_pkt_size;
+    m_packetSizeTo = parser.m_pkt_size;
+    if (m_packetSizeFrom < 64) {
+        throw PluginError("minimal packet size is 64 bytes");
+    }
 
-   if (parser.m_seed.empty()) {
-      std::random_device rd;
-      m_rndGen = std::mt19937(rd());
-   } else {
-      std::seed_seq seed (parser.m_seed.begin(),parser.m_seed.end());
-      m_rndGen = std::mt19937(seed);
-   }
-   gettimeofday(&m_firstTs, nullptr);
+    if (parser.m_seed.empty()) {
+        std::random_device rd;
+        m_rndGen = std::mt19937(rd());
+    } else {
+        std::seed_seq seed(parser.m_seed.begin(), parser.m_seed.end());
+        m_rndGen = std::mt19937(seed);
+    }
+    gettimeofday(&m_firstTs, nullptr);
 }
 
-void Benchmark::close()
-{
-}
+void Benchmark::close() {}
 
-InputPlugin::Result Benchmark::get(PacketBlock &packets)
+InputPlugin::Result Benchmark::get(PacketBlock& packets)
 {
-   gettimeofday(&m_currentTs, nullptr);
-   InputPlugin::Result res = check_constraints();
-   if (res != InputPlugin::Result::PARSED) {
-      return res;
-   }
+    gettimeofday(&m_currentTs, nullptr);
+    InputPlugin::Result res = check_constraints();
+    if (res != InputPlugin::Result::PARSED) {
+        return res;
+    }
 
-   packets.cnt = 0;
-   packets.bytes = 0;
-   for (size_t i = 0; i < packets.size; i++) {
-      (this->*m_generatePacketFunc)(&(packets.pkts[i]));
-      packets.cnt++;
-      packets.bytes += packets.pkts[i].packet_len_wire;
-      m_pktCnt++;
-      if (m_maxPktCnt && m_pktCnt >= m_maxPktCnt) {
-         break;
-      }
-   }
-   m_seen += packets.cnt;
-   m_parsed += packets.cnt;
-   return res;
+    packets.cnt = 0;
+    packets.bytes = 0;
+    for (size_t i = 0; i < packets.size; i++) {
+        (this->*m_generatePacketFunc)(&(packets.pkts[i]));
+        packets.cnt++;
+        packets.bytes += packets.pkts[i].packet_len_wire;
+        m_pktCnt++;
+        if (m_maxPktCnt && m_pktCnt >= m_maxPktCnt) {
+            break;
+        }
+    }
+    m_seen += packets.cnt;
+    m_parsed += packets.cnt;
+    return res;
 }
 
 InputPlugin::Result Benchmark::check_constraints() const
 {
-   int tmp = m_currentTs.tv_usec - m_firstTs.tv_usec ;
-   uint64_t duration = m_currentTs.tv_sec - m_firstTs.tv_sec + (tmp < 0 ? -1 : 0);
+    int tmp = m_currentTs.tv_usec - m_firstTs.tv_usec;
+    uint64_t duration = m_currentTs.tv_sec - m_firstTs.tv_sec + (tmp < 0 ? -1 : 0);
 
-   if ((m_maxPktCnt != BENCHMARK_PKT_CNT_INF && m_pktCnt >= m_maxPktCnt) ||
-       (m_maxDuration != BENCHMARK_DURATION_INF && duration >= m_maxDuration)) {
-      return InputPlugin::Result::END_OF_FILE;
-   }
-   return InputPlugin::Result::PARSED;
+    if ((m_maxPktCnt != BENCHMARK_PKT_CNT_INF && m_pktCnt >= m_maxPktCnt)
+        || (m_maxDuration != BENCHMARK_DURATION_INF && duration >= m_maxDuration)) {
+        return InputPlugin::Result::END_OF_FILE;
+    }
+    return InputPlugin::Result::PARSED;
 }
 
-void Benchmark::swapEndpoints(Packet *pkt)
+void Benchmark::swapEndpoints(Packet* pkt)
 {
-   std::swap(pkt->src_mac, pkt->dst_mac);
-   std::swap(pkt->src_ip, pkt->dst_ip);
-   std::swap(pkt->src_port, pkt->dst_port);
+    std::swap(pkt->src_mac, pkt->dst_mac);
+    std::swap(pkt->src_ip, pkt->dst_ip);
+    std::swap(pkt->src_port, pkt->dst_port);
 }
 
-void Benchmark::generatePacket(Packet *pkt)
+void Benchmark::generatePacket(Packet* pkt)
 {
-   std::uniform_int_distribution<uint32_t> distrib;
+    std::uniform_int_distribution<uint32_t> distrib;
 
-   pkt->ts = m_currentTs;
-   pkt->packet_len = std::uniform_int_distribution<uint16_t>(m_packetSizeFrom, m_packetSizeTo)(m_rndGen);
-   pkt->packet_len_wire = pkt->packet_len;
-   if (distrib(m_rndGen) & 1) {
-      pkt->ethertype = 0x0800;
-      pkt->ip_version = IP::v4;
-      pkt->src_ip.v4 = distrib(m_rndGen);
-      pkt->dst_ip.v4 = distrib(m_rndGen);
-   } else {
-      pkt->ethertype = 0x86DD;
-      pkt->ip_version = IP::v6;
-      for (int i = 0; i < 4; i++) {
-         reinterpret_cast<uint32_t *>(pkt->src_ip.v6)[i] = distrib(m_rndGen);
-         reinterpret_cast<uint32_t *>(pkt->dst_ip.v6)[i] = distrib(m_rndGen);
-      }
-   }
+    pkt->ts = m_currentTs;
+    pkt->packet_len
+        = std::uniform_int_distribution<uint16_t>(m_packetSizeFrom, m_packetSizeTo)(m_rndGen);
+    pkt->packet_len_wire = pkt->packet_len;
+    if (distrib(m_rndGen) & 1) {
+        pkt->ethertype = 0x0800;
+        pkt->ip_version = IP::v4;
+        pkt->src_ip.v4 = distrib(m_rndGen);
+        pkt->dst_ip.v4 = distrib(m_rndGen);
+    } else {
+        pkt->ethertype = 0x86DD;
+        pkt->ip_version = IP::v6;
+        for (int i = 0; i < 4; i++) {
+            reinterpret_cast<uint32_t*>(pkt->src_ip.v6)[i] = distrib(m_rndGen);
+            reinterpret_cast<uint32_t*>(pkt->dst_ip.v6)[i] = distrib(m_rndGen);
+        }
+    }
 
-   pkt->src_port = distrib(m_rndGen);
-   pkt->dst_port = distrib(m_rndGen);
-   if (distrib(m_rndGen) & 1) {
-      pkt->ip_proto = IPPROTO_TCP;
-      pkt->tcp_flags = 0x18; // PSH ACK
-      pkt->ip_payload_len = BENCHMARK_L4_SIZE_TCP;
-   } else {
-      pkt->ip_proto = IPPROTO_UDP;
-      pkt->tcp_flags = 0;
-      pkt->ip_payload_len = BENCHMARK_L4_SIZE_UDP;
-   }
-   int tmp = pkt->ip_payload_len + BENCHMARK_L2_SIZE + BENCHMARK_L3_SIZE;
+    pkt->src_port = distrib(m_rndGen);
+    pkt->dst_port = distrib(m_rndGen);
+    if (distrib(m_rndGen) & 1) {
+        pkt->ip_proto = IPPROTO_TCP;
+        pkt->tcp_flags = 0x18; // PSH ACK
+        pkt->ip_payload_len = BENCHMARK_L4_SIZE_TCP;
+    } else {
+        pkt->ip_proto = IPPROTO_UDP;
+        pkt->tcp_flags = 0;
+        pkt->ip_payload_len = BENCHMARK_L4_SIZE_UDP;
+    }
+    int tmp = pkt->ip_payload_len + BENCHMARK_L2_SIZE + BENCHMARK_L3_SIZE;
 
-   pkt->payload_len = std::uniform_int_distribution<uint16_t>(m_packetSizeFrom - tmp, m_packetSizeTo - tmp)(m_rndGen);
-   pkt->ip_payload_len += pkt->payload_len;
-   pkt->ip_len = pkt->ip_payload_len + BENCHMARK_L3_SIZE;
-   pkt->packet_len = pkt->ip_len + BENCHMARK_L2_SIZE;
+    pkt->payload_len
+        = std::uniform_int_distribution<uint16_t>(m_packetSizeFrom - tmp, m_packetSizeTo - tmp)(
+            m_rndGen);
+    pkt->ip_payload_len += pkt->payload_len;
+    pkt->ip_len = pkt->ip_payload_len + BENCHMARK_L3_SIZE;
+    pkt->packet_len = pkt->ip_len + BENCHMARK_L2_SIZE;
 
-   pkt->packet = pkt->buffer;
-   pkt->payload = pkt->packet + (pkt->packet_len - pkt->payload_len);
+    pkt->packet = pkt->buffer;
+    pkt->payload = pkt->packet + (pkt->packet_len - pkt->payload_len);
 
-   static_assert(BENCHMARK_L2_SIZE + BENCHMARK_L3_SIZE +
-      max(BENCHMARK_L4_SIZE_TCP, BENCHMARK_L4_SIZE_UDP) <= BENCHMARK_MIN_PACKET_SIZE, "minimal packet size is too low");
+    static_assert(
+        BENCHMARK_L2_SIZE + BENCHMARK_L3_SIZE + max(BENCHMARK_L4_SIZE_TCP, BENCHMARK_L4_SIZE_UDP)
+            <= BENCHMARK_MIN_PACKET_SIZE,
+        "minimal packet size is too low");
 }
 
-void Benchmark::generatePacketFlow1(Packet *pkt)
+void Benchmark::generatePacketFlow1(Packet* pkt)
 {
-   int tmp = m_pkt.packet_len - m_pkt.payload_len; // Non payload size
-   int newPayloadLength = std::uniform_int_distribution<uint16_t>(m_packetSizeFrom - tmp, m_packetSizeTo - tmp)(m_rndGen);
-   int diff = newPayloadLength - m_pkt.payload_len;
+    int tmp = m_pkt.packet_len - m_pkt.payload_len; // Non payload size
+    int newPayloadLength
+        = std::uniform_int_distribution<uint16_t>(m_packetSizeFrom - tmp, m_packetSizeTo - tmp)(
+            m_rndGen);
+    int diff = newPayloadLength - m_pkt.payload_len;
 
-   m_pkt.payload_len += diff;
-   m_pkt.payload_len_wire += diff;
-   m_pkt.ip_payload_len += diff;
-   m_pkt.ip_len += diff;
-   m_pkt.packet_len += diff;
-   m_pkt.packet_len_wire += diff;
+    m_pkt.payload_len += diff;
+    m_pkt.payload_len_wire += diff;
+    m_pkt.ip_payload_len += diff;
+    m_pkt.ip_len += diff;
+    m_pkt.packet_len += diff;
+    m_pkt.packet_len_wire += diff;
 
-   m_pkt.ts = m_currentTs;
-   swapEndpoints(&m_pkt);
+    m_pkt.ts = m_currentTs;
+    swapEndpoints(&m_pkt);
 
-   m_pkt.buffer = pkt->buffer;
-   m_pkt.packet = m_pkt.buffer;
-   m_pkt.payload = m_pkt.packet + (pkt->packet_len - pkt->payload_len);
-   *pkt = m_pkt;
+    m_pkt.buffer = pkt->buffer;
+    m_pkt.packet = m_pkt.buffer;
+    m_pkt.payload = m_pkt.packet + (pkt->packet_len - pkt->payload_len);
+    *pkt = m_pkt;
 }
 
-void Benchmark::generatePacketFlowN(Packet *pkt)
+void Benchmark::generatePacketFlowN(Packet* pkt)
 {
-   generatePacket(pkt);
+    generatePacket(pkt);
 }
 
-}
+} // namespace ipxp

--- a/input/benchmark.hpp
+++ b/input/benchmark.hpp
@@ -28,10 +28,10 @@
 #ifndef IPXP_INPUT_BENCHMARK_HPP
 #define IPXP_INPUT_BENCHMARK_HPP
 
-#include <random>
 #include <chrono>
-#include <string>
 #include <cstdint>
+#include <random>
+#include <string>
 
 #include <ipfixprobe/input.hpp>
 #include <ipfixprobe/packet.hpp>
@@ -39,88 +39,154 @@
 
 namespace ipxp {
 
-#define BENCHMARK_L2_SIZE     14
-#define BENCHMARK_L3_SIZE     20
+#define BENCHMARK_L2_SIZE 14
+#define BENCHMARK_L3_SIZE 20
 #define BENCHMARK_L4_SIZE_TCP 20
 #define BENCHMARK_L4_SIZE_UDP 8
 
-#define BENCHMARK_MIN_PACKET_SIZE   64
-#define BENCHMARK_PKT_CNT_INF       0
-#define BENCHMARK_FLOW_CNT_INF      0
-#define BENCHMARK_DURATION_INF      0
+#define BENCHMARK_MIN_PACKET_SIZE 64
+#define BENCHMARK_PKT_CNT_INF 0
+#define BENCHMARK_FLOW_CNT_INF 0
+#define BENCHMARK_DURATION_INF 0
 
-#define BENCHMARK_DEFAULT_DURATION  10 // 10s
-#define BENCHMARK_DEFAULT_FLOW_CNT  BENCHMARK_FLOW_CNT_INF
-#define BENCHMARK_DEFAULT_PKT_CNT   BENCHMARK_PKT_CNT_INF
+#define BENCHMARK_DEFAULT_DURATION 10 // 10s
+#define BENCHMARK_DEFAULT_FLOW_CNT BENCHMARK_FLOW_CNT_INF
+#define BENCHMARK_DEFAULT_PKT_CNT BENCHMARK_PKT_CNT_INF
 #define BENCHMARK_DEFAULT_SIZE_FROM 512
-#define BENCHMARK_DEFAULT_SIZE_TO   512
+#define BENCHMARK_DEFAULT_SIZE_TO 512
 
-class BenchmarkOptParser : public OptionsParser
-{
+class BenchmarkOptParser : public OptionsParser {
 public:
-   std::string m_mode;
-   std::string m_seed;
-   uint64_t m_duration;
-   uint64_t m_pkt_cnt;
-   uint16_t m_pkt_size;
-   uint64_t m_link;
+    std::string m_mode;
+    std::string m_seed;
+    uint64_t m_duration;
+    uint64_t m_pkt_cnt;
+    uint16_t m_pkt_size;
+    uint64_t m_link;
 
-   BenchmarkOptParser() : OptionsParser("benchmark", "Input plugin for various benchmarking purposes"),
-      m_mode("1f"), m_seed(""), m_duration(0), m_pkt_cnt(0), m_pkt_size(BENCHMARK_DEFAULT_SIZE_FROM), m_link(0)
-   {
-      register_option("m", "mode", "STR", "Benchmark mode 1f (1x N-packet flow) or nf (Nx 1-packet flow)", [this](const char *arg){m_mode = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("S", "seed", "STR", "String seed for random generator", [this](const char *arg){m_seed = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("d", "duration", "TIME", "Duration in seconds",
-         [this](const char *arg){try {m_duration = str2num<decltype(m_duration)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("p", "count", "SIZE", "Packet count",
-         [this](const char *arg){try {m_pkt_cnt = str2num<decltype(m_pkt_cnt)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("s", "size", "SIZE", "Packet size",
-         [this](const char *arg){try {m_pkt_size = str2num<decltype(m_pkt_size)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("I", "id", "NUM", "Link identifier number",
-         [this](const char *arg){try {m_link = str2num<decltype(m_link)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-   }
+    BenchmarkOptParser()
+        : OptionsParser("benchmark", "Input plugin for various benchmarking purposes")
+        , m_mode("1f")
+        , m_seed("")
+        , m_duration(0)
+        , m_pkt_cnt(0)
+        , m_pkt_size(BENCHMARK_DEFAULT_SIZE_FROM)
+        , m_link(0)
+    {
+        register_option(
+            "m",
+            "mode",
+            "STR",
+            "Benchmark mode 1f (1x N-packet flow) or nf (Nx 1-packet flow)",
+            [this](const char* arg) {
+                m_mode = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "S",
+            "seed",
+            "STR",
+            "String seed for random generator",
+            [this](const char* arg) {
+                m_seed = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "d",
+            "duration",
+            "TIME",
+            "Duration in seconds",
+            [this](const char* arg) {
+                try {
+                    m_duration = str2num<decltype(m_duration)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "p",
+            "count",
+            "SIZE",
+            "Packet count",
+            [this](const char* arg) {
+                try {
+                    m_pkt_cnt = str2num<decltype(m_pkt_cnt)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "s",
+            "size",
+            "SIZE",
+            "Packet size",
+            [this](const char* arg) {
+                try {
+                    m_pkt_size = str2num<decltype(m_pkt_size)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "I",
+            "id",
+            "NUM",
+            "Link identifier number",
+            [this](const char* arg) {
+                try {
+                    m_link = str2num<decltype(m_link)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+    }
 };
 
-class Benchmark : public InputPlugin
-{
+class Benchmark : public InputPlugin {
 public:
-   enum class BenchmarkMode {
-      FLOW_1, /* 1x N-packet flow */
-      FLOW_N  /* Nx 1-packet flows */
-   };
-   Benchmark();
-   ~Benchmark();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new BenchmarkOptParser(); }
-   std::string get_name() const { return "benchmark"; }
+    enum class BenchmarkMode {
+        FLOW_1, /* 1x N-packet flow */
+        FLOW_N /* Nx 1-packet flows */
+    };
+    Benchmark();
+    ~Benchmark();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new BenchmarkOptParser(); }
+    std::string get_name() const { return "benchmark"; }
 
-   InputPlugin::Result get(PacketBlock &packets);
+    InputPlugin::Result get(PacketBlock& packets);
 
 private:
-   void (Benchmark::*m_generatePacketFunc)(Packet *);
-   BenchmarkMode m_flowMode;
-   uint64_t m_maxDuration;
-   uint64_t m_maxPktCnt;
-   uint16_t m_packetSizeFrom;
-   uint16_t m_packetSizeTo;
+    void (Benchmark::*m_generatePacketFunc)(Packet*);
+    BenchmarkMode m_flowMode;
+    uint64_t m_maxDuration;
+    uint64_t m_maxPktCnt;
+    uint16_t m_packetSizeFrom;
+    uint16_t m_packetSizeTo;
 
-   std::mt19937 m_rndGen;
-   Packet m_pkt;
-   struct timeval m_firstTs;
-   struct timeval m_currentTs;
-   uint64_t m_pktCnt;
+    std::mt19937 m_rndGen;
+    Packet m_pkt;
+    struct timeval m_firstTs;
+    struct timeval m_currentTs;
+    uint64_t m_pktCnt;
 
-   InputPlugin::Result check_constraints() const;
-   void swapEndpoints(Packet *pkt);
-   void generatePacket(Packet *pkt);
-   void generatePacketFlow1(Packet *pkt);
-   void generatePacketFlowN(Packet *pkt);
+    InputPlugin::Result check_constraints() const;
+    void swapEndpoints(Packet* pkt);
+    void generatePacket(Packet* pkt);
+    void generatePacketFlow1(Packet* pkt);
+    void generatePacketFlowN(Packet* pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_BENCHMARK_HPP */

--- a/input/dpdk-ring.cpp
+++ b/input/dpdk-ring.cpp
@@ -25,11 +25,11 @@
  */
 #include <cstring>
 #include <mutex>
+#include <rte_eal.h>
+#include <rte_errno.h>
 #include <rte_ethdev.h>
 #include <rte_version.h>
 #include <unistd.h>
-#include <rte_eal.h>
-#include <rte_errno.h>
 
 #include "dpdk-ring.h"
 #include "parser.hpp"
@@ -41,9 +41,9 @@ __attribute__((constructor)) static void register_this_plugin()
     register_plugin(&rec);
 }
 
-DpdkRingCore *DpdkRingCore::m_instance = nullptr;
+DpdkRingCore* DpdkRingCore::m_instance = nullptr;
 
-DpdkRingCore &DpdkRingCore::getInstance()
+DpdkRingCore& DpdkRingCore::getInstance()
 {
     if (!m_instance) {
         m_instance = new DpdkRingCore();
@@ -65,7 +65,8 @@ void DpdkRingCore::deinit()
     }
 }
 
-void DpdkRingCore::configure(const char* params) {
+void DpdkRingCore::configure(const char* params)
+{
     if (isConfigured) {
         return;
     }
@@ -80,15 +81,15 @@ void DpdkRingCore::configure(const char* params) {
     isConfigured = true;
 }
 
-std::vector<char *> DpdkRingCore::convertStringToArgvFormat(const std::string& ealParams)
+std::vector<char*> DpdkRingCore::convertStringToArgvFormat(const std::string& ealParams)
 {
     // set first value as program name (argv[0])
-    std::vector<char *> args = {"ipfixprobe"};
+    std::vector<char*> args = {"ipfixprobe"};
     std::istringstream iss(ealParams);
     std::string token;
 
-    while(iss >> token) {
-        char *arg = new char[token.size() + 1];
+    while (iss >> token) {
+        char* arg = new char[token.size() + 1];
         copy(token.begin(), token.end(), arg);
         arg[token.size()] = '\0';
         args.push_back(arg);
@@ -98,7 +99,7 @@ std::vector<char *> DpdkRingCore::convertStringToArgvFormat(const std::string& e
 
 void DpdkRingCore::configureEal(const std::string& ealParams)
 {
-    std::vector<char *> args = convertStringToArgvFormat(ealParams);
+    std::vector<char*> args = convertStringToArgvFormat(ealParams);
 
     if (rte_eal_init(args.size(), args.data()) < 0) {
         rte_exit(EXIT_FAILURE, "Cannot initialize RTE_EAL: %s\n", rte_strerror(rte_errno));
@@ -157,7 +158,7 @@ struct timeval DpdkRingReader::getTimestamp(rte_mbuf* mbuf)
     return tv;
 }
 
-InputPlugin::Result DpdkRingReader::get(PacketBlock& packets) 
+InputPlugin::Result DpdkRingReader::get(PacketBlock& packets)
 {
     while (is_reader_ready == false) {
         usleep(1000);
@@ -178,7 +179,8 @@ InputPlugin::Result DpdkRingReader::get(PacketBlock& packets)
         return Result::TIMEOUT;
     }
     for (auto i = 0; i < pkts_read_; i++) {
-        parse_packet(&opt,
+        parse_packet(
+            &opt,
             getTimestamp(mbufs_[i]),
             rte_pktmbuf_mtod(mbufs_[i], const std::uint8_t*),
             rte_pktmbuf_data_len(mbufs_[i]),

--- a/input/dpdk/dpdkDevice.cpp
+++ b/input/dpdk/dpdkDevice.cpp
@@ -36,250 +36,250 @@
 namespace ipxp {
 
 DpdkDevice::DpdkDevice(
-	uint16_t portID,
-	uint16_t rxQueueCount,
-	uint16_t memPoolSize,
-	uint16_t mbufsCount)
-	: m_portID(portID)
-	, m_rxQueueCount(rxQueueCount)
-	, m_txQueueCount(0)
-	, m_mBufsCount(mbufsCount)
-	, m_isNfbDpdkDriver(false)
-	, m_supportedRSS(false)
-	, m_supportedHWTimestamp(false)
+    uint16_t portID,
+    uint16_t rxQueueCount,
+    uint16_t memPoolSize,
+    uint16_t mbufsCount)
+    : m_portID(portID)
+    , m_rxQueueCount(rxQueueCount)
+    , m_txQueueCount(0)
+    , m_mBufsCount(mbufsCount)
+    , m_isNfbDpdkDriver(false)
+    , m_supportedRSS(false)
+    , m_supportedHWTimestamp(false)
 {
-	validatePort();
-	recognizeDriver();
-	configurePort();
-	initMemPools(memPoolSize);
-	setupRxQueues();
-	configureRSS();
-	enablePort();
+    validatePort();
+    recognizeDriver();
+    configurePort();
+    initMemPools(memPoolSize);
+    setupRxQueues();
+    configureRSS();
+    enablePort();
 }
 
 DpdkDevice::~DpdkDevice()
 {
-	rte_eth_dev_stop(m_portID);
-	rte_eth_dev_close(m_portID);
+    rte_eth_dev_stop(m_portID);
+    rte_eth_dev_close(m_portID);
 }
 
 void DpdkDevice::validatePort()
 {
-	if (!rte_eth_dev_is_valid_port(m_portID)) {
-		throw PluginError(
-			"DpdkDevice::validatePort() has failed. Invalid DPDK port [" + std::to_string(m_portID)
-			+ "] specified");
-	}
+    if (!rte_eth_dev_is_valid_port(m_portID)) {
+        throw PluginError(
+            "DpdkDevice::validatePort() has failed. Invalid DPDK port [" + std::to_string(m_portID)
+            + "] specified");
+    }
 }
 
 void DpdkDevice::recognizeDriver()
 {
-	rte_eth_dev_info rteDevInfo;
-	if (rte_eth_dev_info_get(m_portID, &rteDevInfo)) {
-		throw PluginError("DpdkDevice::recognizeDriver() has failed. Unable to get rte dev info");
-	}
+    rte_eth_dev_info rteDevInfo;
+    if (rte_eth_dev_info_get(m_portID, &rteDevInfo)) {
+        throw PluginError("DpdkDevice::recognizeDriver() has failed. Unable to get rte dev info");
+    }
 
-	if (std::strcmp(rteDevInfo.driver_name, "net_nfb") == 0) {
-		m_isNfbDpdkDriver = true;
-		registerRxTimestamp();
-		setRxTimestampDynflag();
-	}
+    if (std::strcmp(rteDevInfo.driver_name, "net_nfb") == 0) {
+        m_isNfbDpdkDriver = true;
+        registerRxTimestamp();
+        setRxTimestampDynflag();
+    }
 
-	std::cerr << "Capabilities of the port " << m_portID << " with driver "
-			  << rteDevInfo.driver_name << ":" << std::endl;
-	std::cerr << "\tRX offload: " << rteDevInfo.rx_offload_capa << std::endl;
-	std::cerr << "\tflow type RSS offloads: " << rteDevInfo.flow_type_rss_offloads << std::endl;
+    std::cerr << "Capabilities of the port " << m_portID << " with driver "
+              << rteDevInfo.driver_name << ":" << std::endl;
+    std::cerr << "\tRX offload: " << rteDevInfo.rx_offload_capa << std::endl;
+    std::cerr << "\tflow type RSS offloads: " << rteDevInfo.flow_type_rss_offloads << std::endl;
 
-	/* Check if RSS hashing is supported in NIC */
-	m_supportedRSS = (rteDevInfo.flow_type_rss_offloads & RTE_ETH_RSS_IP) != 0;
-	std::cerr << "\tDetected RSS offload capability: " << (m_supportedRSS ? "yes" : "no")
-			  << std::endl;
+    /* Check if RSS hashing is supported in NIC */
+    m_supportedRSS = (rteDevInfo.flow_type_rss_offloads & RTE_ETH_RSS_IP) != 0;
+    std::cerr << "\tDetected RSS offload capability: " << (m_supportedRSS ? "yes" : "no")
+              << std::endl;
 
-	/* Check if HW timestamps are supported, we support NFB cards only */
-	if (m_isNfbDpdkDriver) {
-		m_supportedHWTimestamp = (rteDevInfo.rx_offload_capa & RTE_ETH_RX_OFFLOAD_TIMESTAMP) != 0;
-	} else {
-		m_supportedHWTimestamp = false;
-	}
-	std::cerr << "\tDetected HW timestamp capability: " << (m_supportedHWTimestamp ? "yes" : "no")
-			  << std::endl;
+    /* Check if HW timestamps are supported, we support NFB cards only */
+    if (m_isNfbDpdkDriver) {
+        m_supportedHWTimestamp = (rteDevInfo.rx_offload_capa & RTE_ETH_RX_OFFLOAD_TIMESTAMP) != 0;
+    } else {
+        m_supportedHWTimestamp = false;
+    }
+    std::cerr << "\tDetected HW timestamp capability: " << (m_supportedHWTimestamp ? "yes" : "no")
+              << std::endl;
 }
 
 void DpdkDevice::registerRxTimestamp()
 {
-	if (rte_mbuf_dyn_rx_timestamp_register(&m_rxTimestampOffset, NULL)) {
-		throw PluginError(
-			"DpdkDevice::registerRxTimestamp() has failed. Unable to get Rx timestamp offset");
-	}
+    if (rte_mbuf_dyn_rx_timestamp_register(&m_rxTimestampOffset, NULL)) {
+        throw PluginError(
+            "DpdkDevice::registerRxTimestamp() has failed. Unable to get Rx timestamp offset");
+    }
 }
 
 void DpdkDevice::setRxTimestampDynflag()
 {
-	m_rxTimestampDynflag
-		= RTE_BIT64(rte_mbuf_dynflag_lookup(RTE_MBUF_DYNFLAG_RX_TIMESTAMP_NAME, NULL));
+    m_rxTimestampDynflag
+        = RTE_BIT64(rte_mbuf_dynflag_lookup(RTE_MBUF_DYNFLAG_RX_TIMESTAMP_NAME, NULL));
 }
 
 void DpdkDevice::configurePort()
 {
-	auto portConfig = createPortConfig();
-	if (rte_eth_dev_configure(m_portID, m_rxQueueCount, m_txQueueCount, &portConfig)) {
-		throw PluginError("DpdkDevice::configurePort() has failed. Unable to configure interface");
-	}
+    auto portConfig = createPortConfig();
+    if (rte_eth_dev_configure(m_portID, m_rxQueueCount, m_txQueueCount, &portConfig)) {
+        throw PluginError("DpdkDevice::configurePort() has failed. Unable to configure interface");
+    }
 }
 
 rte_eth_conf DpdkDevice::createPortConfig()
 {
-	if (m_rxQueueCount > 1 && !m_supportedRSS) {
-		std::cerr << "RSS is not supported by card, multiple queues will not work as expected."
-				  << std::endl;
-		throw PluginError(
-			"DpdkDevice::createPortConfig() has failed. Required RSS for q>1 is not supported.");
-	}
+    if (m_rxQueueCount > 1 && !m_supportedRSS) {
+        std::cerr << "RSS is not supported by card, multiple queues will not work as expected."
+                  << std::endl;
+        throw PluginError(
+            "DpdkDevice::createPortConfig() has failed. Required RSS for q>1 is not supported.");
+    }
 
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
-	rte_eth_conf portConfig {.rxmode = {.mtu = RTE_ETHER_MAX_LEN}};
+    rte_eth_conf portConfig {.rxmode = {.mtu = RTE_ETHER_MAX_LEN}};
 #else
-	rte_eth_conf portConfig {.rxmode = {.max_rx_pkt_len = RTE_ETHER_MAX_LEN}};
+    rte_eth_conf portConfig {.rxmode = {.max_rx_pkt_len = RTE_ETHER_MAX_LEN}};
 #endif
 
-	if (m_supportedRSS) {
+    if (m_supportedRSS) {
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
-		portConfig.rxmode.mq_mode = RTE_ETH_MQ_RX_RSS;
+        portConfig.rxmode.mq_mode = RTE_ETH_MQ_RX_RSS;
 #else
-		portConfig.rxmode.mq_mode = ETH_MQ_RX_RSS;
+        portConfig.rxmode.mq_mode = ETH_MQ_RX_RSS;
 #endif
-	} else {
-		portConfig.rxmode.mq_mode = RTE_ETH_MQ_RX_NONE;
-	}
+    } else {
+        portConfig.rxmode.mq_mode = RTE_ETH_MQ_RX_NONE;
+    }
 
-	if (m_supportedHWTimestamp) {
-		portConfig.rxmode.offloads |= RTE_ETH_RX_OFFLOAD_TIMESTAMP;
-	}
-	return portConfig;
+    if (m_supportedHWTimestamp) {
+        portConfig.rxmode.offloads |= RTE_ETH_RX_OFFLOAD_TIMESTAMP;
+    }
+    return portConfig;
 }
 
 void DpdkDevice::initMemPools(uint16_t memPoolSize)
 {
-	constexpr int MEMPOOL_CACHE_SIZE = 256;
+    constexpr int MEMPOOL_CACHE_SIZE = 256;
 
-	m_memPools.reserve(m_rxQueueCount);
+    m_memPools.reserve(m_rxQueueCount);
 
-	for (uint16_t rxQueueID = 0; rxQueueID < m_rxQueueCount; rxQueueID++) {
-		std::string memPoolName
-			= "mbuf_pool_" + std::to_string(m_portID) + "_" + std::to_string(rxQueueID);
-		rte_mempool* memPool = rte_pktmbuf_pool_create(
-			memPoolName.c_str(),
-			memPoolSize,
-			MEMPOOL_CACHE_SIZE,
-			0,
-			RTE_MBUF_DEFAULT_BUF_SIZE,
-			rte_lcore_to_socket_id(rxQueueID));
-		if (!memPool) {
-			throw PluginError(
-				"DpdkDevice::initMemPool() has failed. Failed to create packets memory pool for "
-				"port "
-				+ std::to_string(m_portID) + ", pool name: " + memPoolName + ". Error was: '"
-				+ std::string(rte_strerror(rte_errno))
-				+ "' [Error code: " + std::to_string(rte_errno) + "]");
-		}
+    for (uint16_t rxQueueID = 0; rxQueueID < m_rxQueueCount; rxQueueID++) {
+        std::string memPoolName
+            = "mbuf_pool_" + std::to_string(m_portID) + "_" + std::to_string(rxQueueID);
+        rte_mempool* memPool = rte_pktmbuf_pool_create(
+            memPoolName.c_str(),
+            memPoolSize,
+            MEMPOOL_CACHE_SIZE,
+            0,
+            RTE_MBUF_DEFAULT_BUF_SIZE,
+            rte_lcore_to_socket_id(rxQueueID));
+        if (!memPool) {
+            throw PluginError(
+                "DpdkDevice::initMemPool() has failed. Failed to create packets memory pool for "
+                "port "
+                + std::to_string(m_portID) + ", pool name: " + memPoolName + ". Error was: '"
+                + std::string(rte_strerror(rte_errno))
+                + "' [Error code: " + std::to_string(rte_errno) + "]");
+        }
 
-		m_memPools.emplace_back(memPool);
-	}
+        m_memPools.emplace_back(memPool);
+    }
 }
 
 void DpdkDevice::setupRxQueues()
 {
-	for (uint16_t rxQueueID = 0; rxQueueID < m_rxQueueCount; rxQueueID++) {
-		int ret = rte_eth_rx_queue_setup(
-			m_portID,
-			rxQueueID,
-			m_mBufsCount,
-			rte_eth_dev_socket_id(m_portID),
-			nullptr,
-			m_memPools[rxQueueID]);
-		if (ret < 0) {
-			throw PluginError(
-				"DpdkDevice::setupRxQueues() has failed. Failed to set up RX queue(s) for port "
-				+ std::to_string(m_portID));
-		}
-	}
+    for (uint16_t rxQueueID = 0; rxQueueID < m_rxQueueCount; rxQueueID++) {
+        int ret = rte_eth_rx_queue_setup(
+            m_portID,
+            rxQueueID,
+            m_mBufsCount,
+            rte_eth_dev_socket_id(m_portID),
+            nullptr,
+            m_memPools[rxQueueID]);
+        if (ret < 0) {
+            throw PluginError(
+                "DpdkDevice::setupRxQueues() has failed. Failed to set up RX queue(s) for port "
+                + std::to_string(m_portID));
+        }
+    }
 }
 
 void DpdkDevice::configureRSS()
 {
-	if (!m_supportedRSS) {
-		std::cerr << "Skipped RSS hash setting for port " << m_portID << "." << std::endl;
-		return;
-	}
+    if (!m_supportedRSS) {
+        std::cerr << "Skipped RSS hash setting for port " << m_portID << "." << std::endl;
+        return;
+    }
 
-	constexpr size_t RSS_KEY_LEN = 40;
-	// biflow hash key
-	static uint8_t rssKey[RSS_KEY_LEN]
-		= {0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
-		   0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
-		   0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A};
+    constexpr size_t RSS_KEY_LEN = 40;
+    // biflow hash key
+    static uint8_t rssKey[RSS_KEY_LEN]
+        = {0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
+           0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
+           0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A};
 
-	struct rte_eth_rss_conf rssConfig
-		= {.rss_key = rssKey,
-		   .rss_key_len = RSS_KEY_LEN,
+    struct rte_eth_rss_conf rssConfig
+        = {.rss_key = rssKey,
+           .rss_key_len = RSS_KEY_LEN,
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
-		   .rss_hf = RTE_ETH_RSS_IP,
+           .rss_hf = RTE_ETH_RSS_IP,
 #else
-		   .rss_hf = ETH_RSS_IP,
+           .rss_hf = ETH_RSS_IP,
 #endif
-		  };
+          };
 
-	if (rte_eth_dev_rss_hash_update(m_portID, &rssConfig)) {
-		std::cerr << "Setting RSS hash for port " << m_portID << "." << std::endl;
-	}
+    if (rte_eth_dev_rss_hash_update(m_portID, &rssConfig)) {
+        std::cerr << "Setting RSS hash for port " << m_portID << "." << std::endl;
+    }
 }
 
 void DpdkDevice::enablePort()
 {
-	if (rte_eth_dev_start(m_portID) < 0) {
-		throw PluginError("DpdkDevice::enablePort() has failed. Failed to start DPDK port");
-	}
+    if (rte_eth_dev_start(m_portID) < 0) {
+        throw PluginError("DpdkDevice::enablePort() has failed. Failed to start DPDK port");
+    }
 
-	if (rte_eth_promiscuous_enable(m_portID)) {
-		throw PluginError("DpdkDevice::enablePort() has failed. Failed to set promiscuous mode");
-	}
+    if (rte_eth_promiscuous_enable(m_portID)) {
+        throw PluginError("DpdkDevice::enablePort() has failed. Failed to set promiscuous mode");
+    }
 
-	std::cerr << "DPDK input at port " << m_portID << " started." << std::endl;
+    std::cerr << "DPDK input at port " << m_portID << " started." << std::endl;
 }
 
 uint16_t DpdkDevice::receive(DpdkMbuf& dpdkMuf, uint16_t rxQueueID)
 {
-	dpdkMuf.releaseMbufs();
-	uint16_t receivedPackets
-		= rte_eth_rx_burst(m_portID, rxQueueID, dpdkMuf.data(), dpdkMuf.maxSize());
-	dpdkMuf.setMbufsInUse(receivedPackets);
-	return receivedPackets;
+    dpdkMuf.releaseMbufs();
+    uint16_t receivedPackets
+        = rte_eth_rx_burst(m_portID, rxQueueID, dpdkMuf.data(), dpdkMuf.maxSize());
+    dpdkMuf.setMbufsInUse(receivedPackets);
+    return receivedPackets;
 }
 
 timeval DpdkDevice::getPacketTimestamp(rte_mbuf* mbuf)
 {
-	timeval tv;
-	if (m_isNfbDpdkDriver && (mbuf->ol_flags & m_rxTimestampDynflag)) {
-		static constexpr time_t nanosecInSec = 1000000000;
-		static constexpr time_t nsecInUsec = 1000;
+    timeval tv;
+    if (m_isNfbDpdkDriver && (mbuf->ol_flags & m_rxTimestampDynflag)) {
+        static constexpr time_t nanosecInSec = 1000000000;
+        static constexpr time_t nsecInUsec = 1000;
 
-		rte_mbuf_timestamp_t timestamp
-			= *RTE_MBUF_DYNFIELD(mbuf, m_rxTimestampOffset, rte_mbuf_timestamp_t*);
-		tv.tv_sec = timestamp / nanosecInSec;
-		tv.tv_usec = (timestamp - ((tv.tv_sec) * nanosecInSec)) / nsecInUsec;
+        rte_mbuf_timestamp_t timestamp
+            = *RTE_MBUF_DYNFIELD(mbuf, m_rxTimestampOffset, rte_mbuf_timestamp_t*);
+        tv.tv_sec = timestamp / nanosecInSec;
+        tv.tv_usec = (timestamp - ((tv.tv_sec) * nanosecInSec)) / nsecInUsec;
 
-		return tv;
-	} else {
-		auto now = std::chrono::system_clock::now();
-		auto now_t = std::chrono::system_clock::to_time_t(now);
+        return tv;
+    } else {
+        auto now = std::chrono::system_clock::now();
+        auto now_t = std::chrono::system_clock::to_time_t(now);
 
-		auto dur = now - std::chrono::system_clock::from_time_t(now_t);
-		auto micros = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+        auto dur = now - std::chrono::system_clock::from_time_t(now_t);
+        auto micros = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
 
-		tv.tv_sec = now_t;
-		tv.tv_usec = micros;
-		return tv;
-	}
+        tv.tv_sec = now_t;
+        tv.tv_usec = micros;
+        return tv;
+    }
 }
 
 } // namespace ipxp

--- a/input/dpdk/dpdkDevice.hpp
+++ b/input/dpdk/dpdkDevice.hpp
@@ -39,60 +39,59 @@ namespace ipxp {
  */
 class DpdkDevice {
 public:
-	/**
-	 * @brief Constructs a DpdkDevice object with the specified parameters.
-	 * @param portID The ID of the DPDK port to be used.
-	 * @param rxQueueCount The number of receive queues to be configured.
-	 * @param memPoolSize The size of the memory pool for packet buffers.
-	 * @param mbufsCount The number of mbufs (packet buffers) to be allocated.
-	 */
-	DpdkDevice(uint16_t portID, uint16_t rxQueueCount, uint16_t memPoolSize, uint16_t mbufsCount);
+    /**
+     * @brief Constructs a DpdkDevice object with the specified parameters.
+     * @param portID The ID of the DPDK port to be used.
+     * @param rxQueueCount The number of receive queues to be configured.
+     * @param memPoolSize The size of the memory pool for packet buffers.
+     * @param mbufsCount The number of mbufs (packet buffers) to be allocated.
+     */
+    DpdkDevice(uint16_t portID, uint16_t rxQueueCount, uint16_t memPoolSize, uint16_t mbufsCount);
 
-	/**
-	 * @brief Receives packets from the specified receive queue of the DPDK device.
-	 * @param dpdkMuf A reference to a DpdkMbuf object to store the received packets.
-	 * @param rxQueueID The ID of the receive queue from which to receive packets.
-	 * @return The number of packets received.
-	 */
-	uint16_t receive(DpdkMbuf& dpdkMuf, uint16_t rxQueueID);
+    /**
+     * @brief Receives packets from the specified receive queue of the DPDK device.
+     * @param dpdkMuf A reference to a DpdkMbuf object to store the received packets.
+     * @param rxQueueID The ID of the receive queue from which to receive packets.
+     * @return The number of packets received.
+     */
+    uint16_t receive(DpdkMbuf& dpdkMuf, uint16_t rxQueueID);
 
-	/**
-	 * @brief Retrieves the packet timestamp from the given mbuf.
-	 * @param mbuf The rte_mbuf structure representing the received packet.
-	 * @return The timestamp of the packet.
-	 */
-	timeval getPacketTimestamp(rte_mbuf* mbuf);
+    /**
+     * @brief Retrieves the packet timestamp from the given mbuf.
+     * @param mbuf The rte_mbuf structure representing the received packet.
+     * @return The timestamp of the packet.
+     */
+    timeval getPacketTimestamp(rte_mbuf* mbuf);
 
-	/**
-	 * @brief Destructs the DpdkDevice object.
-	 *        Stops and closes the DPDK port associated with the device.
-	 */
-	~DpdkDevice();
+    /**
+     * @brief Destructs the DpdkDevice object.
+     *        Stops and closes the DPDK port associated with the device.
+     */
+    ~DpdkDevice();
 
 private:
-	void validatePort();
-	void recognizeDriver();
-	void configurePort();
-	rte_eth_conf createPortConfig();
-	void initMemPools(uint16_t memPoolSize);
-	void setupRxQueues();
-	void configureRSS();
-	void enablePort();
-	void createRteMempool(uint16_t mempoolSize);
-	void setRxTimestampDynflag();
-	void registerRxTimestamp();
+    void validatePort();
+    void recognizeDriver();
+    void configurePort();
+    rte_eth_conf createPortConfig();
+    void initMemPools(uint16_t memPoolSize);
+    void setupRxQueues();
+    void configureRSS();
+    void enablePort();
+    void createRteMempool(uint16_t mempoolSize);
+    void setRxTimestampDynflag();
+    void registerRxTimestamp();
 
-	std::vector<rte_mempool*> m_memPools;
+    std::vector<rte_mempool*> m_memPools;
     uint16_t m_portID;
-	uint16_t m_rxQueueCount;
-	uint16_t m_txQueueCount;
-	uint16_t m_mBufsCount;
-	bool m_isNfbDpdkDriver;
-	bool m_supportedRSS;
-	bool m_supportedHWTimestamp;
-	int m_rxTimestampOffset;
-	int m_rxTimestampDynflag;
-
+    uint16_t m_rxQueueCount;
+    uint16_t m_txQueueCount;
+    uint16_t m_mBufsCount;
+    bool m_isNfbDpdkDriver;
+    bool m_supportedRSS;
+    bool m_supportedHWTimestamp;
+    int m_rxTimestampOffset;
+    int m_rxTimestampDynflag;
 };
 
 } // namespace ipxp

--- a/input/dpdk/dpdkMbuf.cpp
+++ b/input/dpdk/dpdkMbuf.cpp
@@ -28,50 +28,50 @@
 namespace ipxp {
 
 DpdkMbuf::DpdkMbuf(size_t mBufsCount)
-	: m_mBufsCount(mBufsCount)
-	, m_mBufsInUse(0)
+    : m_mBufsCount(mBufsCount)
+    , m_mBufsInUse(0)
 {
-	m_mBufs.resize(mBufsCount);
+    m_mBufs.resize(mBufsCount);
 }
 
 void DpdkMbuf::resize(size_t mBufsCount)
 {
-	releaseMbufs();
-	m_mBufs.resize(mBufsCount);
-	m_mBufsCount = mBufsCount;
+    releaseMbufs();
+    m_mBufs.resize(mBufsCount);
+    m_mBufsCount = mBufsCount;
 }
 
 void DpdkMbuf::setMbufsInUse(size_t mBufsInUse) noexcept
 {
-	m_mBufsInUse = mBufsInUse;
+    m_mBufsInUse = mBufsInUse;
 }
 
 DpdkMbuf::~DpdkMbuf()
 {
-	releaseMbufs();
+    releaseMbufs();
 }
 
 uint16_t DpdkMbuf::maxSize() const noexcept
 {
-	return m_mBufsCount;
+    return m_mBufsCount;
 }
 
 uint16_t DpdkMbuf::size() const noexcept
 {
-	return m_mBufsInUse;
+    return m_mBufsInUse;
 }
 
 rte_mbuf** DpdkMbuf::data()
 {
-	return m_mBufs.data();
+    return m_mBufs.data();
 }
 
 void DpdkMbuf::releaseMbufs()
 {
-	for (auto mBufID = 0; mBufID < m_mBufsInUse; mBufID++) {
-		rte_pktmbuf_free(m_mBufs[mBufID]);
-	}
-	m_mBufsInUse = 0;
+    for (auto mBufID = 0; mBufID < m_mBufsInUse; mBufID++) {
+        rte_pktmbuf_free(m_mBufs[mBufID]);
+    }
+    m_mBufsInUse = 0;
 }
 
 } // namespace ipxp

--- a/input/dpdk/dpdkMbuf.hpp
+++ b/input/dpdk/dpdkMbuf.hpp
@@ -36,65 +36,64 @@ namespace ipxp {
  */
 class DpdkMbuf {
 public:
-
-	/**
+    /**
      * @brief Constructs a DpdkMbuf object.
      * @param mBufsCount The initial size of the mbufs vector.
      */
-	DpdkMbuf(size_t mBufsCount = 0);
+    DpdkMbuf(size_t mBufsCount = 0);
 
-	/**
+    /**
      * @brief Releases the allocated mbufs.
      */
-	~DpdkMbuf();
+    ~DpdkMbuf();
 
-	/**
+    /**
      * @brief Resizes the mbufs vector.
      * @param mBufsCount The new size of the mbufs vector.
      */
-	void resize(size_t mBufsCount);
+    void resize(size_t mBufsCount);
 
-	/**
+    /**
      * @brief Sets the number of mbufs in use.
      * @param mBufsInUse The number of mbufs currently in use.
      */
-	void setMbufsInUse(size_t mBufsInUse) noexcept;
+    void setMbufsInUse(size_t mBufsInUse) noexcept;
 
-	/**
+    /**
      * @brief Returns the maximum size (currently allocated) of the mbufs vector.
      * @return The maximum size of the mbufs vector.
      */
-	uint16_t maxSize() const noexcept;
+    uint16_t maxSize() const noexcept;
 
-	/**
+    /**
      * @brief Returns the current size of the mbufs vector. (in use)
      * @return The current size of the mbufs vector.
      */
-	uint16_t size() const noexcept;
+    uint16_t size() const noexcept;
 
-	/**
+    /**
      * @brief Returns a pointer to the underlying mbufs data.
      * @return A pointer to the underlying mbufs data.
      */
-	rte_mbuf** data();
+    rte_mbuf** data();
 
-	/**
+    /**
      * @brief Releases all the mbufs.
-	 * @note Function calls rte_pktmbuf_free()
+     * @note Function calls rte_pktmbuf_free()
      */
-	void releaseMbufs();
+    void releaseMbufs();
 
-	/**
+    /**
      * @brief Overloaded subscript operator to access mbufs by index.
      * @param index The index of the mbuf to access.
      * @return The mbuf at the specified index.
      */
-	rte_mbuf* operator[](int index) { return m_mBufs[index]; }
+    rte_mbuf* operator[](int index) { return m_mBufs[index]; }
 
 private:
-	std::vector<rte_mbuf*> m_mBufs;
-	uint16_t m_mBufsCount;
-	uint16_t m_mBufsInUse;
+    std::vector<rte_mbuf*> m_mBufs;
+    uint16_t m_mBufsCount;
+    uint16_t m_mBufsInUse;
 };
 
 } // namespace ipxp

--- a/input/headers.hpp
+++ b/input/headers.hpp
@@ -29,14 +29,14 @@
 #ifndef IPXP_INPUT_HEADERS_HPP
 #define IPXP_INPUT_HEADERS_HPP
 
-#include <netinet/in.h>
 #include <endian.h>
+#include <netinet/in.h>
 
-#define ETH_P_8021AD  0x88A8
-#define ETH_P_8021AH  0x88E7
-#define ETH_P_8021Q   0x8100
-#define ETH_P_IP      0x0800
-#define ETH_P_IPV6    0x86DD
+#define ETH_P_8021AD 0x88A8
+#define ETH_P_8021AH 0x88E7
+#define ETH_P_8021Q 0x8100
+#define ETH_P_IP 0x0800
+#define ETH_P_IPV6 0x86DD
 #define ETH_P_MPLS_UC 0x8847
 #define ETH_P_MPLS_MC 0x8848
 #define ETH_P_PPP_SES 0x8864
@@ -47,234 +47,214 @@
 namespace ipxp {
 
 struct grehdr {
-   uint16_t flags;
+    uint16_t flags;
 #define GRE_CHECKSUM 0x8000
-#define GRE_KEY      0x2000
-#define GRE_SEQNUM   0x1000
-   uint16_t type;
+#define GRE_KEY 0x2000
+#define GRE_SEQNUM 0x1000
+    uint16_t type;
 };
 
 // Copied protocol headers from netinet/* files, which may not be present on other platforms
 
 struct ethhdr {
-   unsigned char  h_dest[ETH_ALEN]; /* destination eth addr */
-   unsigned char  h_source[ETH_ALEN];  /* source ether addr */
-   uint16_t      h_proto;    /* packet type ID field */
+    unsigned char h_dest[ETH_ALEN]; /* destination eth addr */
+    unsigned char h_source[ETH_ALEN]; /* source ether addr */
+    uint16_t h_proto; /* packet type ID field */
 } __attribute__((packed));
 
-struct iphdr
-{
+struct iphdr {
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-   unsigned int ihl:4;
-   unsigned int version:4;
+    unsigned int ihl : 4;
+    unsigned int version : 4;
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-   unsigned int version:4;
-   unsigned int ihl:4;
+    unsigned int version : 4;
+    unsigned int ihl : 4;
 #else
-# error  "Please fix <endian.h>"
+#error "Please fix <endian.h>"
 #endif
-   uint8_t tos;
-   uint16_t tot_len;
-   uint16_t id;
-   uint16_t frag_off;
-   uint8_t ttl;
-   uint8_t protocol;
-   uint16_t check;
-   uint32_t saddr;
-   uint32_t daddr;
-   /*The options start here. */
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t saddr;
+    uint32_t daddr;
+    /*The options start here. */
 };
 
-struct ip6_hdr
-{
-   union
-   {
-      struct ip6_hdrctl
-      {
-         uint32_t ip6_un1_flow;   /* 4 bits version, 8 bits TC,
-                                     20 bits flow-ID */
-         uint16_t ip6_un1_plen;   /* payload length */
-         uint8_t  ip6_un1_nxt;    /* next header */
-         uint8_t  ip6_un1_hlim;   /* hop limit */
-      } ip6_un1;
-      uint8_t ip6_un2_vfc;       /* 4 bits version, top 4 bits tclass */
-   } ip6_ctlun;
-   struct in6_addr ip6_src;      /* source address */
-   struct in6_addr ip6_dst;      /* destination address */
+struct ip6_hdr {
+    union {
+        struct ip6_hdrctl {
+            uint32_t ip6_un1_flow; /* 4 bits version, 8 bits TC,
+                                      20 bits flow-ID */
+            uint16_t ip6_un1_plen; /* payload length */
+            uint8_t ip6_un1_nxt; /* next header */
+            uint8_t ip6_un1_hlim; /* hop limit */
+        } ip6_un1;
+        uint8_t ip6_un2_vfc; /* 4 bits version, top 4 bits tclass */
+    } ip6_ctlun;
+    struct in6_addr ip6_src; /* source address */
+    struct in6_addr ip6_dst; /* destination address */
 };
 
-struct ip6_ext
-{
-   uint8_t  ip6e_nxt;     /* next header.  */
-   uint8_t  ip6e_len;     /* length in units of 8 octets.  */
+struct ip6_ext {
+    uint8_t ip6e_nxt; /* next header.  */
+    uint8_t ip6e_len; /* length in units of 8 octets.  */
 };
 
-struct ip6_rthdr
-{
-   uint8_t  ip6r_nxt;     /* next header */
-   uint8_t  ip6r_len;     /* length in units of 8 octets */
-   uint8_t  ip6r_type;    /* routing type */
-   uint8_t  ip6r_segleft; /* segments left */
-   /* followed by routing type specific data */
+struct ip6_rthdr {
+    uint8_t ip6r_nxt; /* next header */
+    uint8_t ip6r_len; /* length in units of 8 octets */
+    uint8_t ip6r_type; /* routing type */
+    uint8_t ip6r_segleft; /* segments left */
+    /* followed by routing type specific data */
 };
 
-struct tcphdr
-{
-   __extension__ union
-   {
-      struct
-      {
-         uint16_t th_sport;   /* source port */
-         uint16_t th_dport;   /* destination port */
-         uint32_t th_seq;      /* sequence number */
-         uint32_t th_ack;      /* acknowledgement number */
+struct tcphdr {
+    __extension__ union {
+        struct {
+            uint16_t th_sport; /* source port */
+            uint16_t th_dport; /* destination port */
+            uint32_t th_seq; /* sequence number */
+            uint32_t th_ack; /* acknowledgement number */
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-         uint8_t th_x2:4;  /* (unused) */
-         uint8_t th_off:4; /* data offset */
+            uint8_t th_x2 : 4; /* (unused) */
+            uint8_t th_off : 4; /* data offset */
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-         uint8_t th_off:4; /* data offset */
-         uint8_t th_x2:4;  /* (unused) */
-# else
-#  error  "Please fix <endian.h>"
-# endif
-         uint8_t th_flags;
-# define TH_FIN   0x01
-# define TH_SYN   0x02
-# define TH_RST   0x04
-# define TH_PUSH  0x08
-# define TH_ACK   0x10
-# define TH_URG   0x20
-         uint16_t th_win;  /* window */
-         uint16_t th_sum;  /* checksum */
-         uint16_t th_urp;  /* urgent pointer */
-      };
-      struct
-      {
-         uint16_t source;
-         uint16_t dest;
-         uint32_t seq;
-         uint32_t ack_seq;
+            uint8_t th_off : 4; /* data offset */
+            uint8_t th_x2 : 4; /* (unused) */
+#else
+#error "Please fix <endian.h>"
+#endif
+            uint8_t th_flags;
+#define TH_FIN 0x01
+#define TH_SYN 0x02
+#define TH_RST 0x04
+#define TH_PUSH 0x08
+#define TH_ACK 0x10
+#define TH_URG 0x20
+            uint16_t th_win; /* window */
+            uint16_t th_sum; /* checksum */
+            uint16_t th_urp; /* urgent pointer */
+        };
+        struct {
+            uint16_t source;
+            uint16_t dest;
+            uint32_t seq;
+            uint32_t ack_seq;
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-         uint16_t res1:4;
-         uint16_t doff:4;
-         uint16_t fin:1;
-         uint16_t syn:1;
-         uint16_t rst:1;
-         uint16_t psh:1;
-         uint16_t ack:1;
-         uint16_t urg:1;
-         uint16_t res2:2;
+            uint16_t res1 : 4;
+            uint16_t doff : 4;
+            uint16_t fin : 1;
+            uint16_t syn : 1;
+            uint16_t rst : 1;
+            uint16_t psh : 1;
+            uint16_t ack : 1;
+            uint16_t urg : 1;
+            uint16_t res2 : 2;
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-         uint16_t doff:4;
-         uint16_t res1:4;
-         uint16_t res2:2;
-         uint16_t urg:1;
-         uint16_t ack:1;
-         uint16_t psh:1;
-         uint16_t rst:1;
-         uint16_t syn:1;
-         uint16_t fin:1;
-# else
-#  error "Please fix <endian.h>"
-# endif
-         uint16_t window;
-         uint16_t check;
-         uint16_t urg_ptr;
-      };
-   };
+            uint16_t doff : 4;
+            uint16_t res1 : 4;
+            uint16_t res2 : 2;
+            uint16_t urg : 1;
+            uint16_t ack : 1;
+            uint16_t psh : 1;
+            uint16_t rst : 1;
+            uint16_t syn : 1;
+            uint16_t fin : 1;
+#else
+#error "Please fix <endian.h>"
+#endif
+            uint16_t window;
+            uint16_t check;
+            uint16_t urg_ptr;
+        };
+    };
 };
 
-struct udphdr
-{
-   __extension__ union
-   {
-      struct
-      {
-         uint16_t uh_sport;   /* source port */
-         uint16_t uh_dport;   /* destination port */
-         uint16_t uh_ulen;    /* udp length */
-         uint16_t uh_sum;     /* udp checksum */
-      };
-      struct
-      {
-         uint16_t source;
-         uint16_t dest;
-         uint16_t len;
-         uint16_t check;
-      };
-   };
+struct udphdr {
+    __extension__ union {
+        struct {
+            uint16_t uh_sport; /* source port */
+            uint16_t uh_dport; /* destination port */
+            uint16_t uh_ulen; /* udp length */
+            uint16_t uh_sum; /* udp checksum */
+        };
+        struct {
+            uint16_t source;
+            uint16_t dest;
+            uint16_t len;
+            uint16_t check;
+        };
+    };
 };
 
-struct icmphdr
-{
-   uint8_t type;      /* message type */
-   uint8_t code;      /* type sub-code */
-   uint16_t checksum;
-   union
-   {
-      struct
-      {
-         uint16_t id;
-         uint16_t sequence;
-      } echo;       /* echo datagram */
-      uint32_t   gateway; /* gateway address */
-      struct
-      {
-         uint16_t __glibc_reserved;
-         uint16_t mtu;
-      } frag;       /* path mtu discovery */
-   } un;
+struct icmphdr {
+    uint8_t type; /* message type */
+    uint8_t code; /* type sub-code */
+    uint16_t checksum;
+    union {
+        struct {
+            uint16_t id;
+            uint16_t sequence;
+        } echo; /* echo datagram */
+        uint32_t gateway; /* gateway address */
+        struct {
+            uint16_t __glibc_reserved;
+            uint16_t mtu;
+        } frag; /* path mtu discovery */
+    } un;
 };
 
-struct icmp6_hdr
-{
-   uint8_t     icmp6_type;   /* type field */
-   uint8_t     icmp6_code;   /* code field */
-   uint16_t    icmp6_cksum;  /* checksum field */
-   union
-   {
-      uint32_t  icmp6_un_data32[1]; /* type-specific field */
-      uint16_t  icmp6_un_data16[2]; /* type-specific field */
-      uint8_t   icmp6_un_data8[4];  /* type-specific field */
-   } icmp6_dataun;
+struct icmp6_hdr {
+    uint8_t icmp6_type; /* type field */
+    uint8_t icmp6_code; /* code field */
+    uint16_t icmp6_cksum; /* checksum field */
+    union {
+        uint32_t icmp6_un_data32[1]; /* type-specific field */
+        uint16_t icmp6_un_data16[2]; /* type-specific field */
+        uint8_t icmp6_un_data8[4]; /* type-specific field */
+    } icmp6_dataun;
 };
 
 struct __attribute__((packed)) trill_hdr {
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-   uint8_t op_len1:3;
-   uint8_t m:1;
-   uint8_t res:2;
-   uint8_t version:2;
-   uint8_t hop_cnt:6;
-   uint8_t op_len2:2;
+    uint8_t op_len1 : 3;
+    uint8_t m : 1;
+    uint8_t res : 2;
+    uint8_t version : 2;
+    uint8_t hop_cnt : 6;
+    uint8_t op_len2 : 2;
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-   uint8_t version:2;
-   uint8_t res:2;
-   uint8_t m:1;
-   uint8_t op_len1:3;
-   uint8_t op_len2:2;
-   uint8_t hop_cnt:6;
-# else
-#  error  "Please fix <endian.h>"
-# endif
-   uint16_t egress_nick;
-   uint16_t ingress_nick;
+    uint8_t version : 2;
+    uint8_t res : 2;
+    uint8_t m : 1;
+    uint8_t op_len1 : 3;
+    uint8_t op_len2 : 2;
+    uint8_t hop_cnt : 6;
+#else
+#error "Please fix <endian.h>"
+#endif
+    uint16_t egress_nick;
+    uint16_t ingress_nick;
 };
 
 struct __attribute__((packed)) pppoe_hdr {
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-   uint8_t type:4;
-   uint8_t version:4;
+    uint8_t type : 4;
+    uint8_t version : 4;
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-   uint8_t version:4;
-   uint8_t type:4;
-# else
-#  error  "Please fix <endian.h>"
-# endif
-   uint8_t code;
-   uint16_t sid;
-   uint16_t length;
+    uint8_t version : 4;
+    uint8_t type : 4;
+#else
+#error "Please fix <endian.h>"
+#endif
+    uint8_t code;
+    uint16_t sid;
+    uint16_t length;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_HEADERS_HPP */

--- a/input/ndp.hpp
+++ b/input/ndp.hpp
@@ -33,46 +33,70 @@
 #include <ndpreader.hpp>
 
 #include <ipfixprobe/input.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/options.hpp>
+#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
-class NdpOptParser : public OptionsParser
-{
+class NdpOptParser : public OptionsParser {
 public:
-   std::string m_dev;
-   uint64_t m_id;
+    std::string m_dev;
+    uint64_t m_id;
 
-   NdpOptParser() : OptionsParser("ndp", "Input plugin for reading packets from a ndp device"), m_dev(""), m_id(0)
-   {
-      register_option("d", "dev", "PATH", "Path to a device file", [this](const char *arg){m_dev = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("I", "id", "NUM", "Link identifier number",
-         [this](const char *arg){try {m_id = str2num<decltype(m_id)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-   }
+    NdpOptParser()
+        : OptionsParser("ndp", "Input plugin for reading packets from a ndp device")
+        , m_dev("")
+        , m_id(0)
+    {
+        register_option(
+            "d",
+            "dev",
+            "PATH",
+            "Path to a device file",
+            [this](const char* arg) {
+                m_dev = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "I",
+            "id",
+            "NUM",
+            "Link identifier number",
+            [this](const char* arg) {
+                try {
+                    m_id = str2num<decltype(m_id)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+    }
 };
 
-class NdpPacketReader : public InputPlugin
-{
+class NdpPacketReader : public InputPlugin {
 public:
-   NdpPacketReader();
-   ~NdpPacketReader();
+    NdpPacketReader();
+    ~NdpPacketReader();
 
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new NdpOptParser(); }
-   std::string get_name() const { return "ndp"; }
-   InputPlugin::Result get(PacketBlock &packets);
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new NdpOptParser(); }
+    std::string get_name() const { return "ndp"; }
+    InputPlugin::Result get(PacketBlock& packets);
 
 private:
-   NdpReader ndpReader;
+    NdpReader ndpReader;
 
-   void init_ifc(const std::string &dev);
+    void init_ifc(const std::string& dev);
 };
 
-void packet_ndp_handler(Packet *pkt, const struct ndp_packet *ndp_packet, const struct ndp_header *ndp_header);
+void packet_ndp_handler(
+    Packet* pkt,
+    const struct ndp_packet* ndp_packet,
+    const struct ndp_header* ndp_header);
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_NDP_HPP */

--- a/input/nfbCInterface/include/ndpreader.hpp
+++ b/input/nfbCInterface/include/ndpreader.hpp
@@ -1,34 +1,34 @@
 #ifndef NFBREADER_HPP
 #define NFBREADER_HPP
 
+#include "ndpheader.h"
+#include <nfb/ndp.h>
 #include <stdint.h>
 #include <string>
-#include <nfb/ndp.h>
-#include "ndpheader.h"
 
-class NdpReader
-{
+class NdpReader {
 public:
-   NdpReader(uint16_t packet_bufferSize = 50, uint64_t timeout = 300);
-   ~NdpReader();
+    NdpReader(uint16_t packet_bufferSize = 50, uint64_t timeout = 300);
+    ~NdpReader();
 
-   int init_interface(const std::string &interface);
-   void print_stats();
-   void close();
-   int get_pkt(struct ndp_packet **ndp_packet, struct ndp_header **ndp_header);
-   std::string error_msg;
+    int init_interface(const std::string& interface);
+    void print_stats();
+    void close();
+    int get_pkt(struct ndp_packet** ndp_packet, struct ndp_header** ndp_header);
+    std::string error_msg;
+
 private:
-   bool retrieve_ndp_packets();
-   struct nfb_device *dev_handle; // NFB device
-   struct ndp_queue *rx_handle; // data receiving NDP queue
-   uint64_t processed_packets;
-   uint16_t packet_bufferSize;
-   uint64_t timeout;
+    bool retrieve_ndp_packets();
+    struct nfb_device* dev_handle; // NFB device
+    struct ndp_queue* rx_handle; // data receiving NDP queue
+    uint64_t processed_packets;
+    uint16_t packet_bufferSize;
+    uint64_t timeout;
 
-   uint16_t ndp_packet_buffer_processed;
-   uint16_t ndp_packet_buffer_packets;
-   struct ndp_packet *ndp_packet_buffer;
-   bool ndp_packet_buffer_valid;
+    uint16_t ndp_packet_buffer_processed;
+    uint16_t ndp_packet_buffer_packets;
+    struct ndp_packet* ndp_packet_buffer;
+    bool ndp_packet_buffer_valid;
 };
 
-#endif //NFBREADER_HPP
+#endif // NFBREADER_HPP

--- a/input/nfbCInterface/ndpreader.cpp
+++ b/input/nfbCInterface/ndpreader.cpp
@@ -5,20 +5,23 @@
 #include <numa.h>
 #include <unistd.h>
 
-#include "ndpreader.hpp"
 #include "ndpreader.h"
+#include "ndpreader.hpp"
 
 /**
  * \brief Constructor.
  */
-NdpReader::NdpReader(uint16_t packetBufferSize, uint64_t timeout) :
-   dev_handle(nullptr), rx_handle(NULL), processed_packets(0),
-   packet_bufferSize(packetBufferSize), timeout(timeout)
+NdpReader::NdpReader(uint16_t packetBufferSize, uint64_t timeout)
+    : dev_handle(nullptr)
+    , rx_handle(NULL)
+    , processed_packets(0)
+    , packet_bufferSize(packetBufferSize)
+    , timeout(timeout)
 {
-   ndp_packet_buffer = new struct ndp_packet[packet_bufferSize];
-   ndp_packet_buffer_processed = 0;
-   ndp_packet_buffer_packets = 0;
-   ndp_packet_buffer_valid = false;
+    ndp_packet_buffer = new struct ndp_packet[packet_bufferSize];
+    ndp_packet_buffer_processed = 0;
+    ndp_packet_buffer_packets = 0;
+    ndp_packet_buffer_valid = false;
 }
 
 /**
@@ -26,7 +29,7 @@ NdpReader::NdpReader(uint16_t packetBufferSize, uint64_t timeout) :
  */
 NdpReader::~NdpReader()
 {
-   this->close();
+    this->close();
 }
 
 /**
@@ -34,45 +37,46 @@ NdpReader::~NdpReader()
  * \param [in] interface Interface name.
  * \return 0 on success, non 0 on failure + error_msg is filled with error message
  */
-int NdpReader::init_interface(const std::string &interface)
+int NdpReader::init_interface(const std::string& interface)
 {
-   std::string p_interface = interface;
-   int channel = 0;
-   std::size_t del_found = interface.find_last_of(":");
-   if (del_found != std::string::npos) {
-      std::string channel_str = interface.substr(del_found + 1);
-      p_interface = interface.substr(0, del_found);
-      channel = std::stoi(channel_str);
-   }
-   //Open NFB
-   std::cout << "Opening device: " << p_interface.c_str() << " Channel: " << channel << std::endl;
-   dev_handle = nfb_open(p_interface.c_str()); // path to NFB device
-   if (!dev_handle) {
-      error_msg = std::string() + "unable to open NFB device '" + p_interface + "'";
-      return 1;
-   }
+    std::string p_interface = interface;
+    int channel = 0;
+    std::size_t del_found = interface.find_last_of(":");
+    if (del_found != std::string::npos) {
+        std::string channel_str = interface.substr(del_found + 1);
+        p_interface = interface.substr(0, del_found);
+        channel = std::stoi(channel_str);
+    }
+    // Open NFB
+    std::cout << "Opening device: " << p_interface.c_str() << " Channel: " << channel << std::endl;
+    dev_handle = nfb_open(p_interface.c_str()); // path to NFB device
+    if (!dev_handle) {
+        error_msg = std::string() + "unable to open NFB device '" + p_interface + "'";
+        return 1;
+    }
 
-   struct bitmask *bits = nullptr;
-   int node_id;
-   rx_handle = ndp_open_rx_queue(dev_handle, channel);
-   if (!rx_handle) {
-      error_msg = std::string() + "error opening NDP queue of NFB device";
-      return 1;
-   }
-   if (((node_id = ndp_queue_get_numa_node(rx_handle)) >= 0) && // OPTIONAL: bind thread to correct NUMA node
-         ((bits = numa_allocate_nodemask()) != nullptr)) {
-      (void) numa_bitmask_setbit(bits, node_id);
-      numa_bind(bits);
-      numa_free_nodemask(bits);
-   } else {
-      error_msg = std::string() + "warning - NUMA node binding failed\n";
-      return 1;
-   }
-   if (ndp_queue_start(rx_handle)) { // start capturing data from NDP queue
-      error_msg = std::string() + "error starting NDP queue on NFB device";
-      return 1;
-   }
-   return 0;
+    struct bitmask* bits = nullptr;
+    int node_id;
+    rx_handle = ndp_open_rx_queue(dev_handle, channel);
+    if (!rx_handle) {
+        error_msg = std::string() + "error opening NDP queue of NFB device";
+        return 1;
+    }
+    if (((node_id = ndp_queue_get_numa_node(rx_handle)) >= 0)
+        && // OPTIONAL: bind thread to correct NUMA node
+        ((bits = numa_allocate_nodemask()) != nullptr)) {
+        (void) numa_bitmask_setbit(bits, node_id);
+        numa_bind(bits);
+        numa_free_nodemask(bits);
+    } else {
+        error_msg = std::string() + "warning - NUMA node binding failed\n";
+        return 1;
+    }
+    if (ndp_queue_start(rx_handle)) { // start capturing data from NDP queue
+        error_msg = std::string() + "error starting NDP queue on NFB device";
+        return 1;
+    }
+    return 0;
 }
 
 /**
@@ -80,97 +84,99 @@ int NdpReader::init_interface(const std::string &interface)
  */
 void NdpReader::close()
 {
-   if (rx_handle) {
-      ndp_queue_stop(rx_handle);
-      ndp_close_rx_queue(rx_handle);
-      rx_handle = nullptr;
-   }
-   if (dev_handle) { // close NFB device
-      nfb_close(dev_handle);
-      dev_handle = nullptr;
-   }
-   if (ndp_packet_buffer) {
-      delete [] ndp_packet_buffer;
-      ndp_packet_buffer = nullptr;
-   }
+    if (rx_handle) {
+        ndp_queue_stop(rx_handle);
+        ndp_close_rx_queue(rx_handle);
+        rx_handle = nullptr;
+    }
+    if (dev_handle) { // close NFB device
+        nfb_close(dev_handle);
+        dev_handle = nullptr;
+    }
+    if (ndp_packet_buffer) {
+        delete[] ndp_packet_buffer;
+        ndp_packet_buffer = nullptr;
+    }
 }
 
 void NdpReader::print_stats()
 {
-   std::cout << "NFB Reader processed packets: " << processed_packets << std::endl;
+    std::cout << "NFB Reader processed packets: " << processed_packets << std::endl;
 }
 
 bool NdpReader::retrieve_ndp_packets()
 {
-   int ret;
-   if (ndp_packet_buffer_valid) {
-      ndp_rx_burst_put(rx_handle);
-      ndp_packet_buffer_valid = false;
-   }
-   ret = ndp_rx_burst_get(rx_handle, ndp_packet_buffer, packet_bufferSize);
-   if (ret > 0) {
-      ndp_packet_buffer_processed = 0;
-      ndp_packet_buffer_packets = ret;
-      ndp_packet_buffer_valid = true;
-      return true;
-   } else if (ret < 0) {
-      std::cerr << "RX Burst error: " << ret << std::endl;
-   }
+    int ret;
+    if (ndp_packet_buffer_valid) {
+        ndp_rx_burst_put(rx_handle);
+        ndp_packet_buffer_valid = false;
+    }
+    ret = ndp_rx_burst_get(rx_handle, ndp_packet_buffer, packet_bufferSize);
+    if (ret > 0) {
+        ndp_packet_buffer_processed = 0;
+        ndp_packet_buffer_packets = ret;
+        ndp_packet_buffer_valid = true;
+        return true;
+    } else if (ret < 0) {
+        std::cerr << "RX Burst error: " << ret << std::endl;
+    }
 
-   return false;
+    return false;
 }
 
-int NdpReader::get_pkt(struct ndp_packet **ndp_packet_out, struct ndp_header **ndp_header_out)
+int NdpReader::get_pkt(struct ndp_packet** ndp_packet_out, struct ndp_header** ndp_header_out)
 {
-   if (ndp_packet_buffer_processed >= ndp_packet_buffer_packets) {
-      if (!retrieve_ndp_packets()) {
-         return 0;
-      }
-   }
+    if (ndp_packet_buffer_processed >= ndp_packet_buffer_packets) {
+        if (!retrieve_ndp_packets()) {
+            return 0;
+        }
+    }
 
-   struct ndp_packet *ndp_packet = (ndp_packet_buffer + ndp_packet_buffer_processed);
-   *ndp_packet_out = ndp_packet;
-   *ndp_header_out = (struct ndp_header *) ndp_packet->header;
+    struct ndp_packet* ndp_packet = (ndp_packet_buffer + ndp_packet_buffer_processed);
+    *ndp_packet_out = ndp_packet;
+    *ndp_header_out = (struct ndp_header*) ndp_packet->header;
 
-   processed_packets++;
-   ndp_packet_buffer_processed++;
+    processed_packets++;
+    ndp_packet_buffer_processed++;
 
-   return 1;
+    return 1;
 }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-   void ndp_reader_init(struct NdpReaderContext *context)
-   {
-      context->reader = new NdpReader();
-   }
-   void ndp_reader_free(struct NdpReaderContext *context)
-   {
-      delete ((NdpReader *)context->reader);
-   }
-   int ndp_reader_init_interface(struct NdpReaderContext *context, const char *interface)
-   {
-      return ((NdpReader *)context->reader)->init_interface(std::string(interface));
-   }
-   void ndp_reader_print_stats(struct NdpReaderContext *context)
-   {
-      ((NdpReader *)context->reader)->print_stats();
-   }
-   void ndp_reader_close(struct NdpReaderContext *context)
-   {
-      ((NdpReader *)context->reader)->close();
-   }
-   int ndp_reader_get_pkt(struct NdpReaderContext *context, struct ndp_packet **ndp_packet, struct ndp_header **ndp_header)
-   {
-      return ((NdpReader *)context->reader)->get_pkt(ndp_packet, ndp_header);
-   }
-   const char *ndp_reader_error_msg(struct NdpReaderContext *context)
-   {
-      return ((NdpReader *)context->reader)->error_msg.c_str();
-   }
-
+void ndp_reader_init(struct NdpReaderContext* context)
+{
+    context->reader = new NdpReader();
+}
+void ndp_reader_free(struct NdpReaderContext* context)
+{
+    delete ((NdpReader*) context->reader);
+}
+int ndp_reader_init_interface(struct NdpReaderContext* context, const char* interface)
+{
+    return ((NdpReader*) context->reader)->init_interface(std::string(interface));
+}
+void ndp_reader_print_stats(struct NdpReaderContext* context)
+{
+    ((NdpReader*) context->reader)->print_stats();
+}
+void ndp_reader_close(struct NdpReaderContext* context)
+{
+    ((NdpReader*) context->reader)->close();
+}
+int ndp_reader_get_pkt(
+    struct NdpReaderContext* context,
+    struct ndp_packet** ndp_packet,
+    struct ndp_header** ndp_header)
+{
+    return ((NdpReader*) context->reader)->get_pkt(ndp_packet, ndp_header);
+}
+const char* ndp_reader_error_msg(struct NdpReaderContext* context)
+{
+    return ((NdpReader*) context->reader)->error_msg.c_str();
+}
 
 #ifdef __cplusplus
 }

--- a/input/parser.cpp
+++ b/input/parser.cpp
@@ -32,13 +32,13 @@
 #include <iostream>
 #include <sys/types.h>
 
-#include "parser.hpp"
 #include "headers.hpp"
+#include "parser.hpp"
 #include <ipfixprobe/packet.hpp>
 
 namespace ipxp {
 
-//#define DEBUG_PARSER
+// #define DEBUG_PARSER
 
 #ifdef DEBUG_PARSER
 // Print debug message if debugging is allowed.
@@ -58,76 +58,92 @@ static uint32_t s_total_pkts = 0;
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_eth_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_eth_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct ethhdr *eth = (struct ethhdr *) data_ptr;
-   if (sizeof(struct ethhdr) > data_len) {
-      throw "Parser detected malformed packet";
-   }
-   uint16_t hdr_len = sizeof(struct ethhdr);
-   uint16_t ethertype = ntohs(eth->h_proto);
+    struct ethhdr* eth = (struct ethhdr*) data_ptr;
+    if (sizeof(struct ethhdr) > data_len) {
+        throw "Parser detected malformed packet";
+    }
+    uint16_t hdr_len = sizeof(struct ethhdr);
+    uint16_t ethertype = ntohs(eth->h_proto);
 
-   DEBUG_MSG("Ethernet header:\n");
+    DEBUG_MSG("Ethernet header:\n");
 #ifndef __CYGWIN__
-   DEBUG_MSG("\tDest mac:\t%s\n",         ether_ntoa((struct ether_addr *) eth->h_dest));
-   DEBUG_MSG("\tSrc mac:\t%s\n",          ether_ntoa((struct ether_addr *) eth->h_source));
+    DEBUG_MSG("\tDest mac:\t%s\n", ether_ntoa((struct ether_addr*) eth->h_dest));
+    DEBUG_MSG("\tSrc mac:\t%s\n", ether_ntoa((struct ether_addr*) eth->h_source));
 #else
-   DEBUG_CODE(
-      char src_mac[18]; // ether_ntoa missing on some platforms
-      char dst_mac[18];
-      uint8_t *p = (uint8_t *) eth->h_source;
-      snprintf(src_mac, sizeof(src_mac), "%02x:%02x:%02x:%02x:%02x:%02x", p[0], p[1], p[2], p[3], p[4], p[5]);
-      p = (uint8_t *) eth->h_dest;
-      snprintf(dst_mac, sizeof(dst_mac), "%02x:%02x:%02x:%02x:%02x:%02x", p[0], p[1], p[2], p[3], p[4], p[5]);
-   );
-   DEBUG_MSG("\tDest mac:\t%s\n",         dst_mac);
-   DEBUG_MSG("\tSrc mac:\t%s\n",          src_mac);
+    DEBUG_CODE(char src_mac[18]; // ether_ntoa missing on some platforms
+               char dst_mac[18];
+               uint8_t* p = (uint8_t*) eth->h_source;
+               snprintf(
+                   src_mac,
+                   sizeof(src_mac),
+                   "%02x:%02x:%02x:%02x:%02x:%02x",
+                   p[0],
+                   p[1],
+                   p[2],
+                   p[3],
+                   p[4],
+                   p[5]);
+               p = (uint8_t*) eth->h_dest;
+               snprintf(
+                   dst_mac,
+                   sizeof(dst_mac),
+                   "%02x:%02x:%02x:%02x:%02x:%02x",
+                   p[0],
+                   p[1],
+                   p[2],
+                   p[3],
+                   p[4],
+                   p[5]););
+    DEBUG_MSG("\tDest mac:\t%s\n", dst_mac);
+    DEBUG_MSG("\tSrc mac:\t%s\n", src_mac);
 #endif
-   DEBUG_MSG("\tEthertype:\t%#06x\n",     ethertype);
+    DEBUG_MSG("\tEthertype:\t%#06x\n", ethertype);
 
-   memcpy(pkt->dst_mac, eth->h_dest, 6);
-   memcpy(pkt->src_mac, eth->h_source, 6);
+    memcpy(pkt->dst_mac, eth->h_dest, 6);
+    memcpy(pkt->src_mac, eth->h_source, 6);
 
-   // set the default value in case there is no VLAN ID
-   pkt->vlan_id = 0;
+    // set the default value in case there is no VLAN ID
+    pkt->vlan_id = 0;
 
-   if (ethertype == ETH_P_8021AD || ethertype == ETH_P_8021Q) {
-      if (4 > data_len - hdr_len) {
-         throw "Parser detected malformed packet";
-      }
+    if (ethertype == ETH_P_8021AD || ethertype == ETH_P_8021Q) {
+        if (4 > data_len - hdr_len) {
+            throw "Parser detected malformed packet";
+        }
 
-      // only the most outer vlan id is extracted
-      uint16_t vlan = ntohs(*(uint16_t *) (data_ptr + hdr_len));
-      // VLAN ID is the 12 LSb
-      pkt->vlan_id = vlan & 0x0FFF;
+        // only the most outer vlan id is extracted
+        uint16_t vlan = ntohs(*(uint16_t*) (data_ptr + hdr_len));
+        // VLAN ID is the 12 LSb
+        pkt->vlan_id = vlan & 0x0FFF;
 
-      DEBUG_MSG("\t%s field:\n", (ethertype == ETH_P_8021AD ? "802.1ad" : "802.1q"));
-      DEBUG_MSG("\t\tPriority:\t%u\n",    ((vlan & 0xE000) >> 12));
-      DEBUG_MSG("\t\tCFI:\t\t%u\n",       ((vlan & 0x1000) >> 11));
-      DEBUG_MSG("\t\tVLAN:\t\t%u\n",      (pkt->vlan_id));
+        DEBUG_MSG("\t%s field:\n", (ethertype == ETH_P_8021AD ? "802.1ad" : "802.1q"));
+        DEBUG_MSG("\t\tPriority:\t%u\n", ((vlan & 0xE000) >> 12));
+        DEBUG_MSG("\t\tCFI:\t\t%u\n", ((vlan & 0x1000) >> 11));
+        DEBUG_MSG("\t\tVLAN:\t\t%u\n", (pkt->vlan_id));
 
-      hdr_len += 4;
-      ethertype = ntohs(*(uint16_t *) (data_ptr + hdr_len - 2));
-      DEBUG_MSG("\t\tEthertype:\t%#06x\n", ethertype);
-   }
-   while (ethertype == ETH_P_8021Q) {
-      if (4 > data_len - hdr_len) {
-         throw "Parser detected malformed packet";
-      }
-      DEBUG_CODE(uint16_t vlan = ntohs(*(uint16_t *) (data_ptr + hdr_len)));
-      DEBUG_MSG("\t802.1q field:\n");
-      DEBUG_MSG("\t\tPriority:\t%u\n",    ((vlan & 0xE000) >> 12));
-      DEBUG_MSG("\t\tCFI:\t\t%u\n",       ((vlan & 0x1000) >> 11));
-      DEBUG_MSG("\t\tVLAN:\t\t%u\n",      (vlan & 0x0FFF));
+        hdr_len += 4;
+        ethertype = ntohs(*(uint16_t*) (data_ptr + hdr_len - 2));
+        DEBUG_MSG("\t\tEthertype:\t%#06x\n", ethertype);
+    }
+    while (ethertype == ETH_P_8021Q) {
+        if (4 > data_len - hdr_len) {
+            throw "Parser detected malformed packet";
+        }
+        DEBUG_CODE(uint16_t vlan = ntohs(*(uint16_t*) (data_ptr + hdr_len)));
+        DEBUG_MSG("\t802.1q field:\n");
+        DEBUG_MSG("\t\tPriority:\t%u\n", ((vlan & 0xE000) >> 12));
+        DEBUG_MSG("\t\tCFI:\t\t%u\n", ((vlan & 0x1000) >> 11));
+        DEBUG_MSG("\t\tVLAN:\t\t%u\n", (vlan & 0x0FFF));
 
-      hdr_len += 4;
-      ethertype = ntohs(*(uint16_t *) (data_ptr + hdr_len - 2));
-      DEBUG_MSG("\t\tEthertype:\t%#06x\n", ethertype);
-   }
+        hdr_len += 4;
+        ethertype = ntohs(*(uint16_t*) (data_ptr + hdr_len - 2));
+        DEBUG_MSG("\t\tEthertype:\t%#06x\n", ethertype);
+    }
 
-   pkt->ethertype = ethertype;
+    pkt->ethertype = ethertype;
 
-   return hdr_len;
+    return hdr_len;
 }
 
 #ifdef WITH_PCAP
@@ -138,70 +154,61 @@ inline uint16_t parse_eth_hdr(const u_char *data_ptr, uint16_t data_len, Packet 
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_sll(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_sll(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct sll_header *sll = (struct sll_header *) data_ptr;
-   if (sizeof(struct sll_header) > data_len) {
-      throw "Parser detected malformed packet";
-   }
+    struct sll_header* sll = (struct sll_header*) data_ptr;
+    if (sizeof(struct sll_header) > data_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   DEBUG_MSG("SLL header:\n");
-   DEBUG_MSG("\tPacket type:\t%u\n",  ntohs(sll->sll_pkttype));
-   DEBUG_MSG("\tHA type:\t%u\n", ntohs(sll->sll_hatype));
-   DEBUG_MSG("\tHA len:\t\t%u\n",  ntohs(sll->sll_halen));
-   DEBUG_CODE(
-      DEBUG_MSG("\tAddress:\t");
-      for (int i = 0; i < SLL_ADDRLEN; i++) {
-         DEBUG_MSG("%02x ", sll->sll_addr[i]);
-      }
-      DEBUG_MSG("\n");
-   );
-   DEBUG_MSG("\tProtocol:\t%u\n",     ntohs(sll->sll_protocol));
+    DEBUG_MSG("SLL header:\n");
+    DEBUG_MSG("\tPacket type:\t%u\n", ntohs(sll->sll_pkttype));
+    DEBUG_MSG("\tHA type:\t%u\n", ntohs(sll->sll_hatype));
+    DEBUG_MSG("\tHA len:\t\t%u\n", ntohs(sll->sll_halen));
+    DEBUG_CODE(DEBUG_MSG("\tAddress:\t"); for (int i = 0; i < SLL_ADDRLEN; i++) {
+        DEBUG_MSG("%02x ", sll->sll_addr[i]);
+    } DEBUG_MSG("\n"););
+    DEBUG_MSG("\tProtocol:\t%u\n", ntohs(sll->sll_protocol));
 
-   if (ntohs(sll->sll_hatype) == ARPHRD_ETHER) {
-      memcpy(pkt->src_mac, sll->sll_addr, 6);
-   } else {
-      memset(pkt->src_mac, 0, sizeof(pkt->src_mac));
-   }
-   memset(pkt->dst_mac, 0, sizeof(pkt->dst_mac));
-   pkt->ethertype = ntohs(sll->sll_protocol);
-   return sizeof(struct sll_header);
+    if (ntohs(sll->sll_hatype) == ARPHRD_ETHER) {
+        memcpy(pkt->src_mac, sll->sll_addr, 6);
+    } else {
+        memset(pkt->src_mac, 0, sizeof(pkt->src_mac));
+    }
+    memset(pkt->dst_mac, 0, sizeof(pkt->dst_mac));
+    pkt->ethertype = ntohs(sll->sll_protocol);
+    return sizeof(struct sll_header);
 }
 
-# ifdef DLT_LINUX_SLL2
-inline uint16_t parse_sll2(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+#ifdef DLT_LINUX_SLL2
+inline uint16_t parse_sll2(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct sll2_header *sll = (struct sll2_header *) data_ptr;
-   if (sizeof(struct sll2_header) > data_len) {
-      throw "Parser detected malformed packet";
-   }
+    struct sll2_header* sll = (struct sll2_header*) data_ptr;
+    if (sizeof(struct sll2_header) > data_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   DEBUG_MSG("SLL2 header:\n");
-   DEBUG_MSG("\tPacket type:\t%u\n",  ntohs(sll->sll2_pkttype));
-   DEBUG_MSG("\tHA type:\t%u\n", ntohs(sll->sll2_hatype));
-   DEBUG_MSG("\tHA len:\t\t%u\n",  ntohs(sll->sll2_halen));
-   DEBUG_MSG("\tinterface index:\t\t%u\n",  ntohl(sll->sll2_if_index));
-   DEBUG_CODE(
-      DEBUG_MSG("\tAddress:\t");
-      for (int i = 0; i < SLL_ADDRLEN; i++) {
-         DEBUG_MSG("%02x ", sll->sll2_addr[i]);
-      }
-      DEBUG_MSG("\n");
-   );
-   DEBUG_MSG("\tProtocol:\t%u\n",     ntohs(sll->sll2_protocol));
+    DEBUG_MSG("SLL2 header:\n");
+    DEBUG_MSG("\tPacket type:\t%u\n", ntohs(sll->sll2_pkttype));
+    DEBUG_MSG("\tHA type:\t%u\n", ntohs(sll->sll2_hatype));
+    DEBUG_MSG("\tHA len:\t\t%u\n", ntohs(sll->sll2_halen));
+    DEBUG_MSG("\tinterface index:\t\t%u\n", ntohl(sll->sll2_if_index));
+    DEBUG_CODE(DEBUG_MSG("\tAddress:\t"); for (int i = 0; i < SLL_ADDRLEN; i++) {
+        DEBUG_MSG("%02x ", sll->sll2_addr[i]);
+    } DEBUG_MSG("\n"););
+    DEBUG_MSG("\tProtocol:\t%u\n", ntohs(sll->sll2_protocol));
 
-   if (ntohs(sll->sll2_hatype) == ARPHRD_ETHER) {
-      memcpy(pkt->src_mac, sll->sll2_addr, 6);
-   } else {
-      memset(pkt->src_mac, 0, sizeof(pkt->src_mac));
-   }
-   memset(pkt->dst_mac, 0, sizeof(pkt->dst_mac));
-   pkt->ethertype = ntohs(sll->sll2_protocol);
-   return sizeof(struct sll2_header);
+    if (ntohs(sll->sll2_hatype) == ARPHRD_ETHER) {
+        memcpy(pkt->src_mac, sll->sll2_addr, 6);
+    } else {
+        memset(pkt->src_mac, 0, sizeof(pkt->src_mac));
+    }
+    memset(pkt->dst_mac, 0, sizeof(pkt->dst_mac));
+    pkt->ethertype = ntohs(sll->sll2_protocol);
+    return sizeof(struct sll2_header);
 }
-# endif /* DLT_LINUX_SLL2 */
+#endif /* DLT_LINUX_SLL2 */
 #endif /* WITH_PCAP */
-
 
 /**
  * \brief Parse specific fields from TRILL.
@@ -210,77 +217,78 @@ inline uint16_t parse_sll2(const u_char *data_ptr, uint16_t data_len, Packet *pk
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_trill(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_trill(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct trill_hdr *trill = (struct trill_hdr *) data_ptr;
-   if (sizeof(struct trill_hdr) > data_len) {
-      throw "Parser detected malformed packet";
-   }
-   uint8_t op_len = ((trill->op_len1 << 2) | trill->op_len2);
-   uint8_t op_len_bytes = op_len * 4;
+    struct trill_hdr* trill = (struct trill_hdr*) data_ptr;
+    if (sizeof(struct trill_hdr) > data_len) {
+        throw "Parser detected malformed packet";
+    }
+    uint8_t op_len = ((trill->op_len1 << 2) | trill->op_len2);
+    uint8_t op_len_bytes = op_len * 4;
 
-   DEBUG_MSG("TRILL header:\n");
-   DEBUG_MSG("\tHDR version:\t%u\n",         trill->version);
-   DEBUG_MSG("\tRES:\t\t%u\n",               trill->res);
-   DEBUG_MSG("\tM:\t\t%u\n",                 trill->m);
-   DEBUG_MSG("\tOP length:\t%u (%u B)\n",    op_len, op_len_bytes);
-   DEBUG_MSG("\tHop cnt:\t%u\n",             trill->hop_cnt);
-   DEBUG_MSG("\tEgress nick:\t%u\n",         ntohs(trill->egress_nick));
-   DEBUG_MSG("\tIngress nick:\t%u\n",        ntohs(trill->ingress_nick));
+    DEBUG_MSG("TRILL header:\n");
+    DEBUG_MSG("\tHDR version:\t%u\n", trill->version);
+    DEBUG_MSG("\tRES:\t\t%u\n", trill->res);
+    DEBUG_MSG("\tM:\t\t%u\n", trill->m);
+    DEBUG_MSG("\tOP length:\t%u (%u B)\n", op_len, op_len_bytes);
+    DEBUG_MSG("\tHop cnt:\t%u\n", trill->hop_cnt);
+    DEBUG_MSG("\tEgress nick:\t%u\n", ntohs(trill->egress_nick));
+    DEBUG_MSG("\tIngress nick:\t%u\n", ntohs(trill->ingress_nick));
 
-   return sizeof(trill_hdr) + op_len_bytes;
+    return sizeof(trill_hdr) + op_len_bytes;
 }
 
-inline uint16_t parse_ipv4_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt);
-inline uint16_t parse_ipv6_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt);
-uint16_t process_mpls(const u_char *data_ptr, uint16_t data_len, Packet *pkt);
-inline uint16_t process_pppoe(const u_char *data_ptr, uint16_t data_len, Packet *pkt);
+inline uint16_t parse_ipv4_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt);
+inline uint16_t parse_ipv6_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt);
+uint16_t process_mpls(const u_char* data_ptr, uint16_t data_len, Packet* pkt);
+inline uint16_t process_pppoe(const u_char* data_ptr, uint16_t data_len, Packet* pkt);
 
-inline uint16_t parse_gre(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_gre(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   int gre_len = sizeof(struct grehdr);
-   if (data_len < gre_len) {
-       throw "Parser detected malformed packet";
-   }
+    int gre_len = sizeof(struct grehdr);
+    if (data_len < gre_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   auto gre = (struct grehdr *)data_ptr;
-   auto flags = ntohs(gre->flags);
-   auto type = ntohs(gre->type);
+    auto gre = (struct grehdr*) data_ptr;
+    auto flags = ntohs(gre->flags);
+    auto type = ntohs(gre->type);
 
-   // skip optional gre fields
-   if (flags & GRE_CHECKSUM) {
-      gre_len += 4;
-      DEBUG_MSG("GRE has checksum\n");
-   }
-   if (flags & GRE_KEY) {
-      gre_len += 4;
-      DEBUG_MSG("GRE has key\n");
-   }
-   if (flags & GRE_SEQNUM) {
-      gre_len += 4;
-      DEBUG_MSG("GRE has sequence number\n");
-   }
+    // skip optional gre fields
+    if (flags & GRE_CHECKSUM) {
+        gre_len += 4;
+        DEBUG_MSG("GRE has checksum\n");
+    }
+    if (flags & GRE_KEY) {
+        gre_len += 4;
+        DEBUG_MSG("GRE has key\n");
+    }
+    if (flags & GRE_SEQNUM) {
+        gre_len += 4;
+        DEBUG_MSG("GRE has sequence number\n");
+    }
 
-   if (data_len < gre_len) {
-       throw "Parser detected malformed packet";
-   }
+    if (data_len < gre_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   data_ptr += gre_len;
-   data_len -= gre_len;
+    data_ptr += gre_len;
+    data_len -= gre_len;
 
-   switch (type) {
-   case ETH_P_IP:
-      return parse_ipv4_hdr(data_ptr, data_len, pkt) + gre_len;
-   case ETH_P_IPV6:
-      return parse_ipv6_hdr(data_ptr, data_len, pkt) + gre_len;
-   case ETH_P_MPLS_UC: case ETH_P_MPLS_MC:
-      return process_mpls(data_ptr, data_len, pkt) + gre_len;
-   case ETH_P_PPP_SES:
-      return process_pppoe(data_ptr, data_len, pkt) + gre_len;
-   default:
-      pkt->ip_proto = IPPROTO_GRE;
-      return 0;
-   }
+    switch (type) {
+    case ETH_P_IP:
+        return parse_ipv4_hdr(data_ptr, data_len, pkt) + gre_len;
+    case ETH_P_IPV6:
+        return parse_ipv6_hdr(data_ptr, data_len, pkt) + gre_len;
+    case ETH_P_MPLS_UC:
+    case ETH_P_MPLS_MC:
+        return process_mpls(data_ptr, data_len, pkt) + gre_len;
+    case ETH_P_PPP_SES:
+        return process_pppoe(data_ptr, data_len, pkt) + gre_len;
+    default:
+        pkt->ip_proto = IPPROTO_GRE;
+        return 0;
+    }
 }
 
 /**
@@ -290,48 +298,48 @@ inline uint16_t parse_gre(const u_char *data_ptr, uint16_t data_len, Packet *pkt
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_ipv4_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_ipv4_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct iphdr *ip = (struct iphdr *) data_ptr;
-   if (sizeof(struct iphdr) > data_len) {
-      throw "Parser detected malformed packet";
-   }
+    struct iphdr* ip = (struct iphdr*) data_ptr;
+    if (sizeof(struct iphdr) > data_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   const int ihl = ip->ihl << 2;
+    const int ihl = ip->ihl << 2;
 
-   if (ip->protocol == IPPROTO_GRE) {
-      DEBUG_MSG("Parse GRE in ipv4 header\n");
-      if (data_len < ihl) {
-          throw "Parser detected malformed packet";
-      }
-      return parse_gre(data_ptr + ihl, data_len - ihl, pkt) + ihl;
-   }
+    if (ip->protocol == IPPROTO_GRE) {
+        DEBUG_MSG("Parse GRE in ipv4 header\n");
+        if (data_len < ihl) {
+            throw "Parser detected malformed packet";
+        }
+        return parse_gre(data_ptr + ihl, data_len - ihl, pkt) + ihl;
+    }
 
-   pkt->ip_version = IP::v4;
-   pkt->ip_proto = ip->protocol;
-   pkt->ip_tos = ip->tos;
-   pkt->ip_len = ntohs(ip->tot_len);
-   pkt->ip_payload_len = pkt->ip_len - ihl;
-   pkt->ip_ttl = ip->ttl;
-   pkt->ip_flags = (ntohs(ip->frag_off) & 0xE000) >> 13;
-   pkt->src_ip.v4 = ip->saddr;
-   pkt->dst_ip.v4 = ip->daddr;
+    pkt->ip_version = IP::v4;
+    pkt->ip_proto = ip->protocol;
+    pkt->ip_tos = ip->tos;
+    pkt->ip_len = ntohs(ip->tot_len);
+    pkt->ip_payload_len = pkt->ip_len - ihl;
+    pkt->ip_ttl = ip->ttl;
+    pkt->ip_flags = (ntohs(ip->frag_off) & 0xE000) >> 13;
+    pkt->src_ip.v4 = ip->saddr;
+    pkt->dst_ip.v4 = ip->daddr;
 
-   DEBUG_MSG("IPv4 header:\n");
-   DEBUG_MSG("\tHDR version:\t%u\n",   ip->version);
-   DEBUG_MSG("\tHDR length:\t%u\n",    ip->ihl);
-   DEBUG_MSG("\tTOS:\t\t%u\n",         ip->tos);
-   DEBUG_MSG("\tTotal length:\t%u\n",  ntohs(ip->tot_len));
-   DEBUG_MSG("\tID:\t\t%#x\n",         ntohs(ip->id));
-   DEBUG_MSG("\tFlags:\t\t%#x\n",      ((ntohs(ip->frag_off) & 0xE000) >> 13));
-   DEBUG_MSG("\tFrag off:\t%#x\n",     (ntohs(ip->frag_off) & 0x1FFF));
-   DEBUG_MSG("\tTTL:\t\t%u\n",         ip->ttl);
-   DEBUG_MSG("\tProtocol:\t%u\n",      ip->protocol);
-   DEBUG_MSG("\tChecksum:\t%#06x\n",   ntohs(ip->check));
-   DEBUG_MSG("\tSrc addr:\t%s\n",      inet_ntoa(*(struct in_addr *) (&ip->saddr)));
-   DEBUG_MSG("\tDest addr:\t%s\n",     inet_ntoa(*(struct in_addr *) (&ip->daddr)));
+    DEBUG_MSG("IPv4 header:\n");
+    DEBUG_MSG("\tHDR version:\t%u\n", ip->version);
+    DEBUG_MSG("\tHDR length:\t%u\n", ip->ihl);
+    DEBUG_MSG("\tTOS:\t\t%u\n", ip->tos);
+    DEBUG_MSG("\tTotal length:\t%u\n", ntohs(ip->tot_len));
+    DEBUG_MSG("\tID:\t\t%#x\n", ntohs(ip->id));
+    DEBUG_MSG("\tFlags:\t\t%#x\n", ((ntohs(ip->frag_off) & 0xE000) >> 13));
+    DEBUG_MSG("\tFrag off:\t%#x\n", (ntohs(ip->frag_off) & 0x1FFF));
+    DEBUG_MSG("\tTTL:\t\t%u\n", ip->ttl);
+    DEBUG_MSG("\tProtocol:\t%u\n", ip->protocol);
+    DEBUG_MSG("\tChecksum:\t%#06x\n", ntohs(ip->check));
+    DEBUG_MSG("\tSrc addr:\t%s\n", inet_ntoa(*(struct in_addr*) (&ip->saddr)));
+    DEBUG_MSG("\tDest addr:\t%s\n", inet_ntoa(*(struct in_addr*) (&ip->daddr)));
 
-   return ihl;
+    return ihl;
 }
 
 /**
@@ -341,47 +349,46 @@ inline uint16_t parse_ipv4_hdr(const u_char *data_ptr, uint16_t data_len, Packet
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Length of headers in bytes.
  */
-uint16_t skip_ipv6_ext_hdrs(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+uint16_t skip_ipv6_ext_hdrs(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct ip6_ext *ext = (struct ip6_ext *) data_ptr;
-   uint8_t next_hdr = pkt->ip_proto;
-   uint16_t hdrs_len = 0;
+    struct ip6_ext* ext = (struct ip6_ext*) data_ptr;
+    uint8_t next_hdr = pkt->ip_proto;
+    uint16_t hdrs_len = 0;
 
-   /* Skip extension headers... */
-   while (1) {
-      if ((int)sizeof(struct ip6_ext) > data_len - hdrs_len) {
-         throw "Parser detected malformed packet";
-      }
-      if (next_hdr == IPPROTO_HOPOPTS ||
-          next_hdr == IPPROTO_DSTOPTS) {
-         hdrs_len += (ext->ip6e_len << 3) + 8;
-      } else if (next_hdr == IPPROTO_ROUTING) {
-         struct ip6_rthdr *rt = (struct ip6_rthdr *) (data_ptr + hdrs_len);
-         hdrs_len += (rt->ip6r_len << 3) + 8;
-      } else if (next_hdr == IPPROTO_AH) {
-         hdrs_len += (ext->ip6e_len << 2) - 2;
-      } else if (next_hdr == IPPROTO_FRAGMENT) {
-         hdrs_len += 8;
-      } else if (next_hdr == IPPROTO_MH) {
-         hdrs_len += (ext->ip6e_len << 3) + 8;
-         // Mobility header can't have payload now but may have it in the future
-         if (ext->ip6e_nxt == IPPROTO_NONE) {
-            pkt->ip_proto = ext->ip6e_nxt;
+    /* Skip extension headers... */
+    while (1) {
+        if ((int) sizeof(struct ip6_ext) > data_len - hdrs_len) {
+            throw "Parser detected malformed packet";
+        }
+        if (next_hdr == IPPROTO_HOPOPTS || next_hdr == IPPROTO_DSTOPTS) {
+            hdrs_len += (ext->ip6e_len << 3) + 8;
+        } else if (next_hdr == IPPROTO_ROUTING) {
+            struct ip6_rthdr* rt = (struct ip6_rthdr*) (data_ptr + hdrs_len);
+            hdrs_len += (rt->ip6r_len << 3) + 8;
+        } else if (next_hdr == IPPROTO_AH) {
+            hdrs_len += (ext->ip6e_len << 2) - 2;
+        } else if (next_hdr == IPPROTO_FRAGMENT) {
+            hdrs_len += 8;
+        } else if (next_hdr == IPPROTO_MH) {
+            hdrs_len += (ext->ip6e_len << 3) + 8;
+            // Mobility header can't have payload now but may have it in the future
+            if (ext->ip6e_nxt == IPPROTO_NONE) {
+                pkt->ip_proto = ext->ip6e_nxt;
+                break;
+            }
+        } else {
             break;
-         }
-      } else {
-         break;
-      }
-      DEBUG_MSG("\tIPv6 extension header:\t%u\n", next_hdr);
-      DEBUG_MSG("\t\tLength:\t%u\n", ext->ip6e_len);
+        }
+        DEBUG_MSG("\tIPv6 extension header:\t%u\n", next_hdr);
+        DEBUG_MSG("\t\tLength:\t%u\n", ext->ip6e_len);
 
-      next_hdr = ext->ip6e_nxt;
-      ext = (struct ip6_ext *) (data_ptr + hdrs_len);
-      pkt->ip_proto = next_hdr;
-   }
+        next_hdr = ext->ip6e_nxt;
+        ext = (struct ip6_ext*) (data_ptr + hdrs_len);
+        pkt->ip_proto = next_hdr;
+    }
 
-   pkt->ip_payload_len -= hdrs_len;
-   return hdrs_len;
+    pkt->ip_payload_len -= hdrs_len;
+    return hdrs_len;
 }
 
 /**
@@ -391,43 +398,43 @@ uint16_t skip_ipv6_ext_hdrs(const u_char *data_ptr, uint16_t data_len, Packet *p
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_ipv6_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_ipv6_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct ip6_hdr *ip6 = (struct ip6_hdr *) data_ptr;
-   uint16_t hdr_len = sizeof(struct ip6_hdr);
-   if (sizeof(struct ip6_hdr) > data_len) {
-      throw "Parser detected malformed packet";
-   }
+    struct ip6_hdr* ip6 = (struct ip6_hdr*) data_ptr;
+    uint16_t hdr_len = sizeof(struct ip6_hdr);
+    if (sizeof(struct ip6_hdr) > data_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   pkt->ip_version = IP::v6;
-   pkt->ip_tos = (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0x0ff00000) >> 20;
-   pkt->ip_proto = ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt;
-   pkt->ip_ttl = ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim;
-   pkt->ip_flags = 0;
-   pkt->ip_payload_len = ntohs(ip6->ip6_ctlun.ip6_un1.ip6_un1_plen);
-   pkt->ip_len = pkt->ip_payload_len + 40;
-   memcpy(pkt->src_ip.v6, (const char *) &ip6->ip6_src, 16);
-   memcpy(pkt->dst_ip.v6, (const char *) &ip6->ip6_dst, 16);
+    pkt->ip_version = IP::v6;
+    pkt->ip_tos = (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0x0ff00000) >> 20;
+    pkt->ip_proto = ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt;
+    pkt->ip_ttl = ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim;
+    pkt->ip_flags = 0;
+    pkt->ip_payload_len = ntohs(ip6->ip6_ctlun.ip6_un1.ip6_un1_plen);
+    pkt->ip_len = pkt->ip_payload_len + 40;
+    memcpy(pkt->src_ip.v6, (const char*) &ip6->ip6_src, 16);
+    memcpy(pkt->dst_ip.v6, (const char*) &ip6->ip6_dst, 16);
 
-   DEBUG_CODE(char buffer[INET6_ADDRSTRLEN]);
-   DEBUG_MSG("IPv6 header:\n");
-   DEBUG_MSG("\tVersion:\t%u\n",       (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0xf0000000) >> 28);
-   DEBUG_MSG("\tClass:\t\t%u\n",       (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0x0ff00000) >> 20);
-   DEBUG_MSG("\tFlow:\t\t%#x\n",       (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0x000fffff));
-   DEBUG_MSG("\tLength:\t\t%u\n",      ntohs(ip6->ip6_ctlun.ip6_un1.ip6_un1_plen));
-   DEBUG_MSG("\tProtocol:\t%u\n",      ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt);
-   DEBUG_MSG("\tHop limit:\t%u\n",     ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim);
+    DEBUG_CODE(char buffer[INET6_ADDRSTRLEN]);
+    DEBUG_MSG("IPv6 header:\n");
+    DEBUG_MSG("\tVersion:\t%u\n", (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0xf0000000) >> 28);
+    DEBUG_MSG("\tClass:\t\t%u\n", (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0x0ff00000) >> 20);
+    DEBUG_MSG("\tFlow:\t\t%#x\n", (ntohl(ip6->ip6_ctlun.ip6_un1.ip6_un1_flow) & 0x000fffff));
+    DEBUG_MSG("\tLength:\t\t%u\n", ntohs(ip6->ip6_ctlun.ip6_un1.ip6_un1_plen));
+    DEBUG_MSG("\tProtocol:\t%u\n", ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt);
+    DEBUG_MSG("\tHop limit:\t%u\n", ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim);
 
-   DEBUG_CODE(inet_ntop(AF_INET6, (const void *) &ip6->ip6_src, buffer, INET6_ADDRSTRLEN));
-   DEBUG_MSG("\tSrc addr:\t%s\n",      buffer);
-   DEBUG_CODE(inet_ntop(AF_INET6, (const void *) &ip6->ip6_dst, buffer, INET6_ADDRSTRLEN));
-   DEBUG_MSG("\tDest addr:\t%s\n",     buffer);
+    DEBUG_CODE(inet_ntop(AF_INET6, (const void*) &ip6->ip6_src, buffer, INET6_ADDRSTRLEN));
+    DEBUG_MSG("\tSrc addr:\t%s\n", buffer);
+    DEBUG_CODE(inet_ntop(AF_INET6, (const void*) &ip6->ip6_dst, buffer, INET6_ADDRSTRLEN));
+    DEBUG_MSG("\tDest addr:\t%s\n", buffer);
 
-   if (pkt->ip_proto != IPPROTO_TCP && pkt->ip_proto != IPPROTO_UDP) {
-      hdr_len += skip_ipv6_ext_hdrs(data_ptr + hdr_len, data_len - hdr_len, pkt);
-   }
+    if (pkt->ip_proto != IPPROTO_TCP && pkt->ip_proto != IPPROTO_UDP) {
+        hdr_len += skip_ipv6_ext_hdrs(data_ptr + hdr_len, data_len - hdr_len, pkt);
+    }
 
-   return hdr_len;
+    return hdr_len;
 }
 
 /**
@@ -437,70 +444,74 @@ inline uint16_t parse_ipv6_hdr(const u_char *data_ptr, uint16_t data_len, Packet
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_tcp_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_tcp_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct tcphdr *tcp = (struct tcphdr *) data_ptr;
-   if (sizeof(struct tcphdr) > data_len) {
-      throw "Parser detected malformed packet";
-   }
+    struct tcphdr* tcp = (struct tcphdr*) data_ptr;
+    if (sizeof(struct tcphdr) > data_len) {
+        throw "Parser detected malformed packet";
+    }
 
+    pkt->src_port = ntohs(tcp->source);
+    pkt->dst_port = ntohs(tcp->dest);
+    pkt->tcp_seq = ntohl(tcp->seq);
+    pkt->tcp_ack = ntohl(tcp->ack_seq);
+    pkt->tcp_flags = (uint8_t) * (data_ptr + 13) & 0xFF;
+    pkt->tcp_window = ntohs(tcp->window);
 
-   pkt->src_port = ntohs(tcp->source);
-   pkt->dst_port = ntohs(tcp->dest);
-   pkt->tcp_seq = ntohl(tcp->seq);
-   pkt->tcp_ack = ntohl(tcp->ack_seq);
-   pkt->tcp_flags = (uint8_t) *(data_ptr + 13) & 0xFF;
-   pkt->tcp_window = ntohs(tcp->window);
+    DEBUG_MSG("TCP header:\n");
+    DEBUG_MSG("\tSrc port:\t%u\n", ntohs(tcp->source));
+    DEBUG_MSG("\tDest port:\t%u\n", ntohs(tcp->dest));
+    DEBUG_MSG("\tSEQ:\t\t%#x\n", ntohl(tcp->seq));
+    DEBUG_MSG("\tACK SEQ:\t%#x\n", ntohl(tcp->ack_seq));
+    DEBUG_MSG("\tData offset:\t%u\n", tcp->doff);
+    DEBUG_MSG(
+        "\tFlags:\t\t%s%s%s%s%s%s\n",
+        (tcp->fin ? "FIN " : ""),
+        (tcp->syn ? "SYN " : ""),
+        (tcp->rst ? "RST " : ""),
+        (tcp->psh ? "PSH " : ""),
+        (tcp->ack ? "ACK " : ""),
+        (tcp->urg ? "URG" : ""));
+    DEBUG_MSG("\tWindow:\t\t%u\n", ntohs(tcp->window));
+    DEBUG_MSG("\tChecksum:\t%#06x\n", ntohs(tcp->check));
+    DEBUG_MSG("\tUrg ptr:\t%#x\n", ntohs(tcp->urg_ptr));
+    DEBUG_MSG("\tReserved1:\t%#x\n", tcp->res1);
+    DEBUG_MSG("\tReserved2:\t%#x\n", tcp->res2);
 
-   DEBUG_MSG("TCP header:\n");
-   DEBUG_MSG("\tSrc port:\t%u\n",   ntohs(tcp->source));
-   DEBUG_MSG("\tDest port:\t%u\n",  ntohs(tcp->dest));
-   DEBUG_MSG("\tSEQ:\t\t%#x\n",     ntohl(tcp->seq));
-   DEBUG_MSG("\tACK SEQ:\t%#x\n",   ntohl(tcp->ack_seq));
-   DEBUG_MSG("\tData offset:\t%u\n",tcp->doff);
-   DEBUG_MSG("\tFlags:\t\t%s%s%s%s%s%s\n", (tcp->fin ? "FIN " : ""), (tcp->syn ? "SYN " : ""),
-                                           (tcp->rst ? "RST " : ""), (tcp->psh ? "PSH " : ""),
-                                           (tcp->ack ? "ACK " : ""), (tcp->urg ? "URG"  : ""));
-   DEBUG_MSG("\tWindow:\t\t%u\n",   ntohs(tcp->window));
-   DEBUG_MSG("\tChecksum:\t%#06x\n",ntohs(tcp->check));
-   DEBUG_MSG("\tUrg ptr:\t%#x\n",   ntohs(tcp->urg_ptr));
-   DEBUG_MSG("\tReserved1:\t%#x\n", tcp->res1);
-   DEBUG_MSG("\tReserved2:\t%#x\n", tcp->res2);
+    int hdr_len = tcp->doff << 2;
+    int hdr_opt_len = hdr_len - sizeof(struct tcphdr);
+    int i = 0;
+    DEBUG_MSG("\tTCP_OPTIONS (%uB):\n", hdr_opt_len);
+    if (hdr_len > data_len) {
+        throw "Parser detected malformed packet";
+    }
+    while (i < hdr_opt_len) {
+        uint8_t* opt_ptr = (uint8_t*) data_ptr + sizeof(struct tcphdr) + i;
+        uint8_t opt_kind = *opt_ptr;
+        if (i + 1 >= hdr_opt_len) {
+            if (opt_kind <= 1) {
+                return hdr_len;
+            }
+            throw "Parser detected malformed packet";
+        }
+        uint8_t opt_len = (opt_kind <= 1 ? 1 : *(opt_ptr + 1));
+        DEBUG_MSG("\t\t%u: len=%u\n", opt_kind, opt_len);
 
-   int hdr_len = tcp->doff << 2;
-   int hdr_opt_len = hdr_len - sizeof(struct tcphdr);
-   int i = 0;
-   DEBUG_MSG("\tTCP_OPTIONS (%uB):\n", hdr_opt_len);
-   if (hdr_len > data_len) {
-      throw "Parser detected malformed packet";
-   }
-   while (i < hdr_opt_len) {
-      uint8_t *opt_ptr = (uint8_t *) data_ptr + sizeof(struct tcphdr) + i;
-      uint8_t opt_kind = *opt_ptr;
-      if (i + 1 >= hdr_opt_len) {
-         if (opt_kind <= 1) {
-            return hdr_len;
-         }
-         throw "Parser detected malformed packet";
-      }
-      uint8_t opt_len = (opt_kind <= 1 ? 1 : *(opt_ptr + 1));
-      DEBUG_MSG("\t\t%u: len=%u\n", opt_kind, opt_len);
+        pkt->tcp_options |= ((uint64_t) 1 << opt_kind);
+        if (opt_kind == 0x00) {
+            break;
+        } else if (opt_kind == 0x02) {
+            // Parse Maximum Segment Size (MSS)
+            pkt->tcp_mss = ntohl(*(uint32_t*) (opt_ptr + 2));
+        }
+        if (opt_len == 0) {
+            // Prevent infinity loop
+            throw "Parser detected malformed packet";
+        }
+        i += opt_len;
+    }
 
-      pkt->tcp_options |= ((uint64_t) 1 << opt_kind);
-      if (opt_kind == 0x00) {
-         break;
-      } else if (opt_kind == 0x02) {
-         // Parse Maximum Segment Size (MSS)
-         pkt->tcp_mss = ntohl(*(uint32_t *) (opt_ptr + 2));
-      }
-      if (opt_len == 0) {
-         // Prevent infinity loop
-         throw "Parser detected malformed packet";
-      }
-      i += opt_len;
-   }
-
-   return hdr_len;
+    return hdr_len;
 }
 
 /**
@@ -510,23 +521,23 @@ inline uint16_t parse_tcp_hdr(const u_char *data_ptr, uint16_t data_len, Packet 
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of header in bytes.
  */
-inline uint16_t parse_udp_hdr(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t parse_udp_hdr(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct udphdr *udp = (struct udphdr *) data_ptr;
-   if (sizeof(struct udphdr) > data_len) {
-      throw "Parser detected malformed packet";
-   }
+    struct udphdr* udp = (struct udphdr*) data_ptr;
+    if (sizeof(struct udphdr) > data_len) {
+        throw "Parser detected malformed packet";
+    }
 
-   pkt->src_port = ntohs(udp->source);
-   pkt->dst_port = ntohs(udp->dest);
+    pkt->src_port = ntohs(udp->source);
+    pkt->dst_port = ntohs(udp->dest);
 
-   DEBUG_MSG("UDP header:\n");
-   DEBUG_MSG("\tSrc port:\t%u\n",   ntohs(udp->source));
-   DEBUG_MSG("\tDest port:\t%u\n",  ntohs(udp->dest));
-   DEBUG_MSG("\tLength:\t\t%u\n",   ntohs(udp->len));
-   DEBUG_MSG("\tChecksum:\t%#06x\n",ntohs(udp->check));
+    DEBUG_MSG("UDP header:\n");
+    DEBUG_MSG("\tSrc port:\t%u\n", ntohs(udp->source));
+    DEBUG_MSG("\tDest port:\t%u\n", ntohs(udp->dest));
+    DEBUG_MSG("\tLength:\t\t%u\n", ntohs(udp->len));
+    DEBUG_MSG("\tChecksum:\t%#06x\n", ntohs(udp->check));
 
-   return 8;
+    return 8;
 }
 
 /**
@@ -535,27 +546,27 @@ inline uint16_t parse_udp_hdr(const u_char *data_ptr, uint16_t data_len, Packet 
  * \param [in] data_len Length of packet data in `data_ptr`.
  * \return Size of headers in bytes.
  */
-uint16_t process_mpls_stack(const u_char *data_ptr, uint16_t data_len)
+uint16_t process_mpls_stack(const u_char* data_ptr, uint16_t data_len)
 {
-   uint32_t *mpls;
-   uint16_t length = 0;
+    uint32_t* mpls;
+    uint16_t length = 0;
 
-   do {
-      mpls = (uint32_t *) (data_ptr + length);
-      length += sizeof(uint32_t);
-      if (0 > data_len - length) {
-         throw "Parser detected malformed packet";
-      }
+    do {
+        mpls = (uint32_t*) (data_ptr + length);
+        length += sizeof(uint32_t);
+        if (0 > data_len - length) {
+            throw "Parser detected malformed packet";
+        }
 
-      DEBUG_MSG("MPLS:\n");
-      DEBUG_MSG("\tLabel:\t%u\n",   ntohl(*mpls) >> 12);
-      DEBUG_MSG("\tTC:\t%u\n",      (ntohl(*mpls) & 0xE00) >> 9);
-      DEBUG_MSG("\tBOS:\t%u\n",     (ntohl(*mpls) & 0x100) >> 8);
-      DEBUG_MSG("\tTTL:\t%u\n",     ntohl(*mpls) & 0xFF);
+        DEBUG_MSG("MPLS:\n");
+        DEBUG_MSG("\tLabel:\t%u\n", ntohl(*mpls) >> 12);
+        DEBUG_MSG("\tTC:\t%u\n", (ntohl(*mpls) & 0xE00) >> 9);
+        DEBUG_MSG("\tBOS:\t%u\n", (ntohl(*mpls) & 0x100) >> 8);
+        DEBUG_MSG("\tTTL:\t%u\n", ntohl(*mpls) & 0xFF);
 
     } while (!(ntohl(*mpls) & 0x100));
 
-   return length;
+    return length;
 }
 
 /**
@@ -565,29 +576,29 @@ uint16_t process_mpls_stack(const u_char *data_ptr, uint16_t data_len)
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of parsed data in bytes.
  */
-uint16_t process_mpls(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+uint16_t process_mpls(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   Packet tmp;
-   pkt->mplsTop = ntohl(*reinterpret_cast<const uint32_t *>(data_ptr));
-   uint16_t length = process_mpls_stack(data_ptr, data_len);
-   uint8_t next_hdr = (*(data_ptr + length) & 0xF0) >> 4;
+    Packet tmp;
+    pkt->mplsTop = ntohl(*reinterpret_cast<const uint32_t*>(data_ptr));
+    uint16_t length = process_mpls_stack(data_ptr, data_len);
+    uint8_t next_hdr = (*(data_ptr + length) & 0xF0) >> 4;
 
-   if (next_hdr == IP::v4) {
-      length += parse_ipv4_hdr(data_ptr + length, data_len - length, pkt);
-   } else if (next_hdr == IP::v6) {
-      length += parse_ipv6_hdr(data_ptr + length, data_len - length, pkt);
-   } else if (next_hdr == 0) {
-      /* Process EoMPLS */
-      length += 4; /* Skip Pseudo Wire Ethernet control word. */
-      length = parse_eth_hdr(data_ptr + length, data_len - length, &tmp);
-      if (tmp.ethertype == ETH_P_IP) {
-         length += parse_ipv4_hdr(data_ptr + length, data_len - length, pkt);
-      } else if (tmp.ethertype == ETH_P_IPV6) {
-         length += parse_ipv6_hdr(data_ptr + length, data_len - length, pkt);
-      }
-   }
+    if (next_hdr == IP::v4) {
+        length += parse_ipv4_hdr(data_ptr + length, data_len - length, pkt);
+    } else if (next_hdr == IP::v6) {
+        length += parse_ipv6_hdr(data_ptr + length, data_len - length, pkt);
+    } else if (next_hdr == 0) {
+        /* Process EoMPLS */
+        length += 4; /* Skip Pseudo Wire Ethernet control word. */
+        length = parse_eth_hdr(data_ptr + length, data_len - length, &tmp);
+        if (tmp.ethertype == ETH_P_IP) {
+            length += parse_ipv4_hdr(data_ptr + length, data_len - length, pkt);
+        } else if (tmp.ethertype == ETH_P_IPV6) {
+            length += parse_ipv6_hdr(data_ptr + length, data_len - length, pkt);
+        }
+    }
 
-   return length;
+    return length;
 }
 
 /**
@@ -597,146 +608,148 @@ uint16_t process_mpls(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
  * \param [out] pkt Pointer to Packet structure where parsed fields will be stored.
  * \return Size of parsed data in bytes.
  */
-inline uint16_t process_pppoe(const u_char *data_ptr, uint16_t data_len, Packet *pkt)
+inline uint16_t process_pppoe(const u_char* data_ptr, uint16_t data_len, Packet* pkt)
 {
-   struct pppoe_hdr *pppoe = (struct pppoe_hdr *) data_ptr;
-   if (sizeof(struct pppoe_hdr) + 2 > data_len) {
-      throw "Parser detected malformed packet";
-   }
-   uint16_t next_hdr = ntohs(*(uint16_t *) (data_ptr + sizeof(struct pppoe_hdr)));
-   uint16_t length = sizeof(struct pppoe_hdr) + 2;
+    struct pppoe_hdr* pppoe = (struct pppoe_hdr*) data_ptr;
+    if (sizeof(struct pppoe_hdr) + 2 > data_len) {
+        throw "Parser detected malformed packet";
+    }
+    uint16_t next_hdr = ntohs(*(uint16_t*) (data_ptr + sizeof(struct pppoe_hdr)));
+    uint16_t length = sizeof(struct pppoe_hdr) + 2;
 
-   DEBUG_MSG("PPPoE header:\n");
-   DEBUG_MSG("\tVer:\t%u\n",     pppoe->version);
-   DEBUG_MSG("\tType:\t%u\n",    pppoe->type);
-   DEBUG_MSG("\tCode:\t%u\n",    pppoe->code);
-   DEBUG_MSG("\tSID:\t%u\n",     ntohs(pppoe->sid));
-   DEBUG_MSG("\tLength:\t%u\n",  ntohs(pppoe->length));
-   DEBUG_MSG("PPP header:\n");
-   DEBUG_MSG("\tProtocol:\t%#04x\n", next_hdr);
-   if (pppoe->code != 0) {
-      return length;
-   }
+    DEBUG_MSG("PPPoE header:\n");
+    DEBUG_MSG("\tVer:\t%u\n", pppoe->version);
+    DEBUG_MSG("\tType:\t%u\n", pppoe->type);
+    DEBUG_MSG("\tCode:\t%u\n", pppoe->code);
+    DEBUG_MSG("\tSID:\t%u\n", ntohs(pppoe->sid));
+    DEBUG_MSG("\tLength:\t%u\n", ntohs(pppoe->length));
+    DEBUG_MSG("PPP header:\n");
+    DEBUG_MSG("\tProtocol:\t%#04x\n", next_hdr);
+    if (pppoe->code != 0) {
+        return length;
+    }
 
-   if (next_hdr == 0x0021) {
-      length += parse_ipv4_hdr(data_ptr + length, data_len - length, pkt);
-   } else if (next_hdr == 0x0057) {
-      length += parse_ipv6_hdr(data_ptr + length, data_len - length, pkt);
-   }
+    if (next_hdr == 0x0021) {
+        length += parse_ipv4_hdr(data_ptr + length, data_len - length, pkt);
+    } else if (next_hdr == 0x0057) {
+        length += parse_ipv6_hdr(data_ptr + length, data_len - length, pkt);
+    }
 
-   return length;
+    return length;
 }
 
-void parse_packet(parser_opt_t *opt, struct timeval ts, const uint8_t *data, uint16_t len, uint16_t caplen)
+void parse_packet(
+    parser_opt_t* opt,
+    struct timeval ts,
+    const uint8_t* data,
+    uint16_t len,
+    uint16_t caplen)
 {
-   if (opt->pblock->cnt >= opt->pblock->size) {
-      return;
-   }
-   Packet *pkt = &opt->pblock->pkts[opt->pblock->cnt];
-   uint16_t data_offset = 0;
+    if (opt->pblock->cnt >= opt->pblock->size) {
+        return;
+    }
+    Packet* pkt = &opt->pblock->pkts[opt->pblock->cnt];
+    uint16_t data_offset = 0;
 
-   DEBUG_MSG("---------- packet parser  #%u -------------\n", ++s_total_pkts);
-   DEBUG_CODE(
-      char timestamp[32];
-      time_t time = ts.tv_sec;
-      strftime(timestamp, sizeof(timestamp), "%FT%T", localtime(&time));
-   );
-   DEBUG_MSG("Time:\t\t\t%s.%06lu\n",     timestamp, ts.tv_usec);
-   DEBUG_MSG("Packet length:\t\tcaplen=%uB len=%uB\n\n", caplen, len);
+    DEBUG_MSG("---------- packet parser  #%u -------------\n", ++s_total_pkts);
+    DEBUG_CODE(char timestamp[32]; time_t time = ts.tv_sec;
+               strftime(timestamp, sizeof(timestamp), "%FT%T", localtime(&time)););
+    DEBUG_MSG("Time:\t\t\t%s.%06lu\n", timestamp, ts.tv_usec);
+    DEBUG_MSG("Packet length:\t\tcaplen=%uB len=%uB\n\n", caplen, len);
 
-   pkt->packet_len_wire = len;
-   pkt->ts = ts;
-   pkt->src_port = 0;
-   pkt->dst_port = 0;
-   pkt->ip_proto = 0;
-   pkt->ip_ttl = 0;
-   pkt->ip_flags = 0;
-   pkt->ip_version = 0;
-   pkt->ip_payload_len = 0;
-   pkt->tcp_flags = 0;
-   pkt->tcp_window = 0;
-   pkt->tcp_options = 0;
-   pkt->tcp_mss = 0;
-   pkt->mplsTop = 0;
+    pkt->packet_len_wire = len;
+    pkt->ts = ts;
+    pkt->src_port = 0;
+    pkt->dst_port = 0;
+    pkt->ip_proto = 0;
+    pkt->ip_ttl = 0;
+    pkt->ip_flags = 0;
+    pkt->ip_version = 0;
+    pkt->ip_payload_len = 0;
+    pkt->tcp_flags = 0;
+    pkt->tcp_window = 0;
+    pkt->tcp_options = 0;
+    pkt->tcp_mss = 0;
+    pkt->mplsTop = 0;
 
-   uint32_t l3_hdr_offset = 0;
-   uint32_t l4_hdr_offset = 0;
-   try {
-   #ifdef WITH_PCAP
-      if (opt->datalink == DLT_EN10MB) {
-         data_offset = parse_eth_hdr(data, caplen, pkt);
-      } else if (opt->datalink == DLT_LINUX_SLL) {
+    uint32_t l3_hdr_offset = 0;
+    uint32_t l4_hdr_offset = 0;
+    try {
+#ifdef WITH_PCAP
+        if (opt->datalink == DLT_EN10MB) {
+            data_offset = parse_eth_hdr(data, caplen, pkt);
+        } else if (opt->datalink == DLT_LINUX_SLL) {
             data_offset = parse_sll(data, caplen, pkt);
-   # ifdef DLT_LINUX_SLL2
-      } else if (opt->datalink == DLT_LINUX_SLL2) {
+#ifdef DLT_LINUX_SLL2
+        } else if (opt->datalink == DLT_LINUX_SLL2) {
             data_offset = parse_sll2(data, caplen, pkt);
-   # endif /* DLT_LINUX_SLL2 */
-      } else if (opt->datalink == DLT_RAW) {
+#endif /* DLT_LINUX_SLL2 */
+        } else if (opt->datalink == DLT_RAW) {
             if ((data[0] & 0xF0) == 0x40) {
-               pkt->ethertype = ETH_P_IP;
+                pkt->ethertype = ETH_P_IP;
             } else if ((data[0] & 0xF0) == 0x60) {
-               pkt->ethertype = ETH_P_IPV6;
+                pkt->ethertype = ETH_P_IPV6;
             }
-      }
-   #else
-      data_offset = parse_eth_hdr(data, caplen, pkt);
-   #endif /* WITH_PCAP */
+        }
+#else
+        data_offset = parse_eth_hdr(data, caplen, pkt);
+#endif /* WITH_PCAP */
 
-      if (pkt->ethertype == ETH_P_TRILL) {
-         data_offset += parse_trill(data + data_offset, caplen - data_offset, pkt);
-         data_offset += parse_eth_hdr(data + data_offset, caplen - data_offset, pkt);
-      }
-      l3_hdr_offset = data_offset;
-      if (pkt->ethertype == ETH_P_IP) {
-         data_offset += parse_ipv4_hdr(data + data_offset, caplen - data_offset, pkt);
-      } else if (pkt->ethertype == ETH_P_IPV6) {
-         data_offset += parse_ipv6_hdr(data + data_offset, caplen - data_offset, pkt);
-      } else if (pkt->ethertype == ETH_P_MPLS_UC || pkt->ethertype == ETH_P_MPLS_MC) {
-         data_offset += process_mpls(data + data_offset, caplen - data_offset, pkt);
-      } else if (pkt->ethertype == ETH_P_PPP_SES) {
-         data_offset += process_pppoe(data + data_offset, caplen - data_offset, pkt);
-      } else if (!opt->parse_all) {
-         DEBUG_MSG("Unknown ethertype %x\n", pkt->ethertype);
-         return;
-      }
+        if (pkt->ethertype == ETH_P_TRILL) {
+            data_offset += parse_trill(data + data_offset, caplen - data_offset, pkt);
+            data_offset += parse_eth_hdr(data + data_offset, caplen - data_offset, pkt);
+        }
+        l3_hdr_offset = data_offset;
+        if (pkt->ethertype == ETH_P_IP) {
+            data_offset += parse_ipv4_hdr(data + data_offset, caplen - data_offset, pkt);
+        } else if (pkt->ethertype == ETH_P_IPV6) {
+            data_offset += parse_ipv6_hdr(data + data_offset, caplen - data_offset, pkt);
+        } else if (pkt->ethertype == ETH_P_MPLS_UC || pkt->ethertype == ETH_P_MPLS_MC) {
+            data_offset += process_mpls(data + data_offset, caplen - data_offset, pkt);
+        } else if (pkt->ethertype == ETH_P_PPP_SES) {
+            data_offset += process_pppoe(data + data_offset, caplen - data_offset, pkt);
+        } else if (!opt->parse_all) {
+            DEBUG_MSG("Unknown ethertype %x\n", pkt->ethertype);
+            return;
+        }
 
-      l4_hdr_offset = data_offset;
-      if (pkt->ip_proto == IPPROTO_TCP) {
-         data_offset += parse_tcp_hdr(data + data_offset, caplen - data_offset, pkt);
-      } else if (pkt->ip_proto == IPPROTO_UDP) {
-         data_offset += parse_udp_hdr(data + data_offset, caplen - data_offset, pkt);
-      }
-   } catch (const char *err) {
-      DEBUG_MSG("%s\n", err);
-      return;
-   }
+        l4_hdr_offset = data_offset;
+        if (pkt->ip_proto == IPPROTO_TCP) {
+            data_offset += parse_tcp_hdr(data + data_offset, caplen - data_offset, pkt);
+        } else if (pkt->ip_proto == IPPROTO_UDP) {
+            data_offset += parse_udp_hdr(data + data_offset, caplen - data_offset, pkt);
+        }
+    } catch (const char* err) {
+        DEBUG_MSG("%s\n", err);
+        return;
+    }
 
-   uint16_t pkt_len = caplen;
-   pkt->packet = data;
-   pkt->packet_len = caplen;
+    uint16_t pkt_len = caplen;
+    pkt->packet = data;
+    pkt->packet_len = caplen;
 
-   if (l4_hdr_offset != l3_hdr_offset) {
-      if (l4_hdr_offset + pkt->ip_payload_len < 64) {
-         // Packet contains 0x00 padding bytes, do not include them in payload
-         pkt_len = l4_hdr_offset + pkt->ip_payload_len;
-      }
-      pkt->payload_len_wire = pkt->ip_payload_len - (data_offset - l4_hdr_offset);
-   } else {
-      pkt->payload_len_wire = pkt_len - data_offset;
-   }
+    if (l4_hdr_offset != l3_hdr_offset) {
+        if (l4_hdr_offset + pkt->ip_payload_len < 64) {
+            // Packet contains 0x00 padding bytes, do not include them in payload
+            pkt_len = l4_hdr_offset + pkt->ip_payload_len;
+        }
+        pkt->payload_len_wire = pkt->ip_payload_len - (data_offset - l4_hdr_offset);
+    } else {
+        pkt->payload_len_wire = pkt_len - data_offset;
+    }
 
-   pkt->payload_len = pkt->payload_len_wire;
-   if (pkt->payload_len + data_offset > pkt_len) {
-      // Set correct size when payload length is bigger than captured payload length
-      pkt->payload_len = pkt_len - data_offset;
-   }
-   pkt->payload = pkt->packet + data_offset;
+    pkt->payload_len = pkt->payload_len_wire;
+    if (pkt->payload_len + data_offset > pkt_len) {
+        // Set correct size when payload length is bigger than captured payload length
+        pkt->payload_len = pkt_len - data_offset;
+    }
+    pkt->payload = pkt->packet + data_offset;
 
-   DEBUG_MSG("Payload length:\t%u\n", pkt->payload_len);
-   DEBUG_MSG("Packet parser exits: packet parsed\n");
-   opt->packet_valid = true;
-   opt->pblock->cnt++;
-   opt->pblock->bytes += len;
+    DEBUG_MSG("Payload length:\t%u\n", pkt->payload_len);
+    DEBUG_MSG("Packet parser exits: packet parsed\n");
+    opt->packet_valid = true;
+    opt->pblock->cnt++;
+    opt->pblock->bytes += len;
 }
 
-}
+} // namespace ipxp

--- a/input/parser.hpp
+++ b/input/parser.hpp
@@ -49,23 +49,28 @@
 #endif
 
 #ifndef ETH_P_8021AD
-#define ETH_P_8021AD	0x88A8          /* 802.1ad Service VLAN*/
+#define ETH_P_8021AD 0x88A8 /* 802.1ad Service VLAN*/
 #endif
 
 #ifndef ETH_P_TRILL
-#define ETH_P_TRILL	0x22F3          /* TRILL protocol */
+#define ETH_P_TRILL 0x22F3 /* TRILL protocol */
 #endif
 
 namespace ipxp {
 
 typedef struct parser_opt_s {
-   PacketBlock *pblock;
-   bool packet_valid;
-   bool parse_all;
-   int datalink;
+    PacketBlock* pblock;
+    bool packet_valid;
+    bool parse_all;
+    int datalink;
 } parser_opt_t;
 
-void parse_packet(parser_opt_t *opt, struct timeval ts, const uint8_t *data, uint16_t len, uint16_t caplen);
+void parse_packet(
+    parser_opt_t* opt,
+    struct timeval ts,
+    const uint8_t* data,
+    uint16_t len,
+    uint16_t caplen);
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_PARSER_HPP */

--- a/input/pcap.cpp
+++ b/input/pcap.cpp
@@ -28,13 +28,13 @@
 
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
 #include <pcap/pcap.h>
 
-#include "pcap.hpp"
 #include "parser.hpp"
+#include "pcap.hpp"
 
 namespace ipxp {
 
@@ -43,8 +43,8 @@ constexpr size_t PCAP_PACKET_BLOCK_SIZE = 1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("pcap", [](){return new PcapReader();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("pcap", []() { return new PcapReader(); });
+    register_plugin(&rec);
 }
 
 /**
@@ -53,230 +53,242 @@ __attribute__((constructor)) static void register_this_plugin()
  * \param [in] h Contains timestamp and packet size.
  * \param [in] data Pointer to the captured packet data.
  */
-void packet_handler(u_char *arg, const struct pcap_pkthdr *h, const u_char *data)
+void packet_handler(u_char* arg, const struct pcap_pkthdr* h, const u_char* data)
 {
 #ifdef __CYGWIN__
-   // WinPcap, uses Microsoft's definition of struct timeval, which has `long` data type
-   // used for both tv_sec and tv_usec and has 32 bit even on 64 bit platform.
-   // Cygwin uses 64 bit tv_sec and tv_usec, thus a little reinterpretation of bytes needs to be used.
-   struct pcap_pkthdr new_h;
-   new_h.ts.tv_sec = *reinterpret_cast<const uint32_t *>(h);
-   new_h.ts.tv_usec = *(reinterpret_cast<const uint32_t *>(h) + 1);
-   new_h.caplen = *(reinterpret_cast<const uint32_t *>(h) + 2);
-   new_h.len = *(reinterpret_cast<const uint32_t *>(h) + 3);
-   parse_packet((parser_opt_t *) arg, new_h.ts, data, new_h.len, new_h.caplen);
+    // WinPcap, uses Microsoft's definition of struct timeval, which has `long` data type
+    // used for both tv_sec and tv_usec and has 32 bit even on 64 bit platform.
+    // Cygwin uses 64 bit tv_sec and tv_usec, thus a little reinterpretation of bytes needs to be
+    // used.
+    struct pcap_pkthdr new_h;
+    new_h.ts.tv_sec = *reinterpret_cast<const uint32_t*>(h);
+    new_h.ts.tv_usec = *(reinterpret_cast<const uint32_t*>(h) + 1);
+    new_h.caplen = *(reinterpret_cast<const uint32_t*>(h) + 2);
+    new_h.len = *(reinterpret_cast<const uint32_t*>(h) + 3);
+    parse_packet((parser_opt_t*) arg, new_h.ts, data, new_h.len, new_h.caplen);
 #else
-   parse_packet((parser_opt_t *) arg, h->ts, data, h->len, h->caplen);
+    parse_packet((parser_opt_t*) arg, h->ts, data, h->len, h->caplen);
 #endif
 }
 
-PcapReader::PcapReader() : m_handle(nullptr), m_snaplen(-1), m_datalink(0), m_live(false), m_netmask(PCAP_NETMASK_UNKNOWN)
+PcapReader::PcapReader()
+    : m_handle(nullptr)
+    , m_snaplen(-1)
+    , m_datalink(0)
+    , m_live(false)
+    , m_netmask(PCAP_NETMASK_UNKNOWN)
 {
 }
 
 PcapReader::~PcapReader()
 {
-   close();
+    close();
 }
 
-void PcapReader::init(const char *params)
+void PcapReader::init(const char* params)
 {
-   PcapOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    PcapOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   if (parser.m_list) {
-      print_available_ifcs();
-      throw PluginExit();
-   }
+    if (parser.m_list) {
+        print_available_ifcs();
+        throw PluginExit();
+    }
 
-   if (parser.m_ifc.empty() && parser.m_file.empty()) {
-      throw PluginError("specify network interface or pcap file path");
-   }
-   if (!parser.m_ifc.empty() && !parser.m_file.empty()) {
-      throw PluginError("only one input can be specified");
-   }
+    if (parser.m_ifc.empty() && parser.m_file.empty()) {
+        throw PluginError("specify network interface or pcap file path");
+    }
+    if (!parser.m_ifc.empty() && !parser.m_file.empty()) {
+        throw PluginError("only one input can be specified");
+    }
 
-   m_snaplen = parser.m_snaplen;
-   if (m_snaplen < MIN_SNAPLEN) {
-      std::cerr << "setting snapshot length to minimum value " << MIN_SNAPLEN << std::endl;
-      m_snaplen = MIN_SNAPLEN;
-   } else if (m_snaplen > MAX_SNAPLEN) {
-      std::cerr << "setting snapshot length to maximum value " << MAX_SNAPLEN << std::endl;
-      m_snaplen = MAX_SNAPLEN;
-   }
+    m_snaplen = parser.m_snaplen;
+    if (m_snaplen < MIN_SNAPLEN) {
+        std::cerr << "setting snapshot length to minimum value " << MIN_SNAPLEN << std::endl;
+        m_snaplen = MIN_SNAPLEN;
+    } else if (m_snaplen > MAX_SNAPLEN) {
+        std::cerr << "setting snapshot length to maximum value " << MAX_SNAPLEN << std::endl;
+        m_snaplen = MAX_SNAPLEN;
+    }
 
-   if (!parser.m_ifc.empty()) {
-      open_ifc(parser.m_ifc);
-   } else {
-      open_file(parser.m_file);
-   }
+    if (!parser.m_ifc.empty()) {
+        open_ifc(parser.m_ifc);
+    } else {
+        open_file(parser.m_file);
+    }
 
-   if (!parser.m_filter.empty()) {
-      set_filter(parser.m_filter);
-   }
+    if (!parser.m_filter.empty()) {
+        set_filter(parser.m_filter);
+    }
 }
 
 void PcapReader::close()
 {
-   if (m_handle != nullptr) {
-      pcap_close(m_handle);
-      m_handle = nullptr;
-   }
+    if (m_handle != nullptr) {
+        pcap_close(m_handle);
+        m_handle = nullptr;
+    }
 }
 
-void PcapReader::open_file(const std::string &file)
+void PcapReader::open_file(const std::string& file)
 {
-   char errbuf[PCAP_ERRBUF_SIZE];
+    char errbuf[PCAP_ERRBUF_SIZE];
 
-   m_handle = pcap_open_offline(file.c_str(), errbuf);
-   if (m_handle == nullptr) {
-      throw PluginError(std::string("unable to open file: ") + errbuf);
-   }
+    m_handle = pcap_open_offline(file.c_str(), errbuf);
+    if (m_handle == nullptr) {
+        throw PluginError(std::string("unable to open file: ") + errbuf);
+    }
 
-   m_datalink = pcap_datalink(m_handle);
-   m_live = false;
+    m_datalink = pcap_datalink(m_handle);
+    m_live = false;
 
-   check_datalink(m_datalink);
+    check_datalink(m_datalink);
 }
 
-void PcapReader::open_ifc(const std::string &ifc)
+void PcapReader::open_ifc(const std::string& ifc)
 {
-   char errbuf[PCAP_ERRBUF_SIZE];
-   errbuf[0] = 0;
+    char errbuf[PCAP_ERRBUF_SIZE];
+    errbuf[0] = 0;
 
-   m_handle = pcap_open_live(ifc.c_str(), m_snaplen, 1, READ_TIMEOUT, errbuf);
-   if (m_handle == nullptr) {
-      throw PluginError(std::string("unable to open ifc: ") + errbuf);
-   }
-   if (errbuf[0] != 0) {
-      std::cerr << errbuf << std::endl; // Print warning
-   }
-   if (pcap_setnonblock(m_handle, 1, errbuf) < 0) {
-      close();
-      throw PluginError(std::string("unable to set nonblocking mode: ") + errbuf);
-   }
+    m_handle = pcap_open_live(ifc.c_str(), m_snaplen, 1, READ_TIMEOUT, errbuf);
+    if (m_handle == nullptr) {
+        throw PluginError(std::string("unable to open ifc: ") + errbuf);
+    }
+    if (errbuf[0] != 0) {
+        std::cerr << errbuf << std::endl; // Print warning
+    }
+    if (pcap_setnonblock(m_handle, 1, errbuf) < 0) {
+        close();
+        throw PluginError(std::string("unable to set nonblocking mode: ") + errbuf);
+    }
 
-   m_datalink = pcap_datalink(m_handle);
-   check_datalink(m_datalink);
+    m_datalink = pcap_datalink(m_handle);
+    check_datalink(m_datalink);
 
-   bpf_u_int32 net;
-   if (pcap_lookupnet(ifc.c_str(), &net, &m_netmask, errbuf) != 0) {
-      m_netmask = PCAP_NETMASK_UNKNOWN;
-   }
+    bpf_u_int32 net;
+    if (pcap_lookupnet(ifc.c_str(), &net, &m_netmask, errbuf) != 0) {
+        m_netmask = PCAP_NETMASK_UNKNOWN;
+    }
 
-   m_live = true;
+    m_live = true;
 }
 
 void PcapReader::check_datalink(int datalink)
 {
-   if (m_datalink != DLT_EN10MB && m_datalink != DLT_LINUX_SLL && m_datalink != DLT_RAW) {
+    if (m_datalink != DLT_EN10MB && m_datalink != DLT_LINUX_SLL && m_datalink != DLT_RAW) {
 #ifdef DLT_LINUX_SLL2
-      if (m_datalink == DLT_LINUX_SLL2) {
-         // DLT_LINUX_SLL2 is also supported
-         return;
-      } else {
-         close();
-         throw PluginError("unsupported link type detected, supported types are: DLT_EN10MB, DLT_LINUX_SLL, DLT_LINUX_SLL2, and DLT_RAW");
-      }
+        if (m_datalink == DLT_LINUX_SLL2) {
+            // DLT_LINUX_SLL2 is also supported
+            return;
+        } else {
+            close();
+            throw PluginError(
+                "unsupported link type detected, supported types are: DLT_EN10MB, DLT_LINUX_SLL, "
+                "DLT_LINUX_SLL2, and DLT_RAW");
+        }
 #endif
-      close();
-      throw PluginError("unsupported link type detected, supported types are DLT_EN10MB and DLT_LINUX_SLL and DLT_RAW");
-   }
+        close();
+        throw PluginError(
+            "unsupported link type detected, supported types are DLT_EN10MB and DLT_LINUX_SLL and "
+            "DLT_RAW");
+    }
 }
 
 void PcapReader::print_available_ifcs()
 {
-   char errbuf[PCAP_ERRBUF_SIZE];
-   pcap_if_t *devs;
-   pcap_if_t *d;
-   int max_width = 0;
-   int i = 0;
+    char errbuf[PCAP_ERRBUF_SIZE];
+    pcap_if_t* devs;
+    pcap_if_t* d;
+    int max_width = 0;
+    int i = 0;
 
-   if (pcap_findalldevs(&devs, errbuf) == -1) {
-      throw PluginError(std::string("error in pcap_findalldevs: ") + errbuf);
-   }
+    if (pcap_findalldevs(&devs, errbuf) == -1) {
+        throw PluginError(std::string("error in pcap_findalldevs: ") + errbuf);
+    }
 
-   if (devs != nullptr) {
-      std::cout << "List of available interfaces:" << std::endl;
-   }
+    if (devs != nullptr) {
+        std::cout << "List of available interfaces:" << std::endl;
+    }
 
-   for (d = devs; d != nullptr; d = d->next) {
-      int len = strlen(d->name);
-      if (len > max_width) {
-         max_width = len;
-      }
-   }
-   for (d = devs; d != nullptr; d = d->next) {
+    for (d = devs; d != nullptr; d = d->next) {
+        int len = strlen(d->name);
+        if (len > max_width) {
+            max_width = len;
+        }
+    }
+    for (d = devs; d != nullptr; d = d->next) {
 #ifdef PCAP_IF_UP
-      if (!(d->flags & PCAP_IF_UP)) {
-         continue;
-      }
+        if (!(d->flags & PCAP_IF_UP)) {
+            continue;
+        }
 #endif
-      std::cout << std::setw(2) << ++i << ".  " << std::setw(max_width) << d->name;
-      if (d->description) {
-         std::cout << "    " << d->description << std::endl;
-      } else {
-         std::cout << std::endl;
-      }
-   }
-   if (i == 0) {
-      std::cout << "No available interfaces found" << std::endl;
-   }
+        std::cout << std::setw(2) << ++i << ".  " << std::setw(max_width) << d->name;
+        if (d->description) {
+            std::cout << "    " << d->description << std::endl;
+        } else {
+            std::cout << std::endl;
+        }
+    }
+    if (i == 0) {
+        std::cout << "No available interfaces found" << std::endl;
+    }
 
-   pcap_freealldevs(devs);
+    pcap_freealldevs(devs);
 }
 
-void PcapReader::set_filter(const std::string &filter_str)
+void PcapReader::set_filter(const std::string& filter_str)
 {
-   struct bpf_program filter;
-   if (pcap_compile(m_handle, &filter, filter_str.c_str(), 0, m_netmask) == -1) {
-      throw PluginError("couldn't parse filter " + filter_str + ": " + std::string(pcap_geterr(m_handle)));
-   }
-   if (pcap_setfilter(m_handle, &filter) == -1) {
-      pcap_freecode(&filter);
-      throw PluginError("couldn't parse filter " + filter_str + ": " + std::string(pcap_geterr(m_handle)));
-   }
+    struct bpf_program filter;
+    if (pcap_compile(m_handle, &filter, filter_str.c_str(), 0, m_netmask) == -1) {
+        throw PluginError(
+            "couldn't parse filter " + filter_str + ": " + std::string(pcap_geterr(m_handle)));
+    }
+    if (pcap_setfilter(m_handle, &filter) == -1) {
+        pcap_freecode(&filter);
+        throw PluginError(
+            "couldn't parse filter " + filter_str + ": " + std::string(pcap_geterr(m_handle)));
+    }
 
-   pcap_freecode(&filter);
+    pcap_freecode(&filter);
 }
 
-InputPlugin::Result PcapReader::get(PacketBlock &packets)
+InputPlugin::Result PcapReader::get(PacketBlock& packets)
 {
-   parser_opt_t opt = {&packets, false, false, m_datalink};
-   int ret;
+    parser_opt_t opt = {&packets, false, false, m_datalink};
+    int ret;
 
-   if (m_handle == nullptr) {
-      throw PluginError("no interface capture or file opened");
-   }
+    if (m_handle == nullptr) {
+        throw PluginError("no interface capture or file opened");
+    }
 
-   packets.cnt = 0;
-   ret = pcap_dispatch(m_handle, PCAP_PACKET_BLOCK_SIZE, packet_handler, (u_char *) (&opt));
-   if (m_live) {
-      if (ret == 0) {
-         return Result::TIMEOUT;
-      }
-      if (ret > 0) {
-         m_seen += ret;
-         m_parsed += opt.pblock->cnt;
-         return opt.packet_valid ? Result::PARSED : Result::NOT_PARSED;
-      }
-   } else {
-      if (opt.pblock->cnt) {
-         m_seen += ret ? ret : opt.pblock->cnt;
-         m_parsed += opt.pblock->cnt;
-         return Result::PARSED;
-      } else if (ret == 0) {
-         return Result::END_OF_FILE;
-      }
-   }
-   if (ret < 0) {
-      throw PluginError(pcap_geterr(m_handle));
-   }
-   return Result::NOT_PARSED;
- }
-
+    packets.cnt = 0;
+    ret = pcap_dispatch(m_handle, PCAP_PACKET_BLOCK_SIZE, packet_handler, (u_char*) (&opt));
+    if (m_live) {
+        if (ret == 0) {
+            return Result::TIMEOUT;
+        }
+        if (ret > 0) {
+            m_seen += ret;
+            m_parsed += opt.pblock->cnt;
+            return opt.packet_valid ? Result::PARSED : Result::NOT_PARSED;
+        }
+    } else {
+        if (opt.pblock->cnt) {
+            m_seen += ret ? ret : opt.pblock->cnt;
+            m_parsed += opt.pblock->cnt;
+            return Result::PARSED;
+        } else if (ret == 0) {
+            return Result::END_OF_FILE;
+        }
+    }
+    if (ret < 0) {
+        throw PluginError(pcap_geterr(m_handle));
+    }
+    return Result::NOT_PARSED;
 }
+
+} // namespace ipxp

--- a/input/pcap.hpp
+++ b/input/pcap.hpp
@@ -32,8 +32,8 @@
 #include <pcap/pcap.h>
 
 #include <ipfixprobe/input.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/options.hpp>
+#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
@@ -41,70 +41,123 @@ namespace ipxp {
 /*
  * \brief Minimum snapshot length of pcap handle.
  */
-#define MIN_SNAPLEN  120
+#define MIN_SNAPLEN 120
 
 /*
  * \brief Maximum snapshot length of pcap handle.
  */
-#define MAX_SNAPLEN  65535
+#define MAX_SNAPLEN 65535
 
 // Read timeout in miliseconds for pcap_open_live function.
 #define READ_TIMEOUT 1000
 
-class PcapOptParser : public OptionsParser
-{
+class PcapOptParser : public OptionsParser {
 public:
-   std::string m_file;
-   std::string m_ifc;
-   std::string m_filter;
-   uint16_t m_snaplen;
-   uint64_t m_id;
-   bool m_list;
+    std::string m_file;
+    std::string m_ifc;
+    std::string m_filter;
+    uint16_t m_snaplen;
+    uint64_t m_id;
+    bool m_list;
 
-   PcapOptParser() : OptionsParser("pcap", "Input plugin for reading packets from a pcap file or a network interface"),
-      m_file(""), m_ifc(""), m_filter(""), m_snaplen(-1), m_id(0), m_list(false)
-   {
-      register_option("f", "file", "PATH", "Path to a pcap file", [this](const char *arg){m_file = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("i", "ifc", "IFC", "Network interface name", [this](const char *arg){m_ifc = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("F", "filter", "STR", "Filter string", [this](const char *arg){m_filter = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("s", "snaplen", "SIZE", "Snapshot length in bytes (live capture only)",
-         [this](const char *arg){try {m_snaplen = str2num<decltype(m_snaplen)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("l", "list", "", "Print list of available interfaces", [this](const char *arg){m_list = true; return true;}, OptionFlags::NoArgument);
-   }
+    PcapOptParser()
+        : OptionsParser(
+            "pcap",
+            "Input plugin for reading packets from a pcap file or a network interface")
+        , m_file("")
+        , m_ifc("")
+        , m_filter("")
+        , m_snaplen(-1)
+        , m_id(0)
+        , m_list(false)
+    {
+        register_option(
+            "f",
+            "file",
+            "PATH",
+            "Path to a pcap file",
+            [this](const char* arg) {
+                m_file = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "i",
+            "ifc",
+            "IFC",
+            "Network interface name",
+            [this](const char* arg) {
+                m_ifc = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "F",
+            "filter",
+            "STR",
+            "Filter string",
+            [this](const char* arg) {
+                m_filter = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "s",
+            "snaplen",
+            "SIZE",
+            "Snapshot length in bytes (live capture only)",
+            [this](const char* arg) {
+                try {
+                    m_snaplen = str2num<decltype(m_snaplen)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "l",
+            "list",
+            "",
+            "Print list of available interfaces",
+            [this](const char* arg) {
+                m_list = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
 /**
  * \brief Class for reading packets from file or network interface.
  */
-class PcapReader : public InputPlugin
-{
+class PcapReader : public InputPlugin {
 public:
-   PcapReader();
-   ~PcapReader();
+    PcapReader();
+    ~PcapReader();
 
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new PcapOptParser(); }
-   std::string get_name() const { return "pcap"; }
-   InputPlugin::Result get(PacketBlock &packets);
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new PcapOptParser(); }
+    std::string get_name() const { return "pcap"; }
+    InputPlugin::Result get(PacketBlock& packets);
 
 private:
-   pcap_t *m_handle;          /**< libpcap file handle */
-   uint16_t m_snaplen;
-   int m_datalink;
-   bool m_live;               /**< Capturing from network interface */
-   bpf_u_int32 m_netmask;       /**< Network mask. Used when setting filter */
+    pcap_t* m_handle; /**< libpcap file handle */
+    uint16_t m_snaplen;
+    int m_datalink;
+    bool m_live; /**< Capturing from network interface */
+    bpf_u_int32 m_netmask; /**< Network mask. Used when setting filter */
 
-   void open_file(const std::string &file);
-   void open_ifc(const std::string &ifc);
-   void set_filter(const std::string &filter_str);
+    void open_file(const std::string& file);
+    void open_ifc(const std::string& ifc);
+    void set_filter(const std::string& filter_str);
 
-   void check_datalink(int datalink);
-   void print_available_ifcs();
+    void check_datalink(int datalink);
+    void print_available_ifcs();
 };
 
-void packet_handler(u_char *arg, const struct pcap_pkthdr *h, const u_char *data);
+void packet_handler(u_char* arg, const struct pcap_pkthdr* h, const u_char* data);
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_PCAP_HPP */

--- a/input/raw.cpp
+++ b/input/raw.cpp
@@ -30,23 +30,23 @@
 #include <config.h>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
-#include <unistd.h>
-#include <poll.h>
-#include <linux/if_packet.h>
 #include <arpa/inet.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
+#include <ifaddrs.h>
+#include <linux/if_packet.h>
 #include <net/ethernet.h>
 #include <net/if.h>
-#include <ifaddrs.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "raw.hpp"
 #include "parser.hpp"
+#include "raw.hpp"
 
 namespace ipxp {
 
@@ -59,307 +59,328 @@ constexpr size_t RAW_PACKET_BLOCK_SIZE = 1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("raw", [](){return new RawReader();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("raw", []() { return new RawReader(); });
+    register_plugin(&rec);
 }
 
-RawReader::RawReader() : m_sock(-1), m_fanout(0), m_rd(nullptr), m_pfd({0}), m_buffer(nullptr), m_buffer_size(0),
-   m_block_idx(0), m_blocksize(0), m_framesize(0), m_blocknum(0), m_last_ppd(nullptr), m_pbd(nullptr), m_pkts_left(0)
+RawReader::RawReader()
+    : m_sock(-1)
+    , m_fanout(0)
+    , m_rd(nullptr)
+    , m_pfd({0})
+    , m_buffer(nullptr)
+    , m_buffer_size(0)
+    , m_block_idx(0)
+    , m_blocksize(0)
+    , m_framesize(0)
+    , m_blocknum(0)
+    , m_last_ppd(nullptr)
+    , m_pbd(nullptr)
+    , m_pkts_left(0)
 {
 }
 
 RawReader::~RawReader()
 {
-   close();
+    close();
 }
 
-void RawReader::init(const char *params)
+void RawReader::init(const char* params)
 {
-   RawOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    RawOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   if (parser.m_list) {
-      print_available_ifcs();
-      throw PluginExit();
-   }
+    if (parser.m_list) {
+        print_available_ifcs();
+        throw PluginExit();
+    }
 
-   m_fanout = parser.m_fanout;
-   if (parser.m_ifc.empty()) {
-      throw PluginError("specify network interface");
-   }
+    m_fanout = parser.m_fanout;
+    if (parser.m_ifc.empty()) {
+        throw PluginError("specify network interface");
+    }
 
-   long pagesize = sysconf(_SC_PAGESIZE);
-   if (pagesize == -1) {
-      throw PluginError("get page size failed");
-   }
+    long pagesize = sysconf(_SC_PAGESIZE);
+    if (pagesize == -1) {
+        throw PluginError("get page size failed");
+    }
 
-   m_blocksize = pagesize * parser.m_pkt_cnt;
-   m_framesize = 2048;
-   m_blocknum = parser.m_block_cnt;
+    m_blocksize = pagesize * parser.m_pkt_cnt;
+    m_framesize = 2048;
+    m_blocknum = parser.m_block_cnt;
 
-   if (static_cast<long>(m_framesize) > pagesize) {
-      m_framesize = pagesize;
-   }
+    if (static_cast<long>(m_framesize) > pagesize) {
+        m_framesize = pagesize;
+    }
 
-   open_ifc(parser.m_ifc);
+    open_ifc(parser.m_ifc);
 }
 
 void RawReader::close()
 {
-   if (m_buffer != nullptr) {
-      munmap(m_buffer, m_buffer_size);
-      m_buffer = nullptr;
-   }
-   if (m_rd != nullptr) {
-      free(m_rd);
-      m_rd = nullptr;
-   }
-   if (m_sock >= 0) {
-      ::close(m_sock);
-      m_sock = -1;
-   }
+    if (m_buffer != nullptr) {
+        munmap(m_buffer, m_buffer_size);
+        m_buffer = nullptr;
+    }
+    if (m_rd != nullptr) {
+        free(m_rd);
+        m_rd = nullptr;
+    }
+    if (m_sock >= 0) {
+        ::close(m_sock);
+        m_sock = -1;
+    }
 }
 
-void RawReader::open_ifc(const std::string &ifc)
+void RawReader::open_ifc(const std::string& ifc)
 {
-   int sock = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
-   if (sock == -1) {
-      throw PluginError(std::string("could not create AF_PACKET socket: ") + strerror(errno));
-   }
+    int sock = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (sock == -1) {
+        throw PluginError(std::string("could not create AF_PACKET socket: ") + strerror(errno));
+    }
 
-   int version = TPACKET_V3;
-   int ssopt_pkt_version = setsockopt(sock, SOL_PACKET, PACKET_VERSION, &version, sizeof(version));
-   if (ssopt_pkt_version == -1) {
-      ::close(sock);
-      throw PluginError(std::string("unable to set packet to v3: ") + strerror(errno));
-   }
+    int version = TPACKET_V3;
+    int ssopt_pkt_version = setsockopt(sock, SOL_PACKET, PACKET_VERSION, &version, sizeof(version));
+    if (ssopt_pkt_version == -1) {
+        ::close(sock);
+        throw PluginError(std::string("unable to set packet to v3: ") + strerror(errno));
+    }
 
-   struct ifreq ifr;
-   memset(&ifr, 0, sizeof(ifr));
-   if (ifc.size() > sizeof(ifr.ifr_name) - 1) {
-      ::close(sock);
-      throw PluginError("interface name is too long");
-   }
-   strncpy(ifr.ifr_name, ifc.c_str(), sizeof(ifr.ifr_name) - 1);
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    if (ifc.size() > sizeof(ifr.ifr_name) - 1) {
+        ::close(sock);
+        throw PluginError("interface name is too long");
+    }
+    strncpy(ifr.ifr_name, ifc.c_str(), sizeof(ifr.ifr_name) - 1);
 
-   if (ioctl(sock, SIOCGIFINDEX, &ifr) == -1) {
-      ::close(sock);
-      throw PluginError(std::string("unable to get ifc number: ioctl failed: ") + strerror(errno));
-   }
+    if (ioctl(sock, SIOCGIFINDEX, &ifr) == -1) {
+        ::close(sock);
+        throw PluginError(
+            std::string("unable to get ifc number: ioctl failed: ") + strerror(errno));
+    }
 
-   int ifc_num = ifr.ifr_ifindex;
+    int ifc_num = ifr.ifr_ifindex;
 
-   struct packet_mreq sock_params;
-   memset(&sock_params, 0, sizeof(sock_params));
-   sock_params.mr_type = PACKET_MR_PROMISC;
-   sock_params.mr_ifindex = ifc_num;
+    struct packet_mreq sock_params;
+    memset(&sock_params, 0, sizeof(sock_params));
+    sock_params.mr_type = PACKET_MR_PROMISC;
+    sock_params.mr_ifindex = ifc_num;
 
-   int set_promisc = setsockopt(sock, SOL_PACKET, PACKET_ADD_MEMBERSHIP, static_cast<void*>(&sock_params), sizeof(sock_params));
-   if (set_promisc == -1) {
-      ::close(sock);
-      throw PluginError(std::string("unable to set ifc to promisc mode: ") + strerror(errno));
-   }
+    int set_promisc = setsockopt(
+        sock,
+        SOL_PACKET,
+        PACKET_ADD_MEMBERSHIP,
+        static_cast<void*>(&sock_params),
+        sizeof(sock_params));
+    if (set_promisc == -1) {
+        ::close(sock);
+        throw PluginError(std::string("unable to set ifc to promisc mode: ") + strerror(errno));
+    }
 
-   struct tpacket_req3 req;
-   memset(&req, 0, sizeof(req));
+    struct tpacket_req3 req;
+    memset(&req, 0, sizeof(req));
 
-   req.tp_block_size = m_blocksize;
-   req.tp_block_nr = m_blocknum;
-   req.tp_frame_size = m_framesize;
-   req.tp_frame_nr = (m_blocksize * m_blocknum) / m_framesize;
+    req.tp_block_size = m_blocksize;
+    req.tp_block_nr = m_blocknum;
+    req.tp_frame_size = m_framesize;
+    req.tp_frame_nr = (m_blocksize * m_blocknum) / m_framesize;
 
-   req.tp_retire_blk_tov = 60; // timeout in msec
-   req.tp_feature_req_word = TP_FT_REQ_FILL_RXHASH;
+    req.tp_retire_blk_tov = 60; // timeout in msec
+    req.tp_feature_req_word = TP_FT_REQ_FILL_RXHASH;
 
-   int ssopt_rx_ring = setsockopt(sock, SOL_PACKET, PACKET_RX_RING, (void *) &req, sizeof(req));
-   if (ssopt_rx_ring == -1) {
-      ::close(sock);
-      throw PluginError(std::string("failed to enable RX_RING for AF_PACKET: ") + strerror(errno));
-   }
+    int ssopt_rx_ring = setsockopt(sock, SOL_PACKET, PACKET_RX_RING, (void*) &req, sizeof(req));
+    if (ssopt_rx_ring == -1) {
+        ::close(sock);
+        throw PluginError(
+            std::string("failed to enable RX_RING for AF_PACKET: ") + strerror(errno));
+    }
 
-   size_t mmap_bufsize = static_cast<size_t>(req.tp_block_size) * req.tp_block_nr;
-   uint8_t *buffer = static_cast<uint8_t *>(mmap(NULL, mmap_bufsize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_LOCKED, sock, 0));
-   if (buffer == MAP_FAILED) {
-      ::close(sock);
-      throw PluginError(std::string("mmap() failed: ") + strerror(errno));
-   }
+    size_t mmap_bufsize = static_cast<size_t>(req.tp_block_size) * req.tp_block_nr;
+    uint8_t* buffer = static_cast<uint8_t*>(
+        mmap(NULL, mmap_bufsize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_LOCKED, sock, 0));
+    if (buffer == MAP_FAILED) {
+        ::close(sock);
+        throw PluginError(std::string("mmap() failed: ") + strerror(errno));
+    }
 
-   struct iovec *rd = static_cast<struct iovec *>(malloc(req.tp_block_nr * sizeof(struct iovec)));
-   if (rd == nullptr) {
-      munmap(buffer, mmap_bufsize);
-      ::close(sock);
-      throw PluginError("not enough memory");
-   }
-   for (uint32_t i = 0; i < req.tp_block_nr; ++i) {
-      rd[i].iov_base = buffer + (i * req.tp_block_size);
-      rd[i].iov_len = req.tp_block_size;
-   }
+    struct iovec* rd = static_cast<struct iovec*>(malloc(req.tp_block_nr * sizeof(struct iovec)));
+    if (rd == nullptr) {
+        munmap(buffer, mmap_bufsize);
+        ::close(sock);
+        throw PluginError("not enough memory");
+    }
+    for (uint32_t i = 0; i < req.tp_block_nr; ++i) {
+        rd[i].iov_base = buffer + (i * req.tp_block_size);
+        rd[i].iov_len = req.tp_block_size;
+    }
 
-   struct sockaddr_ll bind_addr;
-   memset(&bind_addr, 0, sizeof(bind_addr));
-   bind_addr.sll_family = PF_PACKET;
-   bind_addr.sll_protocol = htons(ETH_P_ALL);
-   bind_addr.sll_ifindex = ifc_num;
-   bind_addr.sll_hatype = 0;
-   bind_addr.sll_pkttype = 0;
-   bind_addr.sll_halen = 0;
+    struct sockaddr_ll bind_addr;
+    memset(&bind_addr, 0, sizeof(bind_addr));
+    bind_addr.sll_family = PF_PACKET;
+    bind_addr.sll_protocol = htons(ETH_P_ALL);
+    bind_addr.sll_ifindex = ifc_num;
+    bind_addr.sll_hatype = 0;
+    bind_addr.sll_pkttype = 0;
+    bind_addr.sll_halen = 0;
 
-   int bind_res = bind(sock, (struct sockaddr *) &bind_addr, sizeof(bind_addr));
-   if (bind_res == -1) {
-      munmap(buffer, mmap_bufsize);
-      ::close(sock);
-      free(rd);
-      throw PluginError(std::string("bind failed: ") + strerror(errno));
-   }
+    int bind_res = bind(sock, (struct sockaddr*) &bind_addr, sizeof(bind_addr));
+    if (bind_res == -1) {
+        munmap(buffer, mmap_bufsize);
+        ::close(sock);
+        free(rd);
+        throw PluginError(std::string("bind failed: ") + strerror(errno));
+    }
 
-   if (m_fanout) {
-      int fanout_type = PACKET_FANOUT_CPU;
-      int fanout_arg = (m_fanout | (fanout_type << 16));
-      int setsockopt_fanout = setsockopt(sock, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg));
-      if (setsockopt_fanout == -1) {
-         munmap(buffer, mmap_bufsize);
-         ::close(sock);
-         free(rd);
-         throw PluginError(std::string("fanout failed: ") + strerror(errno));
-      }
-   }
+    if (m_fanout) {
+        int fanout_type = PACKET_FANOUT_CPU;
+        int fanout_arg = (m_fanout | (fanout_type << 16));
+        int setsockopt_fanout
+            = setsockopt(sock, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg));
+        if (setsockopt_fanout == -1) {
+            munmap(buffer, mmap_bufsize);
+            ::close(sock);
+            free(rd);
+            throw PluginError(std::string("fanout failed: ") + strerror(errno));
+        }
+    }
 
-   memset(&m_pfd, 0, sizeof(m_pfd));
-   m_pfd.fd = sock;
-   m_pfd.events = POLLIN | POLLERR;
-   m_pfd.revents = 0;
+    memset(&m_pfd, 0, sizeof(m_pfd));
+    m_pfd.fd = sock;
+    m_pfd.events = POLLIN | POLLERR;
+    m_pfd.revents = 0;
 
-   m_sock = sock;
-   m_rd = rd;
-   m_buffer_size = mmap_bufsize;
-   m_buffer = buffer;
-   m_block_idx = 0;
+    m_sock = sock;
+    m_rd = rd;
+    m_buffer_size = mmap_bufsize;
+    m_buffer = buffer;
+    m_block_idx = 0;
 
-   m_pbd = (struct tpacket_block_desc *) m_rd[m_block_idx].iov_base;
+    m_pbd = (struct tpacket_block_desc*) m_rd[m_block_idx].iov_base;
 }
 
 bool RawReader::get_block()
 {
-   if ((m_pbd->hdr.bh1.block_status & TP_STATUS_USER) == 0) {
-      // No data available at the moment
-      if (poll(&m_pfd, 1, 0) == -1) {
-         throw PluginError(std::string("poll: ") + strerror(errno));
-      }
-      return false;
-   }
-   return true;
+    if ((m_pbd->hdr.bh1.block_status & TP_STATUS_USER) == 0) {
+        // No data available at the moment
+        if (poll(&m_pfd, 1, 0) == -1) {
+            throw PluginError(std::string("poll: ") + strerror(errno));
+        }
+        return false;
+    }
+    return true;
 }
 
 void RawReader::return_block()
 {
-   m_pbd->hdr.bh1.block_status = TP_STATUS_KERNEL;
-   m_block_idx = (m_block_idx + 1) % m_blocknum;
-   m_pbd = (struct tpacket_block_desc *) m_rd[m_block_idx].iov_base;
+    m_pbd->hdr.bh1.block_status = TP_STATUS_KERNEL;
+    m_block_idx = (m_block_idx + 1) % m_blocknum;
+    m_pbd = (struct tpacket_block_desc*) m_rd[m_block_idx].iov_base;
 }
 
-int RawReader::read_packets(PacketBlock &packets)
+int RawReader::read_packets(PacketBlock& packets)
 {
-   int read_cnt = 0;
+    int read_cnt = 0;
 
-   if (m_pkts_left) {
-      read_cnt = process_packets(m_pbd, packets);
-      if (!m_pkts_left) {
-         return_block();
-      }
-      if (packets.cnt == packets.size) {
-         return read_cnt;
-      }
-   }
-   if (!get_block()) {
-      return 0;
-   }
+    if (m_pkts_left) {
+        read_cnt = process_packets(m_pbd, packets);
+        if (!m_pkts_left) {
+            return_block();
+        }
+        if (packets.cnt == packets.size) {
+            return read_cnt;
+        }
+    }
+    if (!get_block()) {
+        return 0;
+    }
 
-   read_cnt += process_packets(m_pbd, packets);
-   if (!m_pkts_left) {
-      return_block();
-   }
-   return read_cnt;
+    read_cnt += process_packets(m_pbd, packets);
+    if (!m_pkts_left) {
+        return_block();
+    }
+    return read_cnt;
 }
 
-int RawReader::process_packets(struct tpacket_block_desc *pbd, PacketBlock &packets)
+int RawReader::process_packets(struct tpacket_block_desc* pbd, PacketBlock& packets)
 {
-   parser_opt_t opt = {&packets, false, false, DLT_EN10MB};
-   uint32_t num_pkts = pbd->hdr.bh1.num_pkts;
-   uint32_t capacity = RAW_PACKET_BLOCK_SIZE - packets.cnt;
-   uint32_t to_read = 0;
-   struct tpacket3_hdr *ppd;
+    parser_opt_t opt = {&packets, false, false, DLT_EN10MB};
+    uint32_t num_pkts = pbd->hdr.bh1.num_pkts;
+    uint32_t capacity = RAW_PACKET_BLOCK_SIZE - packets.cnt;
+    uint32_t to_read = 0;
+    struct tpacket3_hdr* ppd;
 
-   if (m_pkts_left) {
-      ppd = m_last_ppd;
-      to_read = (m_pkts_left >= capacity ? capacity : m_pkts_left);
-      m_pkts_left = m_pkts_left - to_read;
-   } else {
-      ppd = (struct tpacket3_hdr *) ((uint8_t *) pbd + pbd->hdr.bh1.offset_to_first_pkt);
-      to_read = (num_pkts >= capacity ? capacity : num_pkts);
-      m_pkts_left = num_pkts - to_read;
-   }
+    if (m_pkts_left) {
+        ppd = m_last_ppd;
+        to_read = (m_pkts_left >= capacity ? capacity : m_pkts_left);
+        m_pkts_left = m_pkts_left - to_read;
+    } else {
+        ppd = (struct tpacket3_hdr*) ((uint8_t*) pbd + pbd->hdr.bh1.offset_to_first_pkt);
+        to_read = (num_pkts >= capacity ? capacity : num_pkts);
+        m_pkts_left = num_pkts - to_read;
+    }
 
-   for (uint32_t i = 0; i < to_read; ++i) {
-      const u_char *data = (uint8_t *) ppd + ppd->tp_mac;
-      size_t len = ppd->tp_len;
-      size_t snaplen = ppd->tp_snaplen;
-      struct timeval ts = {ppd->tp_sec, ppd->tp_nsec / 1000};
+    for (uint32_t i = 0; i < to_read; ++i) {
+        const u_char* data = (uint8_t*) ppd + ppd->tp_mac;
+        size_t len = ppd->tp_len;
+        size_t snaplen = ppd->tp_snaplen;
+        struct timeval ts = {ppd->tp_sec, ppd->tp_nsec / 1000};
 
-      parse_packet(&opt, ts, data, len, snaplen);
-      ppd = (struct tpacket3_hdr *) ((uint8_t *) ppd + ppd->tp_next_offset);
-   }
-   m_last_ppd = ppd;
+        parse_packet(&opt, ts, data, len, snaplen);
+        ppd = (struct tpacket3_hdr*) ((uint8_t*) ppd + ppd->tp_next_offset);
+    }
+    m_last_ppd = ppd;
 
-   return to_read;
+    return to_read;
 }
 
 void RawReader::print_available_ifcs()
 {
-   struct ifaddrs *ifaddr;
+    struct ifaddrs* ifaddr;
 
-   if (getifaddrs(&ifaddr) == -1) {
-      throw PluginError(strerror(errno));
-   }
+    if (getifaddrs(&ifaddr) == -1) {
+        throw PluginError(strerror(errno));
+    }
 
-   if (ifaddr == nullptr) {
-      std::cout << "No available interfaces found" << std::endl;
-   } else {
-      std::cout << "List of available interfaces:" << std::endl;
-   }
+    if (ifaddr == nullptr) {
+        std::cout << "No available interfaces found" << std::endl;
+    } else {
+        std::cout << "List of available interfaces:" << std::endl;
+    }
 
-   size_t idx = 1;
-   for (struct ifaddrs *ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
-      if (ifa->ifa_addr == NULL) {
-         continue;
-      }
+    size_t idx = 1;
+    for (struct ifaddrs* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == NULL) {
+            continue;
+        }
 
-      std::cout << idx++ << ".   " << ifa->ifa_name << std::endl;
-   }
+        std::cout << idx++ << ".   " << ifa->ifa_name << std::endl;
+    }
 
-   freeifaddrs(ifaddr);
-   throw PluginExit();
+    freeifaddrs(ifaddr);
+    throw PluginExit();
 }
 
-InputPlugin::Result RawReader::get(PacketBlock &packets)
+InputPlugin::Result RawReader::get(PacketBlock& packets)
 {
-   int ret;
+    int ret;
 
-   packets.cnt = 0;
-   ret = read_packets(packets);
-   if (ret == 0) {
-      return Result::TIMEOUT;
-   }
-   if (ret < 0) {
-      throw PluginError("error during reading from socket");
-   }
+    packets.cnt = 0;
+    ret = read_packets(packets);
+    if (ret == 0) {
+        return Result::TIMEOUT;
+    }
+    if (ret < 0) {
+        throw PluginError("error during reading from socket");
+    }
 
-   m_seen += ret;
-   m_parsed += packets.cnt;
-   return packets.cnt ? Result::PARSED : Result::NOT_PARSED;
- }
-
+    m_seen += ret;
+    m_parsed += packets.cnt;
+    return packets.cnt ? Result::PARSED : Result::NOT_PARSED;
 }
+
+} // namespace ipxp

--- a/input/raw.hpp
+++ b/input/raw.hpp
@@ -32,78 +32,137 @@
 #include <config.h>
 
 #include <ipfixprobe/input.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/options.hpp>
+#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
-class RawOptParser : public OptionsParser
-{
+class RawOptParser : public OptionsParser {
 public:
-   std::string m_ifc;
-   uint16_t m_fanout;
-   uint32_t m_block_cnt;
-   uint32_t m_pkt_cnt;
-   bool m_list;
+    std::string m_ifc;
+    uint16_t m_fanout;
+    uint32_t m_block_cnt;
+    uint32_t m_pkt_cnt;
+    bool m_list;
 
-   RawOptParser() : OptionsParser("raw", "Input plugin for reading packets from a raw socket"),
-      m_ifc(""), m_fanout(0), m_block_cnt(2048), m_pkt_cnt(32), m_list(false)
-   {
-      register_option("i", "ifc", "IFC", "Network interface name", [this](const char *arg){m_ifc = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("f", "fanout", "ID", "Enable packet fanout",
-         [this](const char *arg){if (arg) {
-            try {m_fanout = str2num<decltype(m_fanout)>(arg); if (!m_fanout) {return false;}} catch(std::invalid_argument &e) {return false;}
-         } else {m_fanout = getpid() & 0xFFFF;} return true;},
-         OptionFlags::OptionalArgument);
-      register_option("b", "blocks", "SIZE", "Number of packet blocks (should be power of two num)",
-         [this](const char *arg){try {m_block_cnt = str2num<decltype(m_block_cnt)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("p", "pkts", "SIZE", "Number of packets in block (should be power of two num)",
-         [this](const char *arg){try {m_pkt_cnt = str2num<decltype(m_pkt_cnt)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("l", "list", "", "Print list of available interfaces", [this](const char *arg){m_list = true; return true;}, OptionFlags::NoArgument);
-   }
+    RawOptParser()
+        : OptionsParser("raw", "Input plugin for reading packets from a raw socket")
+        , m_ifc("")
+        , m_fanout(0)
+        , m_block_cnt(2048)
+        , m_pkt_cnt(32)
+        , m_list(false)
+    {
+        register_option(
+            "i",
+            "ifc",
+            "IFC",
+            "Network interface name",
+            [this](const char* arg) {
+                m_ifc = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "f",
+            "fanout",
+            "ID",
+            "Enable packet fanout",
+            [this](const char* arg) {
+                if (arg) {
+                    try {
+                        m_fanout = str2num<decltype(m_fanout)>(arg);
+                        if (!m_fanout) {
+                            return false;
+                        }
+                    } catch (std::invalid_argument& e) {
+                        return false;
+                    }
+                } else {
+                    m_fanout = getpid() & 0xFFFF;
+                }
+                return true;
+            },
+            OptionFlags::OptionalArgument);
+        register_option(
+            "b",
+            "blocks",
+            "SIZE",
+            "Number of packet blocks (should be power of two num)",
+            [this](const char* arg) {
+                try {
+                    m_block_cnt = str2num<decltype(m_block_cnt)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "p",
+            "pkts",
+            "SIZE",
+            "Number of packets in block (should be power of two num)",
+            [this](const char* arg) {
+                try {
+                    m_pkt_cnt = str2num<decltype(m_pkt_cnt)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "l",
+            "list",
+            "",
+            "Print list of available interfaces",
+            [this](const char* arg) {
+                m_list = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-class RawReader : public InputPlugin
-{
+class RawReader : public InputPlugin {
 public:
-   RawReader();
-   ~RawReader();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new RawOptParser(); }
-   std::string get_name() const { return "raw"; }
-   InputPlugin::Result get(PacketBlock &packets);
+    RawReader();
+    ~RawReader();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new RawOptParser(); }
+    std::string get_name() const { return "raw"; }
+    InputPlugin::Result get(PacketBlock& packets);
 
 private:
-   int m_sock;
-   uint16_t m_fanout;
-   struct iovec *m_rd;
-   struct pollfd m_pfd;
+    int m_sock;
+    uint16_t m_fanout;
+    struct iovec* m_rd;
+    struct pollfd m_pfd;
 
-   uint8_t *m_buffer;
-   uint32_t m_buffer_size;
+    uint8_t* m_buffer;
+    uint32_t m_buffer_size;
 
-   uint32_t m_block_idx;
-   uint32_t m_blocksize;
-   uint32_t m_framesize;
-   uint32_t m_blocknum;
+    uint32_t m_block_idx;
+    uint32_t m_blocksize;
+    uint32_t m_framesize;
+    uint32_t m_blocknum;
 
-   struct tpacket3_hdr *m_last_ppd;
-   struct tpacket_block_desc *m_pbd;
-   uint32_t m_pkts_left;
+    struct tpacket3_hdr* m_last_ppd;
+    struct tpacket_block_desc* m_pbd;
+    uint32_t m_pkts_left;
 
-   void open_ifc(const std::string &ifc);
-   bool get_block();
-   void return_block();
-   int read_packets(PacketBlock &packets);
-   int process_packets(struct tpacket_block_desc *pbd, PacketBlock &packets);
-   void print_available_ifcs();
+    void open_ifc(const std::string& ifc);
+    bool get_block();
+    void return_block();
+    int read_packets(PacketBlock& packets);
+    int process_packets(struct tpacket_block_desc* pbd, PacketBlock& packets);
+    void print_available_ifcs();
 };
 
-void packet_handler(u_char *arg, const struct pcap_pkthdr *h, const u_char *data);
+void packet_handler(u_char* arg, const struct pcap_pkthdr* h, const u_char* data);
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_RAW_HPP */

--- a/input/stem.cpp
+++ b/input/stem.cpp
@@ -40,147 +40,148 @@ constexpr size_t STEM_PACKET_BLOCK_SIZE = 1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("stem", [](){return new StemPacketReader();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("stem", []() { return new StemPacketReader(); });
+    register_plugin(&rec);
 }
 
-StemPacketReader::StemPacketReader() : m_reader(nullptr)
+StemPacketReader::StemPacketReader()
+    : m_reader(nullptr)
 {
 }
 
 StemPacketReader::~StemPacketReader()
 {
-   close();
+    close();
 }
 
-void StemPacketReader::init(const char *params)
+void StemPacketReader::init(const char* params)
 {
-   StemOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    StemOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   if (parser.m_dev.empty()) {
-      throw PluginError("specify device path");
-   }
+    if (parser.m_dev.empty()) {
+        throw PluginError("specify device path");
+    }
 
-   open_dev(parser.m_dev);
+    open_dev(parser.m_dev);
 }
 
 void StemPacketReader::close()
 {
-   if (m_reader != nullptr) {
-      delete m_reader;
-      m_reader = nullptr;
-   }
+    if (m_reader != nullptr) {
+        delete m_reader;
+        m_reader = nullptr;
+    }
 }
 
-void StemPacketReader::open_dev(const std::string &file)
+void StemPacketReader::open_dev(const std::string& file)
 {
-   try {
-      m_reader = new Stem::StemInterface<Stem::PcapReader>(file);
-   } catch (Stem::Exceptions::Readers::ReaderSetupError &e) {
-      throw PluginError(e.what());
-   }
+    try {
+        m_reader = new Stem::StemInterface<Stem::PcapReader>(file);
+    } catch (Stem::Exceptions::Readers::ReaderSetupError& e) {
+        throw PluginError(e.what());
+    }
 }
 
-bool StemPacketReader::convert(Stem::StatisticsPacket &stem_pkt, Packet &pkt)
+bool StemPacketReader::convert(Stem::StatisticsPacket& stem_pkt, Packet& pkt)
 {
-   Stem::StadeHardwareData hwdata = stem_pkt.hw_data();
-   if (hwdata.size() > pkt.buffer_size) {
-      return false;
-   }
+    Stem::StadeHardwareData hwdata = stem_pkt.hw_data();
+    if (hwdata.size() > pkt.buffer_size) {
+        return false;
+    }
 
-   pkt.ts = {hwdata.arrived_at.sec, hwdata.arrived_at.nsec / 1000};
+    pkt.ts = {hwdata.arrived_at.sec, hwdata.arrived_at.nsec / 1000};
 
-   memset(pkt.dst_mac, 0, sizeof(pkt.dst_mac));
-   memset(pkt.src_mac, 0, sizeof(pkt.src_mac));
-   pkt.ethertype = 0;
+    memset(pkt.dst_mac, 0, sizeof(pkt.dst_mac));
+    memset(pkt.src_mac, 0, sizeof(pkt.src_mac));
+    pkt.ethertype = 0;
 
-   size_t vlan_cnt = (hwdata.vlan_0 ? 1 : 0) + (hwdata.vlan_1 ? 1 : 0);
-   size_t ip_offset = 14 + vlan_cnt * 4;
+    size_t vlan_cnt = (hwdata.vlan_0 ? 1 : 0) + (hwdata.vlan_1 ? 1 : 0);
+    size_t ip_offset = 14 + vlan_cnt * 4;
 
-   pkt.ip_len = hwdata.frame_len - ip_offset; // this should be done better
-   pkt.ip_version = hwdata.ip_version; // Get ip version
-   pkt.ip_ttl = 0;
-   pkt.ip_proto = hwdata.protocol;
-   pkt.ip_tos = 0;
-   pkt.ip_flags = 0;
-   if (pkt.ip_version == IP::v4) {
-      pkt.src_ip.v4 = *reinterpret_cast<uint32_t*>(hwdata.src_ip.data());
-      pkt.dst_ip.v4 = *reinterpret_cast<uint32_t*>(hwdata.dst_ip.data());
-      pkt.ip_payload_len = pkt.ip_len - 20;
-   } else {
-      memcpy(pkt.src_ip.v6, reinterpret_cast<uint8_t*>(hwdata.src_ip.data()), 16);
-      memcpy(pkt.dst_ip.v6, reinterpret_cast<uint8_t*>(hwdata.dst_ip.data()), 16);
-      pkt.ip_payload_len = pkt.ip_len - 40;
-   }
+    pkt.ip_len = hwdata.frame_len - ip_offset; // this should be done better
+    pkt.ip_version = hwdata.ip_version; // Get ip version
+    pkt.ip_ttl = 0;
+    pkt.ip_proto = hwdata.protocol;
+    pkt.ip_tos = 0;
+    pkt.ip_flags = 0;
+    if (pkt.ip_version == IP::v4) {
+        pkt.src_ip.v4 = *reinterpret_cast<uint32_t*>(hwdata.src_ip.data());
+        pkt.dst_ip.v4 = *reinterpret_cast<uint32_t*>(hwdata.dst_ip.data());
+        pkt.ip_payload_len = pkt.ip_len - 20;
+    } else {
+        memcpy(pkt.src_ip.v6, reinterpret_cast<uint8_t*>(hwdata.src_ip.data()), 16);
+        memcpy(pkt.dst_ip.v6, reinterpret_cast<uint8_t*>(hwdata.dst_ip.data()), 16);
+        pkt.ip_payload_len = pkt.ip_len - 40;
+    }
 
-   pkt.src_port = ntohs(hwdata.src_port);
-   pkt.dst_port = ntohs(hwdata.dst_port);
-   pkt.tcp_flags = hwdata.l4_flags;
-   pkt.tcp_window = 0;
-   pkt.tcp_options = 0;
-   pkt.tcp_mss = 0;
-   pkt.tcp_seq = hwdata.tcp_seq;
-   pkt.tcp_ack = hwdata.tcp_ack;
+    pkt.src_port = ntohs(hwdata.src_port);
+    pkt.dst_port = ntohs(hwdata.dst_port);
+    pkt.tcp_flags = hwdata.l4_flags;
+    pkt.tcp_window = 0;
+    pkt.tcp_options = 0;
+    pkt.tcp_mss = 0;
+    pkt.tcp_seq = hwdata.tcp_seq;
+    pkt.tcp_ack = hwdata.tcp_ack;
 
-   auto &raw_hwdata = stem_pkt.serialized();
-   uint16_t datalen = raw_hwdata->size();
-   if (datalen > pkt.buffer_size) {
-      datalen = pkt.buffer_size;
-   }
-   memcpy(pkt.buffer, raw_hwdata->data(), datalen);
+    auto& raw_hwdata = stem_pkt.serialized();
+    uint16_t datalen = raw_hwdata->size();
+    if (datalen > pkt.buffer_size) {
+        datalen = pkt.buffer_size;
+    }
+    memcpy(pkt.buffer, raw_hwdata->data(), datalen);
 
-   pkt.packet = pkt.buffer;
-   pkt.packet_len = 0;
-   pkt.packet_len_wire = hwdata.frame_len;
+    pkt.packet = pkt.buffer;
+    pkt.packet_len = 0;
+    pkt.packet_len_wire = hwdata.frame_len;
 
-   pkt.custom = pkt.buffer;
-   pkt.custom_len = hwdata.size();
+    pkt.custom = pkt.buffer;
+    pkt.custom_len = hwdata.size();
 
-   pkt.payload = pkt.buffer + hwdata.size();
-   pkt.payload_len = datalen - hwdata.size();
-   if (datalen < hwdata.size()) {
-      pkt.payload_len = 0;
-   }
-   pkt.payload_len_wire = raw_hwdata->size() - hwdata.size();
+    pkt.payload = pkt.buffer + hwdata.size();
+    pkt.payload_len = datalen - hwdata.size();
+    if (datalen < hwdata.size()) {
+        pkt.payload_len = 0;
+    }
+    pkt.payload_len_wire = raw_hwdata->size() - hwdata.size();
 
-   return true;
+    return true;
 }
 
-InputPlugin::Result StemPacketReader::get(PacketBlock &packets)
+InputPlugin::Result StemPacketReader::get(PacketBlock& packets)
 {
-   packets.cnt = 0;
-   packets.bytes = 0;
-   while (packets.cnt < STEM_PACKET_BLOCK_SIZE) {
-      try {
-         auto pkt = m_reader->next_packet();
-         if (!pkt.has_value()) {
-            if (packets.cnt) {
-               return Result::PARSED;
+    packets.cnt = 0;
+    packets.bytes = 0;
+    while (packets.cnt < STEM_PACKET_BLOCK_SIZE) {
+        try {
+            auto pkt = m_reader->next_packet();
+            if (!pkt.has_value()) {
+                if (packets.cnt) {
+                    return Result::PARSED;
+                }
+                return Result::TIMEOUT;
+            } else {
+                Stem::StatisticsPacket spkt = std::move(pkt.value());
+                bool status = convert(spkt, packets.pkts[packets.cnt]);
+                packets.bytes += packets.pkts[packets.cnt].packet_len_wire;
+
+                m_seen += 1;
+                if (!status) {
+                    continue;
+                }
+                packets.cnt++;
+                m_parsed += 1;
             }
-            return Result::TIMEOUT;
-         } else {
-            Stem::StatisticsPacket spkt = std::move(pkt.value());
-            bool status = convert(spkt, packets.pkts[packets.cnt]);
-            packets.bytes += packets.pkts[packets.cnt].packet_len_wire;
+        } catch (Stem::Exceptions::Readers::ReadError& e) {
+            throw PluginError(e.what());
+        }
+    }
 
-            m_seen += 1;
-            if (!status) {
-               continue;
-            }
-            packets.cnt++;
-            m_parsed += 1;
-         }
-      } catch (Stem::Exceptions::Readers::ReadError &e) {
-         throw PluginError(e.what());
-      }
-   }
-
-   return packets.cnt ? Result::PARSED : Result::NOT_PARSED;
- }
-
+    return packets.cnt ? Result::PARSED : Result::NOT_PARSED;
 }
+
+} // namespace ipxp

--- a/input/stem.hpp
+++ b/input/stem.hpp
@@ -31,47 +31,55 @@
 
 #include <config.h>
 
-#include <stem-interface.h>
-#include <statistics-packet.h>
 #include <pcap-reader.h>
+#include <statistics-packet.h>
+#include <stem-interface.h>
 
 #include <ipfixprobe/input.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/options.hpp>
+#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
-class StemOptParser : public OptionsParser
-{
+class StemOptParser : public OptionsParser {
 public:
-   std::string m_dev;
+    std::string m_dev;
 
-   StemOptParser() : OptionsParser("stem", "Input plugin for reading packets using libstem"),
-      m_dev("")
-   {
-      register_option("d", "dev", "PATH", "Path to a device file", [this](const char *arg){m_dev = arg; return true;}, OptionFlags::RequiredArgument);
-   }
+    StemOptParser()
+        : OptionsParser("stem", "Input plugin for reading packets using libstem")
+        , m_dev("")
+    {
+        register_option(
+            "d",
+            "dev",
+            "PATH",
+            "Path to a device file",
+            [this](const char* arg) {
+                m_dev = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+    }
 };
 
-class StemPacketReader : public InputPlugin
-{
+class StemPacketReader : public InputPlugin {
 public:
-   StemPacketReader();
-   ~StemPacketReader();
+    StemPacketReader();
+    ~StemPacketReader();
 
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new StemOptParser(); }
-   std::string get_name() const { return "stem"; }
-   InputPlugin::Result get(PacketBlock &packets);
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new StemOptParser(); }
+    std::string get_name() const { return "stem"; }
+    InputPlugin::Result get(PacketBlock& packets);
 
 private:
-   Stem::StemInterface<Stem::PcapReader> *m_reader;
+    Stem::StemInterface<Stem::PcapReader>* m_reader;
 
-   bool convert(Stem::StatisticsPacket &stem_pkt, Packet &pkt);
-   void open_dev(const std::string &file);
+    bool convert(Stem::StatisticsPacket& stem_pkt, Packet& pkt);
+    void open_dev(const std::string& file);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_INPUT_STEM_HPP */

--- a/ipfixprobe.cpp
+++ b/ipfixprobe.cpp
@@ -27,17 +27,17 @@
  */
 
 #include <config.h>
-#include <unistd.h>
-#include <string>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 #include <fstream>
-#include <memory>
-#include <thread>
 #include <future>
-#include <signal.h>
+#include <iomanip>
+#include <iostream>
+#include <memory>
 #include <poll.h>
+#include <signal.h>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unistd.h>
 
 #include "ipfixprobe.hpp"
 #ifdef WITH_LIBUNWIND
@@ -63,587 +63,577 @@ const uint32_t DEFAULT_FPS = 0; // unlimited
 void signal_handler(int sig)
 {
 #ifdef WITH_LIBUNWIND
-   if (sig == SIGSEGV) {
-      st_dump(STDERR_FILENO, sig);
-      abort();
-   }
+    if (sig == SIGSEGV) {
+        st_dump(STDERR_FILENO, sig);
+        abort();
+    }
 #endif
-   stop = 1;
+    stop = 1;
 }
 
 void register_handlers()
 {
-   signal(SIGTERM, signal_handler);
-   signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+    signal(SIGINT, signal_handler);
 #ifdef WITH_LIBUNWIND
-   signal(SIGSEGV, signal_handler);
+    signal(SIGSEGV, signal_handler);
 #endif
 #ifdef WITH_NEMEA
-   signal(SIGPIPE, SIG_IGN);
+    signal(SIGPIPE, SIG_IGN);
 #endif
 }
 
 void error(std::string msg)
 {
-   std::cerr << "Error: " << msg << std::endl;
+    std::cerr << "Error: " << msg << std::endl;
 }
 
 template<typename T>
-static void print_plugins_help(std::vector<Plugin *> &plugins)
+static void print_plugins_help(std::vector<Plugin*>& plugins)
 {
-   for (auto &it : plugins) {
-      if (dynamic_cast<T *>(it)) {
-         OptionsParser *parser = it->get_parser();
-         parser->usage(std::cout);
-         std::cout << std::endl;
-         delete parser;
-      }
-   }
+    for (auto& it : plugins) {
+        if (dynamic_cast<T*>(it)) {
+            OptionsParser* parser = it->get_parser();
+            parser->usage(std::cout);
+            std::cout << std::endl;
+            delete parser;
+        }
+    }
 }
 
-void print_help(ipxp_conf_t &conf, const std::string &arg)
+void print_help(ipxp_conf_t& conf, const std::string& arg)
 {
-   auto deleter = [&](std::vector<Plugin *> *p) {
-      for (auto &it : *p) {
-         delete it;
-      }
-      delete p;
-   };
-   auto plugins = std::unique_ptr<std::vector<Plugin *>, decltype(deleter)>(new std::vector<Plugin*>(conf.mgr.get()), deleter);
+    auto deleter = [&](std::vector<Plugin*>* p) {
+        for (auto& it : *p) {
+            delete it;
+        }
+        delete p;
+    };
+    auto plugins = std::unique_ptr<std::vector<Plugin*>, decltype(deleter)>(
+        new std::vector<Plugin*>(conf.mgr.get()),
+        deleter);
 
-   if (arg == "input") {
-      print_plugins_help<InputPlugin>(*plugins);
-   } else if (arg == "storage") {
-      print_plugins_help<StoragePlugin>(*plugins);
-   } else if (arg == "output") {
-      print_plugins_help<OutputPlugin>(*plugins);
-   } else if (arg == "process") {
-      print_plugins_help<ProcessPlugin>(*plugins);
-   } else {
-      Plugin *p;
-      try {
-         p = conf.mgr.get(arg);
-         if (p == nullptr) {
-            std::cout << "No help available for " << arg << std::endl;
-            return;
-         }
-      } catch (PluginManagerError &e) {
-         error(std::string("when loading plugin: ") + e.what());
-         return;
-      }
-      OptionsParser *parser = p->get_parser();
-      parser->usage(std::cout);
-      delete parser;
-      delete p;
-   }
-}
-
-void process_plugin_argline(const std::string &args, std::string &plugin, std::string &params)
-{
-   size_t delim;
-
-   params = args;
-   delim = params.find(OptionsParser::DELIM);
-
-   plugin = params.substr(0, delim);
-   params.erase(0, delim == std::string::npos ? delim : delim + 1);
-
-   trim_str(plugin);
-   trim_str(params);
-}
-
-bool process_plugin_args(ipxp_conf_t &conf, IpfixprobeOptParser &parser)
-{
-   auto deleter = [&](OutputPlugin::Plugins *p) {
-      for (auto &it : *p) {
-         delete it.second;
-      }
-      delete p;
-   };
-   auto process_plugins = std::unique_ptr<OutputPlugin::Plugins, decltype(deleter)>(new OutputPlugin::Plugins(), deleter);
-   std::string storage_name = "cache";
-   std::string storage_params = "";
-   std::string output_name = "ipfix";
-   std::string output_params = "";
-
-   if (parser.m_storage.size()) {
-      process_plugin_argline(parser.m_storage[0], storage_name, storage_params);
-   }
-   if (parser.m_output.size()) {
-      process_plugin_argline(parser.m_output[0], output_name, output_params);
-   }
-
-   // Process
-   for (auto &it : parser.m_process) {
-      ProcessPlugin *process_plugin = nullptr;
-      std::string process_params;
-      std::string process_name;
-      process_plugin_argline(it, process_name, process_params);
-      for (auto &it : *process_plugins) {
-         std::string plugin_name = it.first;
-         if (plugin_name == process_name) {
-            throw IPXPError(process_name + " plugin was specified multiple times");
-         }
-      }
-      if (process_name == BASIC_PLUGIN_NAME) {
-         continue;
-      }
-      try {
-         process_plugin = dynamic_cast<ProcessPlugin *>(conf.mgr.get(process_name));
-         if (process_plugin == nullptr) {
-            throw IPXPError("invalid processing plugin " + process_name);
-         }
-
-         process_plugin->init(process_params.c_str());
-         process_plugins->push_back(std::make_pair(process_name, process_plugin));
-      } catch (PluginError &e) {
-         delete process_plugin;
-         throw IPXPError(process_name + std::string(": ") + e.what());
-      } catch (PluginExit &e) {
-         delete process_plugin;
-         return true;
-      } catch (PluginManagerError &e) {
-         throw IPXPError(process_name + std::string(": ") + e.what());
-      }
-   }
-
-   // Output
-   ipx_ring_t *output_queue = ipx_ring_init(conf.oqueue_size, 1);
-   if (output_queue == nullptr) {
-      throw IPXPError("unable to initialize ring buffer");
-   }
-   OutputPlugin *output_plugin = nullptr;
-   try {
-      output_plugin = dynamic_cast<OutputPlugin *>(conf.mgr.get(output_name));
-      if (output_plugin == nullptr) {
-         ipx_ring_destroy(output_queue);
-         throw IPXPError("invalid output plugin " + output_name);
-      }
-
-      output_plugin->init(output_params.c_str(), *process_plugins);
-      conf.active.output.push_back(output_plugin);
-      conf.active.all.push_back(output_plugin);
-   } catch (PluginError &e) {
-      ipx_ring_destroy(output_queue);
-      delete output_plugin;
-      throw IPXPError(output_name + std::string(": ") + e.what());
-   } catch (PluginExit &e) {
-      ipx_ring_destroy(output_queue);
-      delete output_plugin;
-      return true;
-   } catch (PluginManagerError &e) {
-      throw IPXPError(output_name + std::string(": ") + e.what());
-   }
-
-   {
-      std::promise<WorkerResult> *output_res = new std::promise<WorkerResult>();
-      auto output_stats = new std::atomic<OutputStats>();
-      conf.output_stats.push_back(output_stats);
-      OutputWorker tmp = {
-              output_plugin,
-              new std::thread(output_worker, output_plugin, output_queue, output_res, output_stats, conf.fps),
-              output_res,
-              output_stats,
-              output_queue
-      };
-      conf.outputs.push_back(tmp);
-      conf.output_fut.push_back(output_res->get_future());
-   }
-
-   // Input
-   size_t pipeline_idx = 0;
-   for (auto &it : parser.m_input) {
-      InputPlugin *input_plugin = nullptr;
-      StoragePlugin *storage_plugin = nullptr;
-      std::string input_params;
-      std::string input_name;
-      process_plugin_argline(it, input_name, input_params);
-
-      try {
-         input_plugin = dynamic_cast<InputPlugin *>(conf.mgr.get(input_name));
-         if (input_plugin == nullptr) {
-            throw IPXPError("invalid input plugin " + input_name);
-         }
-         input_plugin->init(input_params.c_str());
-         conf.active.input.push_back(input_plugin);
-         conf.active.all.push_back(input_plugin);
-      } catch (PluginError &e) {
-         delete input_plugin;
-         throw IPXPError(input_name + std::string(": ") + e.what());
-      } catch (PluginExit &e) {
-         delete input_plugin;
-         return true;
-      } catch (PluginManagerError &e) {
-         throw IPXPError(input_name + std::string(": ") + e.what());
-      }
-
-      try {
-         storage_plugin = dynamic_cast<StoragePlugin *>(conf.mgr.get(storage_name));
-         if (storage_plugin == nullptr) {
-            throw IPXPError("invalid storage plugin " + storage_name);
-         }
-         storage_plugin->set_queue(output_queue);
-         storage_plugin->init(storage_params.c_str());
-         conf.active.storage.push_back(storage_plugin);
-         conf.active.all.push_back(storage_plugin);
-      } catch (PluginError &e) {
-         delete storage_plugin;
-         throw IPXPError(storage_name + std::string(": ") + e.what());
-      } catch (PluginExit &e) {
-         delete storage_plugin;
-         return true;
-      } catch (PluginManagerError &e) {
-         throw IPXPError(storage_name + std::string(": ") + e.what());
-      }
-
-      std::vector<ProcessPlugin *> storage_process_plugins;
-      for (auto &it : *process_plugins) {
-         ProcessPlugin *tmp = it.second->copy();
-         storage_plugin->add_plugin(tmp);
-         conf.active.process.push_back(tmp);
-         conf.active.all.push_back(tmp);
-         storage_process_plugins.push_back(tmp);
-      }
-
-      std::promise<WorkerResult> *input_res = new std::promise<WorkerResult>();
-      conf.input_fut.push_back(input_res->get_future());
-
-      auto input_stats = new std::atomic<InputStats>();
-      conf.input_stats.push_back(input_stats);
-
-      WorkPipeline tmp = {
-         {
-            input_plugin,
-            new std::thread(input_storage_worker, input_plugin, storage_plugin, conf.iqueue_size, 
-               conf.max_pkts, input_res, input_stats),
-            input_res,
-            input_stats
-         },
-         {
-            storage_plugin,
-            storage_process_plugins
-         }
-      };
-      conf.pipelines.push_back(tmp);
-      pipeline_idx++;
-   }
-
-   return false;
-}
-
-void finish(ipxp_conf_t &conf)
-{
-   bool ok = true;
-
-   // Terminate all inputs
-   terminate_input = 1;
-   for (auto &it : conf.pipelines) {
-      it.input.thread->join();
-      it.input.plugin->close();
-   }
-
-   // Terminate all storages
-   for (auto &it : conf.pipelines) {
-      for (auto &itp : it.storage.plugins) {
-         itp->close();
-      }
-   }
-
-   // Terminate all outputs
-   terminate_export = 1;
-   for (auto &it : conf.outputs) {
-      it.thread->join();
-   }
-
-   for (auto &it : conf.pipelines) {
-      it.storage.plugin->close();
-   }
-
-   std::cout << "Input stats:" << std::endl <<
-      std::setw(3) << "#" <<
-      std::setw(13) << "packets" <<
-      std::setw(13) << "parsed" <<
-      std::setw(20) << "bytes" <<
-      std::setw(13) << "dropped" <<
-      std::setw(16) << "qtime" <<
-      std::setw(7) << "status" << std::endl;
-
-   int idx = 0;
-   uint64_t total_packets = 0;
-   uint64_t total_parsed = 0;
-   uint64_t total_bytes = 0;
-   uint64_t total_dropped = 0;
-   uint64_t total_qtime = 0;
-
-   for (auto &it : conf.input_fut) {
-      WorkerResult res = it.get();
-      std::string status = "ok";
-      if (res.error) {
-         ok = false;
-         status = res.msg;
-      }
-      InputStats stats = conf.input_stats[idx]->load();
-      std::cout <<
-         std::setw(3) << idx++ << " " <<
-         std::setw(12) << stats.packets << " " <<
-         std::setw(12) << stats.parsed << " " <<
-         std::setw(19) << stats.bytes << " " <<
-         std::setw(12) << stats.dropped << " " <<
-         std::setw(15) << stats.qtime << " " <<
-         std::setw(6) << status << std::endl;
-      total_packets += stats.packets;
-      total_parsed += stats.parsed;
-      total_bytes += stats.bytes;
-      total_dropped += stats.dropped;
-      total_qtime += stats.qtime;
-   }
-
-   std::cout <<
-      std::setw(3) << "SUM" <<
-      std::setw(13) << total_packets <<
-      std::setw(13) << total_parsed <<
-      std::setw(20) << total_bytes <<
-      std::setw(13) << total_dropped <<
-      std::setw(16) << total_qtime << std::endl;
-
-   std::cout << std::endl;
-
-   std::cout << "Output stats:" << std::endl <<
-      std::setw(3) << "#" <<
-      std::setw(13) << "biflows" <<
-      std::setw(13) << "packets" <<
-      std::setw(20) << "bytes (L4)" <<
-      std::setw(13) << "dropped" <<
-      std::setw(7) << "status" << std::endl;
-
-   idx = 0;
-   for (auto &it : conf.output_fut) {
-      WorkerResult res = it.get();
-      std::string status = "ok";
-      if (res.error) {
-         ok = false;
-         status = res.msg;
-      }
-      OutputStats stats = conf.output_stats[idx]->load();
-      std::cout <<
-         std::setw(3) << idx++ << " " <<
-         std::setw(12) << stats.biflows << " " <<
-         std::setw(12) << stats.packets << " " <<
-         std::setw(19) << stats.bytes << " " <<
-         std::setw(12) << stats.dropped << " " <<
-         std::setw(6) << status << std::endl;
-   }
-
-   if (!ok) {
-      throw IPXPError("one of the plugins exitted unexpectedly");
-   }
-}
-
-void serve_stat_clients(ipxp_conf_t &conf, struct pollfd pfds[2])
-{
-   uint8_t buffer[100000];
-   size_t written = 0;
-   msg_header_t *hdr = (msg_header_t *) buffer;
-   int ret = poll(pfds, 2, 0);
-   if (ret <= 0) {
-      return;
-   }
-   if (pfds[1].fd > 0 && pfds[1].revents & POLL_IN) {
-      ret = recv_data(pfds[1].fd, sizeof(uint32_t), buffer);
-      if (ret < 0) {
-         // Client disconnected
-         close(pfds[1].fd);
-         pfds[1].fd = -1;
-      } else {
-         if (*((uint32_t *) buffer) != MSG_MAGIC) {
-            return;
-         }
-         // Received stats request from client
-         written += sizeof(msg_header_t);
-         for (auto &it : conf.input_stats) {
-            InputStats stats = it->load();
-            *(InputStats *)(buffer + written) = stats;
-            written += sizeof(InputStats);
-         }
-         for (auto &it : conf.output_stats) {
-            OutputStats stats = it->load();
-            *(OutputStats *)(buffer + written) = stats;
-            written += sizeof(OutputStats);
-         }
-
-         hdr->magic = MSG_MAGIC;
-         hdr->size = written - sizeof(msg_header_t);
-         hdr->inputs = conf.input_stats.size();
-         hdr->outputs = conf.output_stats.size();
-
-         send_data(pfds[1].fd, written, buffer);
-      }
-   }
-
-   if (pfds[0].revents & POLL_IN) {
-      int fd = accept(pfds[0].fd, NULL, NULL);
-      if (pfds[1].fd == -1) {
-         pfds[1].fd = fd;
-      } else if (fd != -1) {
-         // Close incoming connection
-         close(fd);
-      }
-   }
-}
-
-void main_loop(ipxp_conf_t &conf)
-{
-   std::vector<std::shared_future<WorkerResult>*> futs;
-   for (auto &it : conf.input_fut) {
-      futs.push_back(&it);
-   }
-
-   struct pollfd pfds[2] = {
-      {.fd = -1, .events = POLL_IN}, // Server
-      {.fd = -1, .events = POLL_IN} // Client
-   };
-
-   std::string sock_path = create_sockpath(std::to_string(getpid()).c_str());
-   pfds[0].fd = create_stats_sock(sock_path.c_str());
-   if (pfds[0].fd < 0) {
-      error("Unable to create stats socket " + sock_path);
-   }
-
-   while (!stop && futs.size()) {
-      serve_stat_clients(conf, pfds);
-
-      for (auto it = futs.begin(); it != futs.end(); it++) {
-         std::future_status status = (*it)->wait_for(std::chrono::seconds(0));
-         if (status == std::future_status::ready) {
-            WorkerResult res = (*it)->get();
-            if (!res.error) {
-               it = futs.erase(it);
-               break;
+    if (arg == "input") {
+        print_plugins_help<InputPlugin>(*plugins);
+    } else if (arg == "storage") {
+        print_plugins_help<StoragePlugin>(*plugins);
+    } else if (arg == "output") {
+        print_plugins_help<OutputPlugin>(*plugins);
+    } else if (arg == "process") {
+        print_plugins_help<ProcessPlugin>(*plugins);
+    } else {
+        Plugin* p;
+        try {
+            p = conf.mgr.get(arg);
+            if (p == nullptr) {
+                std::cout << "No help available for " << arg << std::endl;
+                return;
             }
-            stop = 1;
-            break;
-         }
-      }
-      for (auto &it : conf.output_fut) {
-         std::future_status status = it.wait_for(std::chrono::seconds(0));
-         if (status == std::future_status::ready) {
-            stop = 1;
-            break;
-         }
-      }
-
-      usleep(1000);
-   }
-
-   if (pfds[0].fd != -1) {
-      close(pfds[0].fd);
-   }
-   if (pfds[1].fd != -1) {
-      close(pfds[1].fd);
-   }
-   unlink(sock_path.c_str());
-   finish(conf);
+        } catch (PluginManagerError& e) {
+            error(std::string("when loading plugin: ") + e.what());
+            return;
+        }
+        OptionsParser* parser = p->get_parser();
+        parser->usage(std::cout);
+        delete parser;
+        delete p;
+    }
 }
 
-int run(int argc, char *argv[])
+void process_plugin_argline(const std::string& args, std::string& plugin, std::string& params)
 {
-   IpfixprobeOptParser parser;
-   ipxp_conf_t conf;
-   int status = EXIT_SUCCESS;
+    size_t delim;
 
-   register_handlers();
+    params = args;
+    delim = params.find(OptionsParser::DELIM);
 
-   try {
-      parser.parse(argc - 1, const_cast<const char **>(argv) + 1);
-   } catch (ParserError &e) {
-      error(e.what());
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
+    plugin = params.substr(0, delim);
+    params.erase(0, delim == std::string::npos ? delim : delim + 1);
 
-   if (parser.m_help) {
-      if (parser.m_help_str.empty()) {
-         parser.usage(std::cout, 0, PACKAGE_NAME);
-      } else {
-         print_help(conf, parser.m_help_str);
-      }
-      goto EXIT;
-   }
-   if (parser.m_version) {
-      std::cout << PACKAGE_VERSION << std::endl;
-      goto EXIT;
-   }
-   if (parser.m_storage.size() > 1 || parser.m_output.size() > 1) {
-      error("only one storage and output plugin can be specified");
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
-   if (parser.m_input.size() == 0) {
-      error("specify at least one input plugin");
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
+    trim_str(plugin);
+    trim_str(params);
+}
 
-   if (parser.m_daemon) {
-      if (daemon(1, 0) == -1) {
-         error("failed to run as a standalone process");
-         status = EXIT_FAILURE;
-         goto EXIT;
-      }
-   }
-   if (!parser.m_pid.empty()) {
-      std::ofstream pid_file(parser.m_pid, std::ofstream::out);
-      if (pid_file.fail()) {
-         error("failed to write pid file");
-         status = EXIT_FAILURE;
-         goto EXIT;
-      }
-      pid_file << getpid();
-      pid_file.close();
-   }
+bool process_plugin_args(ipxp_conf_t& conf, IpfixprobeOptParser& parser)
+{
+    auto deleter = [&](OutputPlugin::Plugins* p) {
+        for (auto& it : *p) {
+            delete it.second;
+        }
+        delete p;
+    };
+    auto process_plugins = std::unique_ptr<OutputPlugin::Plugins, decltype(deleter)>(
+        new OutputPlugin::Plugins(),
+        deleter);
+    std::string storage_name = "cache";
+    std::string storage_params = "";
+    std::string output_name = "ipfix";
+    std::string output_params = "";
 
-   if (parser.m_iqueue < 1) {
-      error("input queue size must be at least 1 record");
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
-   if (parser.m_oqueue < 1) {
-      error("output queue size must be at least 1 record");
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
+    if (parser.m_storage.size()) {
+        process_plugin_argline(parser.m_storage[0], storage_name, storage_params);
+    }
+    if (parser.m_output.size()) {
+        process_plugin_argline(parser.m_output[0], output_name, output_params);
+    }
 
-   conf.worker_cnt = parser.m_input.size();
-   conf.iqueue_size = parser.m_iqueue;
-   conf.oqueue_size = parser.m_oqueue;
-   conf.fps = parser.m_fps;
-   conf.pkt_bufsize = parser.m_pkt_bufsize;
-   conf.max_pkts = parser.m_max_pkts;
+    // Process
+    for (auto& it : parser.m_process) {
+        ProcessPlugin* process_plugin = nullptr;
+        std::string process_params;
+        std::string process_name;
+        process_plugin_argline(it, process_name, process_params);
+        for (auto& it : *process_plugins) {
+            std::string plugin_name = it.first;
+            if (plugin_name == process_name) {
+                throw IPXPError(process_name + " plugin was specified multiple times");
+            }
+        }
+        if (process_name == BASIC_PLUGIN_NAME) {
+            continue;
+        }
+        try {
+            process_plugin = dynamic_cast<ProcessPlugin*>(conf.mgr.get(process_name));
+            if (process_plugin == nullptr) {
+                throw IPXPError("invalid processing plugin " + process_name);
+            }
 
-   try {
-      if (process_plugin_args(conf, parser)) {
-         goto EXIT;
-      }
-      main_loop(conf);
-   } catch (std::system_error &e) {
-      error(e.what());
-      status = EXIT_FAILURE;
-      goto EXIT;
-   } catch (std::bad_alloc &e) {
-      error("not enough memory");
-      status = EXIT_FAILURE;
-      goto EXIT;
-   } catch (IPXPError &e) {
-      error(e.what());
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
+            process_plugin->init(process_params.c_str());
+            process_plugins->push_back(std::make_pair(process_name, process_plugin));
+        } catch (PluginError& e) {
+            delete process_plugin;
+            throw IPXPError(process_name + std::string(": ") + e.what());
+        } catch (PluginExit& e) {
+            delete process_plugin;
+            return true;
+        } catch (PluginManagerError& e) {
+            throw IPXPError(process_name + std::string(": ") + e.what());
+        }
+    }
+
+    // Output
+    ipx_ring_t* output_queue = ipx_ring_init(conf.oqueue_size, 1);
+    if (output_queue == nullptr) {
+        throw IPXPError("unable to initialize ring buffer");
+    }
+    OutputPlugin* output_plugin = nullptr;
+    try {
+        output_plugin = dynamic_cast<OutputPlugin*>(conf.mgr.get(output_name));
+        if (output_plugin == nullptr) {
+            ipx_ring_destroy(output_queue);
+            throw IPXPError("invalid output plugin " + output_name);
+        }
+
+        output_plugin->init(output_params.c_str(), *process_plugins);
+        conf.active.output.push_back(output_plugin);
+        conf.active.all.push_back(output_plugin);
+    } catch (PluginError& e) {
+        ipx_ring_destroy(output_queue);
+        delete output_plugin;
+        throw IPXPError(output_name + std::string(": ") + e.what());
+    } catch (PluginExit& e) {
+        ipx_ring_destroy(output_queue);
+        delete output_plugin;
+        return true;
+    } catch (PluginManagerError& e) {
+        throw IPXPError(output_name + std::string(": ") + e.what());
+    }
+
+    {
+        std::promise<WorkerResult>* output_res = new std::promise<WorkerResult>();
+        auto output_stats = new std::atomic<OutputStats>();
+        conf.output_stats.push_back(output_stats);
+        OutputWorker tmp
+            = {output_plugin,
+               new std::thread(
+                   output_worker,
+                   output_plugin,
+                   output_queue,
+                   output_res,
+                   output_stats,
+                   conf.fps),
+               output_res,
+               output_stats,
+               output_queue};
+        conf.outputs.push_back(tmp);
+        conf.output_fut.push_back(output_res->get_future());
+    }
+
+    // Input
+    size_t pipeline_idx = 0;
+    for (auto& it : parser.m_input) {
+        InputPlugin* input_plugin = nullptr;
+        StoragePlugin* storage_plugin = nullptr;
+        std::string input_params;
+        std::string input_name;
+        process_plugin_argline(it, input_name, input_params);
+
+        try {
+            input_plugin = dynamic_cast<InputPlugin*>(conf.mgr.get(input_name));
+            if (input_plugin == nullptr) {
+                throw IPXPError("invalid input plugin " + input_name);
+            }
+            input_plugin->init(input_params.c_str());
+            conf.active.input.push_back(input_plugin);
+            conf.active.all.push_back(input_plugin);
+        } catch (PluginError& e) {
+            delete input_plugin;
+            throw IPXPError(input_name + std::string(": ") + e.what());
+        } catch (PluginExit& e) {
+            delete input_plugin;
+            return true;
+        } catch (PluginManagerError& e) {
+            throw IPXPError(input_name + std::string(": ") + e.what());
+        }
+
+        try {
+            storage_plugin = dynamic_cast<StoragePlugin*>(conf.mgr.get(storage_name));
+            if (storage_plugin == nullptr) {
+                throw IPXPError("invalid storage plugin " + storage_name);
+            }
+            storage_plugin->set_queue(output_queue);
+            storage_plugin->init(storage_params.c_str());
+            conf.active.storage.push_back(storage_plugin);
+            conf.active.all.push_back(storage_plugin);
+        } catch (PluginError& e) {
+            delete storage_plugin;
+            throw IPXPError(storage_name + std::string(": ") + e.what());
+        } catch (PluginExit& e) {
+            delete storage_plugin;
+            return true;
+        } catch (PluginManagerError& e) {
+            throw IPXPError(storage_name + std::string(": ") + e.what());
+        }
+
+        std::vector<ProcessPlugin*> storage_process_plugins;
+        for (auto& it : *process_plugins) {
+            ProcessPlugin* tmp = it.second->copy();
+            storage_plugin->add_plugin(tmp);
+            conf.active.process.push_back(tmp);
+            conf.active.all.push_back(tmp);
+            storage_process_plugins.push_back(tmp);
+        }
+
+        std::promise<WorkerResult>* input_res = new std::promise<WorkerResult>();
+        conf.input_fut.push_back(input_res->get_future());
+
+        auto input_stats = new std::atomic<InputStats>();
+        conf.input_stats.push_back(input_stats);
+
+        WorkPipeline tmp
+            = {{input_plugin,
+                new std::thread(
+                    input_storage_worker,
+                    input_plugin,
+                    storage_plugin,
+                    conf.iqueue_size,
+                    conf.max_pkts,
+                    input_res,
+                    input_stats),
+                input_res,
+                input_stats},
+               {storage_plugin, storage_process_plugins}};
+        conf.pipelines.push_back(tmp);
+        pipeline_idx++;
+    }
+
+    return false;
+}
+
+void finish(ipxp_conf_t& conf)
+{
+    bool ok = true;
+
+    // Terminate all inputs
+    terminate_input = 1;
+    for (auto& it : conf.pipelines) {
+        it.input.thread->join();
+        it.input.plugin->close();
+    }
+
+    // Terminate all storages
+    for (auto& it : conf.pipelines) {
+        for (auto& itp : it.storage.plugins) {
+            itp->close();
+        }
+    }
+
+    // Terminate all outputs
+    terminate_export = 1;
+    for (auto& it : conf.outputs) {
+        it.thread->join();
+    }
+
+    for (auto& it : conf.pipelines) {
+        it.storage.plugin->close();
+    }
+
+    std::cout << "Input stats:" << std::endl
+              << std::setw(3) << "#" << std::setw(13) << "packets" << std::setw(13) << "parsed"
+              << std::setw(20) << "bytes" << std::setw(13) << "dropped" << std::setw(16) << "qtime"
+              << std::setw(7) << "status" << std::endl;
+
+    int idx = 0;
+    uint64_t total_packets = 0;
+    uint64_t total_parsed = 0;
+    uint64_t total_bytes = 0;
+    uint64_t total_dropped = 0;
+    uint64_t total_qtime = 0;
+
+    for (auto& it : conf.input_fut) {
+        WorkerResult res = it.get();
+        std::string status = "ok";
+        if (res.error) {
+            ok = false;
+            status = res.msg;
+        }
+        InputStats stats = conf.input_stats[idx]->load();
+        std::cout << std::setw(3) << idx++ << " " << std::setw(12) << stats.packets << " "
+                  << std::setw(12) << stats.parsed << " " << std::setw(19) << stats.bytes << " "
+                  << std::setw(12) << stats.dropped << " " << std::setw(15) << stats.qtime << " "
+                  << std::setw(6) << status << std::endl;
+        total_packets += stats.packets;
+        total_parsed += stats.parsed;
+        total_bytes += stats.bytes;
+        total_dropped += stats.dropped;
+        total_qtime += stats.qtime;
+    }
+
+    std::cout << std::setw(3) << "SUM" << std::setw(13) << total_packets << std::setw(13)
+              << total_parsed << std::setw(20) << total_bytes << std::setw(13) << total_dropped
+              << std::setw(16) << total_qtime << std::endl;
+
+    std::cout << std::endl;
+
+    std::cout << "Output stats:" << std::endl
+              << std::setw(3) << "#" << std::setw(13) << "biflows" << std::setw(13) << "packets"
+              << std::setw(20) << "bytes (L4)" << std::setw(13) << "dropped" << std::setw(7)
+              << "status" << std::endl;
+
+    idx = 0;
+    for (auto& it : conf.output_fut) {
+        WorkerResult res = it.get();
+        std::string status = "ok";
+        if (res.error) {
+            ok = false;
+            status = res.msg;
+        }
+        OutputStats stats = conf.output_stats[idx]->load();
+        std::cout << std::setw(3) << idx++ << " " << std::setw(12) << stats.biflows << " "
+                  << std::setw(12) << stats.packets << " " << std::setw(19) << stats.bytes << " "
+                  << std::setw(12) << stats.dropped << " " << std::setw(6) << status << std::endl;
+    }
+
+    if (!ok) {
+        throw IPXPError("one of the plugins exitted unexpectedly");
+    }
+}
+
+void serve_stat_clients(ipxp_conf_t& conf, struct pollfd pfds[2])
+{
+    uint8_t buffer[100000];
+    size_t written = 0;
+    msg_header_t* hdr = (msg_header_t*) buffer;
+    int ret = poll(pfds, 2, 0);
+    if (ret <= 0) {
+        return;
+    }
+    if (pfds[1].fd > 0 && pfds[1].revents & POLL_IN) {
+        ret = recv_data(pfds[1].fd, sizeof(uint32_t), buffer);
+        if (ret < 0) {
+            // Client disconnected
+            close(pfds[1].fd);
+            pfds[1].fd = -1;
+        } else {
+            if (*((uint32_t*) buffer) != MSG_MAGIC) {
+                return;
+            }
+            // Received stats request from client
+            written += sizeof(msg_header_t);
+            for (auto& it : conf.input_stats) {
+                InputStats stats = it->load();
+                *(InputStats*) (buffer + written) = stats;
+                written += sizeof(InputStats);
+            }
+            for (auto& it : conf.output_stats) {
+                OutputStats stats = it->load();
+                *(OutputStats*) (buffer + written) = stats;
+                written += sizeof(OutputStats);
+            }
+
+            hdr->magic = MSG_MAGIC;
+            hdr->size = written - sizeof(msg_header_t);
+            hdr->inputs = conf.input_stats.size();
+            hdr->outputs = conf.output_stats.size();
+
+            send_data(pfds[1].fd, written, buffer);
+        }
+    }
+
+    if (pfds[0].revents & POLL_IN) {
+        int fd = accept(pfds[0].fd, NULL, NULL);
+        if (pfds[1].fd == -1) {
+            pfds[1].fd = fd;
+        } else if (fd != -1) {
+            // Close incoming connection
+            close(fd);
+        }
+    }
+}
+
+void main_loop(ipxp_conf_t& conf)
+{
+    std::vector<std::shared_future<WorkerResult>*> futs;
+    for (auto& it : conf.input_fut) {
+        futs.push_back(&it);
+    }
+
+    struct pollfd pfds[2] = {
+        {.fd = -1, .events = POLL_IN}, // Server
+        {.fd = -1, .events = POLL_IN} // Client
+    };
+
+    std::string sock_path = create_sockpath(std::to_string(getpid()).c_str());
+    pfds[0].fd = create_stats_sock(sock_path.c_str());
+    if (pfds[0].fd < 0) {
+        error("Unable to create stats socket " + sock_path);
+    }
+
+    while (!stop && futs.size()) {
+        serve_stat_clients(conf, pfds);
+
+        for (auto it = futs.begin(); it != futs.end(); it++) {
+            std::future_status status = (*it)->wait_for(std::chrono::seconds(0));
+            if (status == std::future_status::ready) {
+                WorkerResult res = (*it)->get();
+                if (!res.error) {
+                    it = futs.erase(it);
+                    break;
+                }
+                stop = 1;
+                break;
+            }
+        }
+        for (auto& it : conf.output_fut) {
+            std::future_status status = it.wait_for(std::chrono::seconds(0));
+            if (status == std::future_status::ready) {
+                stop = 1;
+                break;
+            }
+        }
+
+        usleep(1000);
+    }
+
+    if (pfds[0].fd != -1) {
+        close(pfds[0].fd);
+    }
+    if (pfds[1].fd != -1) {
+        close(pfds[1].fd);
+    }
+    unlink(sock_path.c_str());
+    finish(conf);
+}
+
+int run(int argc, char* argv[])
+{
+    IpfixprobeOptParser parser;
+    ipxp_conf_t conf;
+    int status = EXIT_SUCCESS;
+
+    register_handlers();
+
+    try {
+        parser.parse(argc - 1, const_cast<const char**>(argv) + 1);
+    } catch (ParserError& e) {
+        error(e.what());
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
+
+    if (parser.m_help) {
+        if (parser.m_help_str.empty()) {
+            parser.usage(std::cout, 0, PACKAGE_NAME);
+        } else {
+            print_help(conf, parser.m_help_str);
+        }
+        goto EXIT;
+    }
+    if (parser.m_version) {
+        std::cout << PACKAGE_VERSION << std::endl;
+        goto EXIT;
+    }
+    if (parser.m_storage.size() > 1 || parser.m_output.size() > 1) {
+        error("only one storage and output plugin can be specified");
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
+    if (parser.m_input.size() == 0) {
+        error("specify at least one input plugin");
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
+
+    if (parser.m_daemon) {
+        if (daemon(1, 0) == -1) {
+            error("failed to run as a standalone process");
+            status = EXIT_FAILURE;
+            goto EXIT;
+        }
+    }
+    if (!parser.m_pid.empty()) {
+        std::ofstream pid_file(parser.m_pid, std::ofstream::out);
+        if (pid_file.fail()) {
+            error("failed to write pid file");
+            status = EXIT_FAILURE;
+            goto EXIT;
+        }
+        pid_file << getpid();
+        pid_file.close();
+    }
+
+    if (parser.m_iqueue < 1) {
+        error("input queue size must be at least 1 record");
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
+    if (parser.m_oqueue < 1) {
+        error("output queue size must be at least 1 record");
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
+
+    conf.worker_cnt = parser.m_input.size();
+    conf.iqueue_size = parser.m_iqueue;
+    conf.oqueue_size = parser.m_oqueue;
+    conf.fps = parser.m_fps;
+    conf.pkt_bufsize = parser.m_pkt_bufsize;
+    conf.max_pkts = parser.m_max_pkts;
+
+    try {
+        if (process_plugin_args(conf, parser)) {
+            goto EXIT;
+        }
+        main_loop(conf);
+    } catch (std::system_error& e) {
+        error(e.what());
+        status = EXIT_FAILURE;
+        goto EXIT;
+    } catch (std::bad_alloc& e) {
+        error("not enough memory");
+        status = EXIT_FAILURE;
+        goto EXIT;
+    } catch (IPXPError& e) {
+        error(e.what());
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
 
 EXIT:
-   if (!parser.m_pid.empty()) {
-      unlink(parser.m_pid.c_str());
-   }
-   return status;
+    if (!parser.m_pid.empty()) {
+        unlink(parser.m_pid.c_str());
+    }
+    return status;
 }
 
-}
+} // namespace ipxp

--- a/ipfixprobe.hpp
+++ b/ipfixprobe.hpp
@@ -29,24 +29,24 @@
 #ifndef IPXP_IPFIXPROBE_HPP
 #define IPXP_IPFIXPROBE_HPP
 
+#include <atomic>
 #include <config.h>
+#include <csignal>
+#include <future>
 #include <string>
 #include <thread>
-#include <future>
-#include <atomic>
-#include <csignal>
 
-#include <ipfixprobe/input.hpp>
-#include <ipfixprobe/storage.hpp>
-#include <ipfixprobe/output.hpp>
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/plugin.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/options.hpp>
-#include <ipfixprobe/utils.hpp>
-#include <ipfixprobe/ring.h>
 #include "pluginmgr.hpp"
 #include "workers.hpp"
+#include <ipfixprobe/input.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/output.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/plugin.hpp>
+#include <ipfixprobe/process.hpp>
+#include <ipfixprobe/ring.h>
+#include <ipfixprobe/storage.hpp>
+#include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
@@ -64,195 +64,298 @@ struct ipxp_conf_t;
 void signal_handler(int sig);
 void register_handlers();
 void error(std::string msg);
-void print_help(ipxp_conf_t &conf, const std::string &arg);
-void init_packets(ipxp_conf_t &conf);
-bool process_plugin_args(ipxp_conf_t &conf, IpfixprobeOptParser &parser);
-void main_loop(ipxp_conf_t &conf);
-int run(int argc, char *argv[]);
+void print_help(ipxp_conf_t& conf, const std::string& arg);
+void init_packets(ipxp_conf_t& conf);
+bool process_plugin_args(ipxp_conf_t& conf, IpfixprobeOptParser& parser);
+void main_loop(ipxp_conf_t& conf);
+int run(int argc, char* argv[]);
 
 class IpfixprobeOptParser : public OptionsParser {
 public:
-   std::vector<std::string> m_input;
-   std::vector<std::string> m_storage;
-   std::vector<std::string> m_output;
-   std::vector<std::string> m_process;
-   std::string m_pid;
-   bool m_daemon;
-   uint32_t m_iqueue;
-   uint32_t m_oqueue;
-   uint32_t m_fps;
-   uint32_t m_pkt_bufsize;
-   uint32_t m_max_pkts;
-   bool m_help;
-   std::string m_help_str;
-   bool m_version;
+    std::vector<std::string> m_input;
+    std::vector<std::string> m_storage;
+    std::vector<std::string> m_output;
+    std::vector<std::string> m_process;
+    std::string m_pid;
+    bool m_daemon;
+    uint32_t m_iqueue;
+    uint32_t m_oqueue;
+    uint32_t m_fps;
+    uint32_t m_pkt_bufsize;
+    uint32_t m_max_pkts;
+    bool m_help;
+    std::string m_help_str;
+    bool m_version;
 
-   IpfixprobeOptParser() : OptionsParser("ipfixprobe", "flow exporter supporting various custom IPFIX elements"),
-                           m_pid(""), m_daemon(false),
-                           m_iqueue(DEFAULT_IQUEUE_SIZE), m_oqueue(DEFAULT_OQUEUE_SIZE), m_fps(DEFAULT_FPS),
-                           m_pkt_bufsize(1600), m_max_pkts(0), m_help(false), m_help_str(""), m_version(false)
-   {
-      m_delim = ' ';
+    IpfixprobeOptParser()
+        : OptionsParser("ipfixprobe", "flow exporter supporting various custom IPFIX elements")
+        , m_pid("")
+        , m_daemon(false)
+        , m_iqueue(DEFAULT_IQUEUE_SIZE)
+        , m_oqueue(DEFAULT_OQUEUE_SIZE)
+        , m_fps(DEFAULT_FPS)
+        , m_pkt_bufsize(1600)
+        , m_max_pkts(0)
+        , m_help(false)
+        , m_help_str("")
+        , m_version(false)
+    {
+        m_delim = ' ';
 
-      register_option("-i", "--input", "ARGS", "Activate input plugin (-h input for help)",
-                      [this](const char *arg) {
-                          m_input.push_back(arg);
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-s", "--storage", "ARGS", "Activate storage plugin (-h storage for help)",
-                      [this](const char *arg) {
-                          m_storage.push_back(arg);
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-o", "--output", "ARGS", "Activate output plugin (-h output for help)",
-                      [this](const char *arg) {
-                          m_output.push_back(arg);
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-p", "--process", "ARGS", "Activate processing plugin (-h process for help)",
-                      [this](const char *arg) {
-                          m_process.push_back(arg);
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-q", "--iqueue", "SIZE", "Size of queue between input and storage plugins",
-                      [this](const char *arg) {
-                          try { m_iqueue = str2num<decltype(m_iqueue)>(arg); } catch (
-                                  std::invalid_argument &e) { return false; }
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-Q", "--oqueue", "SIZE", "Size of queue between storage and output plugins",
-                      [this](const char *arg) {
-                          try { m_oqueue = str2num<decltype(m_oqueue)>(arg); } catch (
-                                  std::invalid_argument &e) { return false; }
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-B", "--pbuf", "SIZE", "Size of packet buffer",
-                      [this](const char *arg) {
-                          try { m_pkt_bufsize = str2num<decltype(m_pkt_bufsize)>(arg); } catch (std::invalid_argument &e) { return false; }
-                          return true;
-                      },
-                      OptionFlags::RequiredArgument);
-      register_option("-f", "--fps", "NUM", "Export max flows per second",
-                      [this](const char *arg) {
-                          try { m_fps = str2num<decltype(m_fps)>(arg); } catch (std::invalid_argument &e) { return false; }
-                          return true;
-                      },
-                      OptionFlags::RequiredArgument);
-      register_option("-c", "--count", "SIZE", "Quit after number of packets are processed on each interface",
-                      [this](const char *arg) {
-                          try { m_max_pkts = str2num<decltype(m_max_pkts)>(arg); } catch (
-                                  std::invalid_argument &e) { return false; }
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-P", "--pid", "FILE", "Create pid file", [this](const char *arg) {
-          m_pid = arg;
-          return m_pid != "";
-      }, OptionFlags::RequiredArgument);
-      register_option("-d", "--daemon", "", "Run as a standalone process", [this](const char *arg) {
-          m_daemon = true;
-          return true;
-      }, OptionFlags::NoArgument);
-      register_option("-h", "--help", "PLUGIN", "Print help text. Supported help for input, storage, output and process plugins", [this](const char *arg) {
-          m_help = true;
-          m_help_str = arg ? arg : "";
-          return true;
-      }, OptionFlags::OptionalArgument);
-      register_option("-V", "--version", "", "Show version and exit", [this](const char *arg) {
-          m_version = true;
-          return true;
-      }, OptionFlags::NoArgument);
-   }
+        register_option(
+            "-i",
+            "--input",
+            "ARGS",
+            "Activate input plugin (-h input for help)",
+            [this](const char* arg) {
+                m_input.push_back(arg);
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-s",
+            "--storage",
+            "ARGS",
+            "Activate storage plugin (-h storage for help)",
+            [this](const char* arg) {
+                m_storage.push_back(arg);
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-o",
+            "--output",
+            "ARGS",
+            "Activate output plugin (-h output for help)",
+            [this](const char* arg) {
+                m_output.push_back(arg);
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-p",
+            "--process",
+            "ARGS",
+            "Activate processing plugin (-h process for help)",
+            [this](const char* arg) {
+                m_process.push_back(arg);
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-q",
+            "--iqueue",
+            "SIZE",
+            "Size of queue between input and storage plugins",
+            [this](const char* arg) {
+                try {
+                    m_iqueue = str2num<decltype(m_iqueue)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-Q",
+            "--oqueue",
+            "SIZE",
+            "Size of queue between storage and output plugins",
+            [this](const char* arg) {
+                try {
+                    m_oqueue = str2num<decltype(m_oqueue)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-B",
+            "--pbuf",
+            "SIZE",
+            "Size of packet buffer",
+            [this](const char* arg) {
+                try {
+                    m_pkt_bufsize = str2num<decltype(m_pkt_bufsize)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-f",
+            "--fps",
+            "NUM",
+            "Export max flows per second",
+            [this](const char* arg) {
+                try {
+                    m_fps = str2num<decltype(m_fps)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-c",
+            "--count",
+            "SIZE",
+            "Quit after number of packets are processed on each interface",
+            [this](const char* arg) {
+                try {
+                    m_max_pkts = str2num<decltype(m_max_pkts)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-P",
+            "--pid",
+            "FILE",
+            "Create pid file",
+            [this](const char* arg) {
+                m_pid = arg;
+                return m_pid != "";
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-d",
+            "--daemon",
+            "",
+            "Run as a standalone process",
+            [this](const char* arg) {
+                m_daemon = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "-h",
+            "--help",
+            "PLUGIN",
+            "Print help text. Supported help for input, storage, output and process plugins",
+            [this](const char* arg) {
+                m_help = true;
+                m_help_str = arg ? arg : "";
+                return true;
+            },
+            OptionFlags::OptionalArgument);
+        register_option(
+            "-V",
+            "--version",
+            "",
+            "Show version and exit",
+            [this](const char* arg) {
+                m_version = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
 struct ipxp_conf_t {
-   uint32_t iqueue_size;
-   uint32_t oqueue_size;
-   uint32_t worker_cnt;
-   uint32_t fps;
-   uint32_t max_pkts;
+    uint32_t iqueue_size;
+    uint32_t oqueue_size;
+    uint32_t worker_cnt;
+    uint32_t fps;
+    uint32_t max_pkts;
 
-   PluginManager mgr;
-   struct Plugins {
-      std::vector<InputPlugin *> input;
-      std::vector<StoragePlugin *> storage;
-      std::vector<OutputPlugin *> output;
-      std::vector<ProcessPlugin *> process;
-      std::vector<Plugin *> all;
-   } active;
+    PluginManager mgr;
+    struct Plugins {
+        std::vector<InputPlugin*> input;
+        std::vector<StoragePlugin*> storage;
+        std::vector<OutputPlugin*> output;
+        std::vector<ProcessPlugin*> process;
+        std::vector<Plugin*> all;
+    } active;
 
-   std::vector<WorkPipeline> pipelines;
-   std::vector<OutputWorker> outputs;
+    std::vector<WorkPipeline> pipelines;
+    std::vector<OutputWorker> outputs;
 
-   std::vector<std::atomic<InputStats> *> input_stats;
-   std::vector<std::atomic<OutputStats> *> output_stats;
+    std::vector<std::atomic<InputStats>*> input_stats;
+    std::vector<std::atomic<OutputStats>*> output_stats;
 
-   std::vector<std::shared_future<WorkerResult>> input_fut;
-   std::vector<std::future<WorkerResult>> output_fut;  
+    std::vector<std::shared_future<WorkerResult>> input_fut;
+    std::vector<std::future<WorkerResult>> output_fut;
 
-   size_t pkt_bufsize;
-   size_t blocks_cnt;
-   size_t pkts_cnt;
-   size_t pkt_data_cnt;
+    size_t pkt_bufsize;
+    size_t blocks_cnt;
+    size_t pkts_cnt;
+    size_t pkt_data_cnt;
 
-   PacketBlock *blocks;
-   Packet *pkts;
-   uint8_t *pkt_data;
+    PacketBlock* blocks;
+    Packet* pkts;
+    uint8_t* pkt_data;
 
-   ipxp_conf_t() : iqueue_size(DEFAULT_IQUEUE_SIZE),
-                   oqueue_size(DEFAULT_OQUEUE_SIZE),
-                   worker_cnt(0), fps(0), max_pkts(0),
-                   pkt_bufsize(1600), blocks_cnt(0), pkts_cnt(0), pkt_data_cnt(0), blocks(nullptr), pkts(nullptr), pkt_data(nullptr)
-   {
-   }
+    ipxp_conf_t()
+        : iqueue_size(DEFAULT_IQUEUE_SIZE)
+        , oqueue_size(DEFAULT_OQUEUE_SIZE)
+        , worker_cnt(0)
+        , fps(0)
+        , max_pkts(0)
+        , pkt_bufsize(1600)
+        , blocks_cnt(0)
+        , pkts_cnt(0)
+        , pkt_data_cnt(0)
+        , blocks(nullptr)
+        , pkts(nullptr)
+        , pkt_data(nullptr)
+    {
+    }
 
-   ~ipxp_conf_t()
-   {
-      terminate_input = 1;
-      for (auto &it : pipelines) {
-         if (it.input.thread->joinable()) {
-            it.input.thread->join();
-         }
-         delete it.input.plugin;
-         delete it.input.thread;
-         delete it.input.promise;
-      }
+    ~ipxp_conf_t()
+    {
+        terminate_input = 1;
+        for (auto& it : pipelines) {
+            if (it.input.thread->joinable()) {
+                it.input.thread->join();
+            }
+            delete it.input.plugin;
+            delete it.input.thread;
+            delete it.input.promise;
+        }
 
-      for (auto &it : pipelines) {
-         delete it.storage.plugin;
-      }
+        for (auto& it : pipelines) {
+            delete it.storage.plugin;
+        }
 
-      for (auto &it : pipelines) {
-         for (auto &itp : it.storage.plugins) {
-            delete itp;
-         }
-      }
+        for (auto& it : pipelines) {
+            for (auto& itp : it.storage.plugins) {
+                delete itp;
+            }
+        }
 
-      terminate_export = 1;
-      for (auto &it : outputs) {
-         if (it.thread->joinable()) {
-            it.thread->join();
-         }
-         delete it.thread;
-         delete it.promise;
-         delete it.plugin;
-         ipx_ring_destroy(it.queue);
-      }
+        terminate_export = 1;
+        for (auto& it : outputs) {
+            if (it.thread->joinable()) {
+                it.thread->join();
+            }
+            delete it.thread;
+            delete it.promise;
+            delete it.plugin;
+            ipx_ring_destroy(it.queue);
+        }
 
-      for (auto &it : input_stats) {
-         delete it;
-      }
-      for (auto &it : output_stats) {
-         delete it;
-      }
-   }
+        for (auto& it : input_stats) {
+            delete it;
+        }
+        for (auto& it : output_stats) {
+            delete it;
+        }
+    }
 };
 
 class IPXPError : public std::runtime_error {
 public:
-   explicit IPXPError(const std::string &msg) : std::runtime_error(msg) {};
+    explicit IPXPError(const std::string& msg)
+        : std::runtime_error(msg) {};
 
-   explicit IPXPError(const char *msg) : std::runtime_error(msg) {};
+    explicit IPXPError(const char* msg)
+        : std::runtime_error(msg) {};
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_IPFIXPROBE_HPP */

--- a/ipfixprobe_stats.cpp
+++ b/ipfixprobe_stats.cpp
@@ -27,11 +27,11 @@
  */
 
 #include <config.h>
+#include <iomanip>
+#include <iostream>
+#include <signal.h>
 #include <string>
 #include <unistd.h>
-#include <signal.h>
-#include <iostream>
-#include <iomanip>
 
 #include <ipfixprobe/options.hpp>
 #include <ipfixprobe/utils.hpp>
@@ -44,158 +44,169 @@ volatile sig_atomic_t stop = 0;
 
 void signal_handler(int sig)
 {
-   stop = 1;
+    stop = 1;
 }
 
 class IpfixStatsParser : public OptionsParser {
 public:
-   pid_t m_pid;
-   bool m_one;
-   bool m_help;
+    pid_t m_pid;
+    bool m_one;
+    bool m_help;
 
-   IpfixStatsParser() : OptionsParser("ipfixprobe_stats", "Read statistics from running ipfixprobe exporter"),
-                        m_pid(0), m_one(false), m_help(false)
-   {
-      m_delim = ' ';
+    IpfixStatsParser()
+        : OptionsParser("ipfixprobe_stats", "Read statistics from running ipfixprobe exporter")
+        , m_pid(0)
+        , m_one(false)
+        , m_help(false)
+    {
+        m_delim = ' ';
 
-      register_option("-p", "--pid", "NUM", "ipfixprobe exporter PID number", [this](const char *arg) {
-            try { m_pid = str2num<decltype(m_pid)>(arg); } catch (
-                  std::invalid_argument &e) { return false; }
-            return true;
-      }, OptionFlags::RequiredArgument);
-      register_option("-1", "--one", "", "Print stats and exit", [this](const char *arg) {
-            m_one = true;
-            return true;
-      }, OptionFlags::NoArgument);
-      register_option("-h", "--help", "", "Print help", [this](const char *arg) {
-            m_help = true;
-            return true;
-      }, OptionFlags::NoArgument);
-   }
+        register_option(
+            "-p",
+            "--pid",
+            "NUM",
+            "ipfixprobe exporter PID number",
+            [this](const char* arg) {
+                try {
+                    m_pid = str2num<decltype(m_pid)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-1",
+            "--one",
+            "",
+            "Print stats and exit",
+            [this](const char* arg) {
+                m_one = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "-h",
+            "--help",
+            "",
+            "Print help",
+            [this](const char* arg) {
+                m_help = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-static void error(const std::string &msg)
+static void error(const std::string& msg)
 {
-   std::cerr << "Error: " << msg << std::endl;
+    std::cerr << "Error: " << msg << std::endl;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-   size_t lines_written = 0;
-   int fd = -1;
-   int status = EXIT_SUCCESS;
-   uint8_t buffer[100000];
-   msg_header_t *hdr = (msg_header_t *) buffer;
-   std::string path;
-   IpfixStatsParser parser;
+    size_t lines_written = 0;
+    int fd = -1;
+    int status = EXIT_SUCCESS;
+    uint8_t buffer[100000];
+    msg_header_t* hdr = (msg_header_t*) buffer;
+    std::string path;
+    IpfixStatsParser parser;
 
+    signal(SIGTERM, signal_handler);
+    signal(SIGINT, signal_handler);
+    try {
+        parser.parse(argc - 1, const_cast<const char**>(argv) + 1);
 
-   signal(SIGTERM, signal_handler);
-   signal(SIGINT, signal_handler);
-   try {
-      parser.parse(argc - 1, const_cast<const char **>(argv) + 1);
+        if (parser.m_help) {
+            parser.usage(std::cout, 0);
+            goto EXIT;
+        }
 
-      if (parser.m_help) {
-         parser.usage(std::cout, 0);
-         goto EXIT;
-      }
+        path = DEFAULTSOCKETDIR "/ipfixprobe_" + std::to_string(parser.m_pid) + ".sock";
+        fd = connect_to_exporter(path.c_str());
+        if (fd == -1) {
+            error("connecting to exporter");
+            goto EXIT;
+        }
+    } catch (std::runtime_error& e) {
+        error(e.what());
+        status = EXIT_FAILURE;
+        goto EXIT;
+    }
 
-      path = DEFAULTSOCKETDIR "/ipfixprobe_" + std::to_string(parser.m_pid) + ".sock";
-      fd = connect_to_exporter(path.c_str());
-      if (fd == -1) {
-         error("connecting to exporter");
-         goto EXIT;
-      }
-   } catch (std::runtime_error &e) {
-      error(e.what());
-      status = EXIT_FAILURE;
-      goto EXIT;
-   }
+    while (!stop) {
+        *(uint32_t*) buffer = MSG_MAGIC;
+        // Send stats data request
+        if (send_data(fd, sizeof(uint32_t), buffer)) {
+            status = EXIT_FAILURE;
+            break;
+        }
 
-   while (!stop) {
-      *(uint32_t *) buffer = MSG_MAGIC;
-      // Send stats data request
-      if (send_data(fd, sizeof(uint32_t), buffer)) {
-         status = EXIT_FAILURE;
-         break;
-      }
+        // Receive message header
+        if (recv_data(fd, sizeof(msg_header_t), buffer)) {
+            status = EXIT_FAILURE;
+            break;
+        }
 
-      // Receive message header
-      if (recv_data(fd, sizeof(msg_header_t), buffer)) {
-         status = EXIT_FAILURE;
-         break;
-      }
+        // Check if message header is correct
+        if (hdr->magic != MSG_MAGIC) {
+            error("received data are invalid");
+            status = EXIT_FAILURE;
+            break;
+        }
 
-      // Check if message header is correct
-      if (hdr->magic != MSG_MAGIC) {
-         error("received data are invalid");
-         status = EXIT_FAILURE;
-         break;
-      }
+        // Receive array of various stats from exporter
+        if (recv_data(fd, hdr->size, (buffer + sizeof(msg_header_t)))) {
+            status = EXIT_FAILURE;
+            break;
+        }
 
-      // Receive array of various stats from exporter
-      if (recv_data(fd, hdr->size, (buffer + sizeof(msg_header_t)))) {
-         status = EXIT_FAILURE;
-         break;
-      }
+        // Erase previous stats output lines
+        for (size_t i = 0; i < lines_written; i++) {
+            std::cout << "\033[A\33[2K\r";
+        }
 
-      // Erase previous stats output lines
-      for (size_t i = 0; i < lines_written; i++) {
-         std::cout << "\033[A\33[2K\r";
-      }
+        // Process received stats
+        std::cout << "Input stats:" << std::endl
+                  << std::setw(3) << "#" << std::setw(10) << "packets" << std::setw(10) << "parsed"
+                  << std::setw(16) << "bytes" << std::setw(10) << "dropped" << std::setw(10)
+                  << "qtime" << std::endl;
 
-      // Process received stats
-      std::cout << "Input stats:" << std::endl <<
-         std::setw(3) << "#" <<
-         std::setw(10) << "packets" <<
-         std::setw(10) << "parsed" <<
-         std::setw(16) << "bytes" <<
-         std::setw(10) << "dropped" <<
-         std::setw(10) << "qtime" << std::endl;
+        uint8_t* data = buffer + sizeof(msg_header_t);
+        size_t idx = 0;
+        for (size_t i = 0; i < hdr->inputs; i++) {
+            InputStats* stats = (InputStats*) data;
+            data += sizeof(InputStats);
+            std::cout << std::setw(3) << idx++ << " " << std::setw(9) << stats->packets << " "
+                      << std::setw(9) << stats->parsed << " " << std::setw(15) << stats->bytes
+                      << " " << std::setw(9) << stats->dropped << " " << std::setw(9)
+                      << stats->qtime << " " << std::endl;
+        }
 
-      uint8_t *data = buffer + sizeof(msg_header_t);
-      size_t idx = 0;
-      for (size_t i = 0; i < hdr->inputs; i++) {
-         InputStats *stats = (InputStats *) data;
-         data += sizeof(InputStats);
-         std::cout <<
-            std::setw(3) << idx++ << " " <<
-            std::setw(9) << stats->packets << " " <<
-            std::setw(9) << stats->parsed << " " <<
-            std::setw(15) << stats->bytes << " " <<
-            std::setw(9) << stats->dropped << " " <<
-            std::setw(9) << stats->qtime << " " << std::endl;
-      }
+        std::cout << "Output stats:" << std::endl
+                  << std::setw(3) << "#" << std::setw(10) << "biflows" << std::setw(10) << "packets"
+                  << std::setw(16) << "bytes" << std::setw(10) << "dropped" << std::endl;
 
-      std::cout << "Output stats:" << std::endl <<
-         std::setw(3) << "#" <<
-         std::setw(10) << "biflows" <<
-         std::setw(10) << "packets" <<
-         std::setw(16) << "bytes" <<
-         std::setw(10) << "dropped" << std::endl;
+        idx = 0;
+        for (size_t i = 0; i < hdr->outputs; i++) {
+            OutputStats* stats = (OutputStats*) data;
+            data += sizeof(OutputStats);
+            std::cout << std::setw(3) << idx++ << " " << std::setw(9) << stats->biflows << " "
+                      << std::setw(9) << stats->packets << " " << std::setw(15) << stats->bytes
+                      << " " << std::setw(9) << stats->dropped << " " << std::endl;
+        }
 
-      idx = 0;
-      for (size_t i = 0; i < hdr->outputs; i++) {
-         OutputStats *stats = (OutputStats *) data;
-         data += sizeof(OutputStats);
-         std::cout <<
-            std::setw(3) << idx++ << " " <<
-            std::setw(9) << stats->biflows << " " <<
-            std::setw(9) << stats->packets << " " <<
-            std::setw(15) << stats->bytes << " " <<
-            std::setw(9) << stats->dropped << " " << std::endl;
-      }
+        if (parser.m_one) {
+            break;
+        }
 
-      if (parser.m_one) {
-         break;
-      }
-
-      lines_written = hdr->inputs + hdr->outputs + 4;
-      usleep(1000000);
-   }
+        lines_written = hdr->inputs + hdr->outputs + 4;
+        usleep(1000000);
+    }
 EXIT:
-   if (fd != -1) {
-      close(fd);
-   }
-   return status;
+    if (fd != -1) {
+        close(fd);
+    }
+    return status;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -28,12 +28,12 @@
 
 #include "ipfixprobe.hpp"
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-   try {
-      return ipxp::run(argc, argv);
-   } catch (std::runtime_error &e) {
-      std::cerr << "Error: " << e.what() << std::endl;
-   }
-   return EXIT_FAILURE;
+    try {
+        return ipxp::run(argc, argv);
+    } catch (std::runtime_error& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+    }
+    return EXIT_FAILURE;
 }

--- a/options.cpp
+++ b/options.cpp
@@ -26,194 +26,208 @@
  *
  */
 
-#include <vector>
-#include <string>
 #include <iomanip>
+#include <string>
+#include <vector>
 
 #include <ipfixprobe/options.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
-OptionsParser::OptionsParser() : m_name(""), m_info(""), m_delim(OptionsParser::DELIM)
+OptionsParser::OptionsParser()
+    : m_name("")
+    , m_info("")
+    , m_delim(OptionsParser::DELIM)
 {
 }
 
-OptionsParser::OptionsParser(const std::string &name, const std::string &info) : m_name(name), m_info(info), m_delim(OptionsParser::DELIM)
+OptionsParser::OptionsParser(const std::string& name, const std::string& info)
+    : m_name(name)
+    , m_info(info)
+    , m_delim(OptionsParser::DELIM)
 {
 }
 
 OptionsParser::~OptionsParser()
 {
-   for (const auto &it : m_options) {
-      delete it;
-   }
-   m_options.clear();
-   m_short.clear();
-   m_long.clear();
+    for (const auto& it : m_options) {
+        delete it;
+    }
+    m_options.clear();
+    m_short.clear();
+    m_long.clear();
 }
 
-void OptionsParser::parse(const char *args) const
+void OptionsParser::parse(const char* args) const
 {
-   std::vector<std::string> tokens;
-   std::vector<const char *> token_ptrs;
-   size_t first = 0;
-   size_t last = 0;
-   if (args == nullptr || args[0] == 0) {
-      parse(0, nullptr);
-      return;
-   }
-   while (1) {
-      if (args[last] == m_delim || !args[last]) {
-         std::string token = std::string(args, first, last - first);
-         size_t pos = token.find("=");
-         std::string name = token.substr(0, pos);
-         std::string arg;
+    std::vector<std::string> tokens;
+    std::vector<const char*> token_ptrs;
+    size_t first = 0;
+    size_t last = 0;
+    if (args == nullptr || args[0] == 0) {
+        parse(0, nullptr);
+        return;
+    }
+    while (1) {
+        if (args[last] == m_delim || !args[last]) {
+            std::string token = std::string(args, first, last - first);
+            size_t pos = token.find("=");
+            std::string name = token.substr(0, pos);
+            std::string arg;
 
-         tokens.push_back(name);
-         if (pos != std::string::npos) {
-            arg = token.substr(pos + 1, std::string::npos);
-            tokens.push_back(arg);
-         }
-         first = last + 1;
-      }
-      if (!args[last]) {
-         break;
-      }
-      last += 1;
-   }
-   for (const auto &it : tokens) {
-      token_ptrs.push_back(it.c_str());
-   }
-   parse(token_ptrs.size(), token_ptrs.data());
-}
-
-void OptionsParser::parse(int argc, const char **argv) const
-{
-   if (argc && !argv) {
-      throw std::runtime_error("invalid arguments passed");
-   }
-   for (int i = 0; i < argc; i++) {
-      Option *opt_spec = nullptr;
-      std::string opt = argv[i];
-      std::string eq_param;
-      const char *arg = nullptr;
-      size_t eq_pos = opt.find("=");
-      if (opt.empty()) {
-         continue;
-      }
-      if (eq_pos != std::string::npos) {
-         eq_param = opt.substr(eq_pos + 1);
-         opt = opt.erase(eq_pos);
-      }
-
-      if (m_long.find(opt) != m_long.end()) {
-         opt_spec = m_long.at(opt);
-      } else if (m_short.find(opt) != m_short.end()) {
-         opt_spec = m_short.at(opt);
-      } else {
-         throw ParserError("invalid option " + opt);
-      }
-
-      if (opt_spec->m_flags & OptionFlags::RequiredArgument) {
-         if (eq_pos != std::string::npos) {
-            arg = eq_param.c_str();
-         } else {
-            if (i + 1 == argc) {
-               throw ParserError("missing argument for option " + opt);
+            tokens.push_back(name);
+            if (pos != std::string::npos) {
+                arg = token.substr(pos + 1, std::string::npos);
+                tokens.push_back(arg);
             }
-            arg = argv[i + 1];
-            i++;
-         }
-      } else if (opt_spec->m_flags & OptionFlags::OptionalArgument) {
-         if (eq_pos != std::string::npos) {
-            arg = eq_param.c_str();
-         } else {
-            if (i + 1 < argc &&
-               m_long.find(argv[i + 1]) == m_long.end() && m_short.find(argv[i + 1]) == m_short.end()) {
-               arg = argv[i + 1];
-               i++;
+            first = last + 1;
+        }
+        if (!args[last]) {
+            break;
+        }
+        last += 1;
+    }
+    for (const auto& it : tokens) {
+        token_ptrs.push_back(it.c_str());
+    }
+    parse(token_ptrs.size(), token_ptrs.data());
+}
+
+void OptionsParser::parse(int argc, const char** argv) const
+{
+    if (argc && !argv) {
+        throw std::runtime_error("invalid arguments passed");
+    }
+    for (int i = 0; i < argc; i++) {
+        Option* opt_spec = nullptr;
+        std::string opt = argv[i];
+        std::string eq_param;
+        const char* arg = nullptr;
+        size_t eq_pos = opt.find("=");
+        if (opt.empty()) {
+            continue;
+        }
+        if (eq_pos != std::string::npos) {
+            eq_param = opt.substr(eq_pos + 1);
+            opt = opt.erase(eq_pos);
+        }
+
+        if (m_long.find(opt) != m_long.end()) {
+            opt_spec = m_long.at(opt);
+        } else if (m_short.find(opt) != m_short.end()) {
+            opt_spec = m_short.at(opt);
+        } else {
+            throw ParserError("invalid option " + opt);
+        }
+
+        if (opt_spec->m_flags & OptionFlags::RequiredArgument) {
+            if (eq_pos != std::string::npos) {
+                arg = eq_param.c_str();
+            } else {
+                if (i + 1 == argc) {
+                    throw ParserError("missing argument for option " + opt);
+                }
+                arg = argv[i + 1];
+                i++;
             }
-         }
-      }
+        } else if (opt_spec->m_flags & OptionFlags::OptionalArgument) {
+            if (eq_pos != std::string::npos) {
+                arg = eq_param.c_str();
+            } else {
+                if (i + 1 < argc && m_long.find(argv[i + 1]) == m_long.end()
+                    && m_short.find(argv[i + 1]) == m_short.end()) {
+                    arg = argv[i + 1];
+                    i++;
+                }
+            }
+        }
 
-      if (!opt_spec->m_parser(arg)) {
-         throw ParserError("invalid argument for option " + opt);
-      }
-   }
+        if (!opt_spec->m_parser(arg)) {
+            throw ParserError("invalid argument for option " + opt);
+        }
+    }
 }
 
-void OptionsParser::register_option(std::string arg_short, std::string arg_long, std::string arg_hint, std::string description, OptionParserFunc parser, OptionsParser::OptionFlags flags)
+void OptionsParser::register_option(
+    std::string arg_short,
+    std::string arg_long,
+    std::string arg_hint,
+    std::string description,
+    OptionParserFunc parser,
+    OptionsParser::OptionFlags flags)
 {
-   if (arg_short.empty() || arg_long.empty() || description.empty()) {
-      throw std::runtime_error("invalid option registration: short, long or description string is missing");
-   }
+    if (arg_short.empty() || arg_long.empty() || description.empty()) {
+        throw std::runtime_error(
+            "invalid option registration: short, long or description string is missing");
+    }
 
-   if (m_short.find(arg_short) != m_short.end() ||
-       m_long.find(arg_long) != m_long.end()) {
-      throw std::runtime_error("invalid option registration: option " + arg_short + " " + arg_long + " already exists");
-   }
+    if (m_short.find(arg_short) != m_short.end() || m_long.find(arg_long) != m_long.end()) {
+        throw std::runtime_error(
+            "invalid option registration: option " + arg_short + " " + arg_long
+            + " already exists");
+    }
 
-   Option *opt = new Option();
-   opt->m_short = arg_short;
-   opt->m_long = arg_long;
-   opt->m_hint = arg_hint;
-   opt->m_description = description;
-   opt->m_parser = parser;
-   opt->m_flags = flags;
+    Option* opt = new Option();
+    opt->m_short = arg_short;
+    opt->m_long = arg_long;
+    opt->m_hint = arg_hint;
+    opt->m_description = description;
+    opt->m_parser = parser;
+    opt->m_flags = flags;
 
-   m_options.push_back(opt);
-   m_short[arg_short] = opt;
-   m_long[arg_long] = opt;
+    m_options.push_back(opt);
+    m_short[arg_short] = opt;
+    m_long[arg_long] = opt;
 }
 
-void OptionsParser::usage(std::ostream &os, int indentation, std::string mod_name) const
+void OptionsParser::usage(std::ostream& os, int indentation, std::string mod_name) const
 {
-   std::string indent_str = std::string(indentation, ' ');
-   size_t max_long = 0;
-   size_t max_short = 0;
-   size_t max_req_arg = 0;
-   for (const auto &it : m_options) {
-      size_t arg_len = it->m_flags & OptionFlags::RequiredArgument ? it->m_hint.size() : 0;
-      arg_len = it->m_flags & OptionFlags::OptionalArgument ? it->m_hint.size() + 2 : arg_len;
+    std::string indent_str = std::string(indentation, ' ');
+    size_t max_long = 0;
+    size_t max_short = 0;
+    size_t max_req_arg = 0;
+    for (const auto& it : m_options) {
+        size_t arg_len = it->m_flags & OptionFlags::RequiredArgument ? it->m_hint.size() : 0;
+        arg_len = it->m_flags & OptionFlags::OptionalArgument ? it->m_hint.size() + 2 : arg_len;
 
-      max_short = max(max_short, it->m_short.size());
-      max_long = max(max_long, it->m_long.size());
-      max_req_arg = max(max_req_arg, arg_len);
-   }
+        max_short = max(max_short, it->m_short.size());
+        max_long = max(max_long, it->m_long.size());
+        max_req_arg = max(max_req_arg, arg_len);
+    }
 
-   std::string name = (mod_name.empty() ? m_name : mod_name);
-   std::string usage_str = "Usage: ";
-   os << indent_str << name  << std::endl;
-   os << indent_str << m_info << std::endl;
-   os << indent_str << usage_str << name;
-   for (const auto &it : m_options) {
-      std::string arg_str = it->m_flags & OptionFlags::RequiredArgument ? "=" + it->m_hint : "";
-      arg_str = it->m_flags & OptionFlags::OptionalArgument ? "[=" + it->m_hint + "]" : arg_str;
-      os << m_delim << it->m_long << arg_str;
-   }
-   os << std::endl;
-   if (!m_options.empty()) {
-      os << indent_str << std::string(usage_str.size(), ' ') << name;
-      for (const auto &it : m_options) {
-         std::string arg_str = it->m_flags & OptionFlags::RequiredArgument ? "=" + it->m_hint : "";
-         arg_str = it->m_flags & OptionFlags::OptionalArgument ? "[=" + it->m_hint + "]" : arg_str;
-         os << m_delim << it->m_short << arg_str;
-      }
-      os << std::endl;
-      os << "Params:" << std::endl;
-   }
-   indent_str += "  ";
-   for (const auto &it : m_options) {
-      std::string arg_str = it->m_flags & OptionFlags::RequiredArgument ? it->m_hint : "";
-      arg_str = it->m_flags & OptionFlags::OptionalArgument ? "[" + it->m_hint + "]" : arg_str;
+    std::string name = (mod_name.empty() ? m_name : mod_name);
+    std::string usage_str = "Usage: ";
+    os << indent_str << name << std::endl;
+    os << indent_str << m_info << std::endl;
+    os << indent_str << usage_str << name;
+    for (const auto& it : m_options) {
+        std::string arg_str = it->m_flags & OptionFlags::RequiredArgument ? "=" + it->m_hint : "";
+        arg_str = it->m_flags & OptionFlags::OptionalArgument ? "[=" + it->m_hint + "]" : arg_str;
+        os << m_delim << it->m_long << arg_str;
+    }
+    os << std::endl;
+    if (!m_options.empty()) {
+        os << indent_str << std::string(usage_str.size(), ' ') << name;
+        for (const auto& it : m_options) {
+            std::string arg_str
+                = it->m_flags & OptionFlags::RequiredArgument ? "=" + it->m_hint : "";
+            arg_str
+                = it->m_flags & OptionFlags::OptionalArgument ? "[=" + it->m_hint + "]" : arg_str;
+            os << m_delim << it->m_short << arg_str;
+        }
+        os << std::endl;
+        os << "Params:" << std::endl;
+    }
+    indent_str += "  ";
+    for (const auto& it : m_options) {
+        std::string arg_str = it->m_flags & OptionFlags::RequiredArgument ? it->m_hint : "";
+        arg_str = it->m_flags & OptionFlags::OptionalArgument ? "[" + it->m_hint + "]" : arg_str;
 
-      os << indent_str <<
-         std::setw(max_short + 1) << std::left << it->m_short <<
-         std::setw(max_long + 1) << std::left << it->m_long <<
-         std::setw(max_req_arg + 2) << std::left << arg_str <<
-         " " + it->m_description << std::endl;
-   }
+        os << indent_str << std::setw(max_short + 1) << std::left << it->m_short
+           << std::setw(max_long + 1) << std::left << it->m_long << std::setw(max_req_arg + 2)
+           << std::left << arg_str << " " + it->m_description << std::endl;
+    }
 }
 
-}
+} // namespace ipxp

--- a/output/ipfix-basiclist.cpp
+++ b/output/ipfix-basiclist.cpp
@@ -26,102 +26,109 @@
  *
  */
 
-
 #include <ipfixprobe/ipfix-basiclist.hpp>
 
 namespace ipxp {
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, uint16_t *values, uint16_t len, uint16_t fieldID)
+int32_t
+IpfixBasicList::FillBuffer(uint8_t* buffer, uint16_t* values, uint16_t len, uint16_t fieldID)
 {
-   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint16_t), fieldID);
+    int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint16_t), fieldID);
 
-   for (int i = 0; i < len; i++) {
-      (*reinterpret_cast<uint16_t *>(buffer + written)) = htons(values[i]);
-      written += sizeof(uint16_t);
-   }
-   return written;
+    for (int i = 0; i < len; i++) {
+        (*reinterpret_cast<uint16_t*>(buffer + written)) = htons(values[i]);
+        written += sizeof(uint16_t);
+    }
+    return written;
 }
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, int16_t *values, uint16_t len, uint16_t fieldID)
+int32_t IpfixBasicList::FillBuffer(uint8_t* buffer, int16_t* values, uint16_t len, uint16_t fieldID)
 {
-   return this->FillBuffer(buffer, (uint16_t *) values, len, fieldID);
+    return this->FillBuffer(buffer, (uint16_t*) values, len, fieldID);
 }
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, uint32_t *values, uint16_t len, uint16_t fieldID)
+int32_t
+IpfixBasicList::FillBuffer(uint8_t* buffer, uint32_t* values, uint16_t len, uint16_t fieldID)
 {
-   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint32_t), fieldID);
+    int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint32_t), fieldID);
 
-   for (int i = 0; i < len; i++) {
-      (*reinterpret_cast<uint32_t *>(buffer + written)) = htonl(values[i]);
-      written += sizeof(uint32_t);
-   }
-   return written;
+    for (int i = 0; i < len; i++) {
+        (*reinterpret_cast<uint32_t*>(buffer + written)) = htonl(values[i]);
+        written += sizeof(uint32_t);
+    }
+    return written;
 }
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, int32_t *values, uint16_t len, uint16_t fieldID)
+int32_t IpfixBasicList::FillBuffer(uint8_t* buffer, int32_t* values, uint16_t len, uint16_t fieldID)
 {
-   return this->FillBuffer(buffer, (uint32_t *) values, len, fieldID);
+    return this->FillBuffer(buffer, (uint32_t*) values, len, fieldID);
 }
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, struct timeval *values, uint16_t len, uint16_t fieldID)
+int32_t
+IpfixBasicList::FillBuffer(uint8_t* buffer, struct timeval* values, uint16_t len, uint16_t fieldID)
 {
-   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint64_t), fieldID);
+    int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint64_t), fieldID);
 
-   for (int i = 0; i < len; i++) {
-      (*reinterpret_cast<uint64_t *>(buffer + written)) = swap_uint64(Tv2Ts(values[i]));
-      written += sizeof(uint64_t);
-   }
-   return written;
+    for (int i = 0; i < len; i++) {
+        (*reinterpret_cast<uint64_t*>(buffer + written)) = swap_uint64(Tv2Ts(values[i]));
+        written += sizeof(uint64_t);
+    }
+    return written;
 }
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, uint8_t *values, uint16_t len, uint16_t fieldID)
+int32_t IpfixBasicList::FillBuffer(uint8_t* buffer, uint8_t* values, uint16_t len, uint16_t fieldID)
 {
-   int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint8_t), fieldID);
+    int32_t written = this->FillBufferHdr(buffer, len, sizeof(uint8_t), fieldID);
 
-   memcpy(buffer + written, values, len);
-   written += len;
-   return written;
+    memcpy(buffer + written, values, len);
+    written += len;
+    return written;
 }
 
-int32_t IpfixBasicList::FillBuffer(uint8_t *buffer, int8_t *values, uint16_t len, uint16_t fieldID)
+int32_t IpfixBasicList::FillBuffer(uint8_t* buffer, int8_t* values, uint16_t len, uint16_t fieldID)
 {
-   return this->FillBuffer(buffer, (uint8_t *) values, len, fieldID);
+    return this->FillBuffer(buffer, (uint8_t*) values, len, fieldID);
 }
 
-int32_t IpfixBasicList::FillBufferHdr(uint8_t *buffer, uint16_t length, uint16_t elementLength, uint16_t fieldID)
+int32_t IpfixBasicList::FillBufferHdr(
+    uint8_t* buffer,
+    uint16_t length,
+    uint16_t elementLength,
+    uint16_t fieldID)
 {
-   uint32_t bufferPtr = 0;
+    uint32_t bufferPtr = 0;
 
-   // Copy flag
-   buffer[bufferPtr] = flag;
-   bufferPtr        += sizeof(uint8_t);
-   // Copy length;
-   *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(IpfixBasicListHdrSize + length * elementLength);
-   bufferPtr += sizeof(uint16_t);
-   // copy hdr_semantic
-   buffer[bufferPtr] = hdrSemantic;
-   bufferPtr        += sizeof(uint8_t);
-   // copy hdr_field_id
-   *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons((1 << 15) | fieldID);
-   bufferPtr += sizeof(uint16_t);
-   // copy hdr_element_len
-   *(reinterpret_cast<uint16_t *>(buffer + bufferPtr)) = htons(elementLength);
-   bufferPtr += sizeof(uint16_t);
-   // copy enterprise num from hdr struct
-   *(reinterpret_cast<uint32_t *>(buffer + bufferPtr)) = htonl((uint32_t) hdrEnterpriseNum);
-   bufferPtr += sizeof(uint32_t);
+    // Copy flag
+    buffer[bufferPtr] = flag;
+    bufferPtr += sizeof(uint8_t);
+    // Copy length;
+    *(reinterpret_cast<uint16_t*>(buffer + bufferPtr))
+        = htons(IpfixBasicListHdrSize + length * elementLength);
+    bufferPtr += sizeof(uint16_t);
+    // copy hdr_semantic
+    buffer[bufferPtr] = hdrSemantic;
+    bufferPtr += sizeof(uint8_t);
+    // copy hdr_field_id
+    *(reinterpret_cast<uint16_t*>(buffer + bufferPtr)) = htons((1 << 15) | fieldID);
+    bufferPtr += sizeof(uint16_t);
+    // copy hdr_element_len
+    *(reinterpret_cast<uint16_t*>(buffer + bufferPtr)) = htons(elementLength);
+    bufferPtr += sizeof(uint16_t);
+    // copy enterprise num from hdr struct
+    *(reinterpret_cast<uint32_t*>(buffer + bufferPtr)) = htonl((uint32_t) hdrEnterpriseNum);
+    bufferPtr += sizeof(uint32_t);
 
-   return bufferPtr;
+    return bufferPtr;
 }
 
 int32_t IpfixBasicList::HeaderSize()
 {
-   return IpfixBasicListRecordHdrSize;
+    return IpfixBasicListRecordHdrSize;
 }
 
 uint64_t IpfixBasicList::Tv2Ts(timeval input)
 {
-   return static_cast<uint64_t>(input.tv_sec) * 1000 + (input.tv_usec / 1000);
+    return static_cast<uint64_t>(input.tv_sec) * 1000 + (input.tv_usec / 1000);
 }
 
-}
+} // namespace ipxp

--- a/output/ipfix.cpp
+++ b/output/ipfix.cpp
@@ -34,39 +34,39 @@
  * in contract, strict liability, or tort (including negligence or
  * otherwise) arising in any way out of the use of this software, even
  * if advised of the possibility of such damage.
-*/
+ */
 
+#include <arpa/inet.h>
+#include <assert.h>
 #include <config.h>
-#include <vector>
+#include <endian.h>
+#include <errno.h>
+#include <memory>
+#include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <errno.h>
-#include <assert.h>
-#include <endian.h>
-#include <memory>
+#include <unistd.h>
+#include <vector>
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+#include "ipfix.hpp"
+#include <ipfixprobe/byte-utils.hpp>
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
 #include <ipfixprobe/output.hpp>
 #include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/byte-utils.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
-#include "ipfix.hpp"
 
 namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("ipfix", [](){return new IPFIXExporter();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("ipfix", []() { return new IPFIXExporter(); });
+    register_plugin(&rec);
 }
 
 #define GCC_CHECK_PRAGMA ((__GNUC__ == 4 && 6 <= __GNUC_MINOR__) || 4 < __GNUC__)
@@ -91,290 +91,300 @@ __attribute__((constructor)) static void register_this_plugin()
  * \param[in] SOURCE pointer to source of data
  * \param[in] LENGTH size of data in bytes
  */
-#define IPFIX_FILL_FIELD(TARGET, FIELD) do { \
-   if (FIELD_LEN(FIELD) == 1) { \
-      *((uint8_t *) TARGET) = *((uint8_t *) FIELD_SOURCE(FIELD)); \
-   } else if (FIELD_LEN(FIELD) == 2) { \
-      *((uint16_t *) TARGET) = htons(*((uint16_t *) FIELD_SOURCE(FIELD))); \
-   } else if ((FIELD_EN(FIELD) == 0) && \
-              ((FIELD_ID(FIELD) == FIELD_ID(L3_IPV4_ADDR_SRC)) || (FIELD_ID(FIELD) == FIELD_ID(L3_IPV4_ADDR_DST)))) { \
-      *((uint32_t *) TARGET) = *((uint32_t *) FIELD_SOURCE(FIELD)); \
-   } else if (FIELD_LEN(FIELD) == 4) { \
-      *((uint32_t *) TARGET) = htonl(*((uint32_t *) FIELD_SOURCE(FIELD))); \
-   } else if (FIELD_LEN(FIELD) == 8) { \
-      *((uint64_t *) TARGET) = swap_uint64(*((uint64_t *) FIELD_SOURCE(FIELD))); \
-   } else { \
-      memcpy(TARGET, (void *) FIELD_SOURCE(FIELD), FIELD_LEN(FIELD)); \
-   } \
-   TARGET += FIELD_LEN(FIELD); \
-} while (0)
+#define IPFIX_FILL_FIELD(TARGET, FIELD)                                                            \
+    do {                                                                                           \
+        if (FIELD_LEN(FIELD) == 1) {                                                               \
+            *((uint8_t*) TARGET) = *((uint8_t*) FIELD_SOURCE(FIELD));                              \
+        } else if (FIELD_LEN(FIELD) == 2) {                                                        \
+            *((uint16_t*) TARGET) = htons(*((uint16_t*) FIELD_SOURCE(FIELD)));                     \
+        } else if (                                                                                \
+            (FIELD_EN(FIELD) == 0)                                                                 \
+            && ((FIELD_ID(FIELD) == FIELD_ID(L3_IPV4_ADDR_SRC))                                    \
+                || (FIELD_ID(FIELD) == FIELD_ID(L3_IPV4_ADDR_DST)))) {                             \
+            *((uint32_t*) TARGET) = *((uint32_t*) FIELD_SOURCE(FIELD));                            \
+        } else if (FIELD_LEN(FIELD) == 4) {                                                        \
+            *((uint32_t*) TARGET) = htonl(*((uint32_t*) FIELD_SOURCE(FIELD)));                     \
+        } else if (FIELD_LEN(FIELD) == 8) {                                                        \
+            *((uint64_t*) TARGET) = swap_uint64(*((uint64_t*) FIELD_SOURCE(FIELD)));               \
+        } else {                                                                                   \
+            memcpy(TARGET, (void*) FIELD_SOURCE(FIELD), FIELD_LEN(FIELD));                         \
+        }                                                                                          \
+        TARGET += FIELD_LEN(FIELD);                                                                \
+    } while (0)
 
 /*
  * IPFIX template fields.
  *
  * name enterprise-number element-id length
  */
-template_file_record_t ipfix_fields[][1] = {
-   IPFIX_ENABLED_TEMPLATES(X)
-   nullptr
-};
+template_file_record_t ipfix_fields[][1] = {IPFIX_ENABLED_TEMPLATES(X) nullptr};
 
 /* Basic IPv4 template. */
-const char *basic_tmplt_v4[] = {
-   BASIC_TMPLT_V4(IPFIX_FIELD_NAMES)
-   nullptr
-};
+const char* basic_tmplt_v4[] = {BASIC_TMPLT_V4(IPFIX_FIELD_NAMES) nullptr};
 
 /* Basic IPv6 template. */
-const char *basic_tmplt_v6[] = {
-   BASIC_TMPLT_V6(IPFIX_FIELD_NAMES)
-   nullptr
-};
+const char* basic_tmplt_v6[] = {BASIC_TMPLT_V6(IPFIX_FIELD_NAMES) nullptr};
 
-IPFIXExporter::IPFIXExporter() :
-   extensions(nullptr), extension_cnt(0),
-   templates(nullptr), templatesDataSize(0),
-   basic_ifc_num(-1), verbose(false),
-   sequenceNum(0), exportedPackets(0),
-   fd(-1), addrinfo(nullptr),
-   host(""), port(4739), protocol(IPPROTO_TCP),
-   ip(AF_UNSPEC), flags(0),
-   reconnectTimeout(RECONNECT_TIMEOUT), lastReconnect(0), odid(0),
-   templateRefreshTime(TEMPLATE_REFRESH_TIME),
-   templateRefreshPackets(TEMPLATE_REFRESH_PACKETS),
-   dir_bit_field(0),
-   mtu(DEFAULT_MTU), packetDataBuffer(nullptr),
-   tmpltMaxBufferSize(mtu - IPFIX_HEADER_SIZE)
+IPFIXExporter::IPFIXExporter()
+    : extensions(nullptr)
+    , extension_cnt(0)
+    , templates(nullptr)
+    , templatesDataSize(0)
+    , basic_ifc_num(-1)
+    , verbose(false)
+    , sequenceNum(0)
+    , exportedPackets(0)
+    , fd(-1)
+    , addrinfo(nullptr)
+    , host("")
+    , port(4739)
+    , protocol(IPPROTO_TCP)
+    , ip(AF_UNSPEC)
+    , flags(0)
+    , reconnectTimeout(RECONNECT_TIMEOUT)
+    , lastReconnect(0)
+    , odid(0)
+    , templateRefreshTime(TEMPLATE_REFRESH_TIME)
+    , templateRefreshPackets(TEMPLATE_REFRESH_PACKETS)
+    , dir_bit_field(0)
+    , mtu(DEFAULT_MTU)
+    , packetDataBuffer(nullptr)
+    , tmpltMaxBufferSize(mtu - IPFIX_HEADER_SIZE)
 {
 }
 
 IPFIXExporter::~IPFIXExporter()
 {
-   close();
+    close();
 }
 
-void IPFIXExporter::init(const char *params)
+void IPFIXExporter::init(const char* params)
 {
-   IpfixOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
-   verbose = parser.m_verbose;
-   if (verbose) {
-      fprintf(stderr, "VERBOSE: IPFIX export plugin init start\n");
-   }
+    IpfixOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
+    verbose = parser.m_verbose;
+    if (verbose) {
+        fprintf(stderr, "VERBOSE: IPFIX export plugin init start\n");
+    }
 
-   host = parser.m_host;
-   port = parser.m_port;
-   odid = parser.m_id;
-   mtu = parser.m_mtu;
-   dir_bit_field = parser.m_dir;
-   templateRefreshTime = parser.m_template_refresh_time;
+    host = parser.m_host;
+    port = parser.m_port;
+    odid = parser.m_id;
+    mtu = parser.m_mtu;
+    dir_bit_field = parser.m_dir;
+    templateRefreshTime = parser.m_template_refresh_time;
 
-   if (parser.m_udp) {
-      protocol = IPPROTO_UDP;
-   }
+    if (parser.m_udp) {
+        protocol = IPPROTO_UDP;
+    }
 
-   if (mtu <= IPFIX_HEADER_SIZE) {
-      throw PluginError("IPFIX message MTU size should be at least " + std::to_string(IPFIX_HEADER_SIZE));
-   }
-   tmpltMaxBufferSize = mtu - IPFIX_HEADER_SIZE;
-   packetDataBuffer = (uint8_t *) malloc(sizeof(uint8_t) * mtu);
-   if (!packetDataBuffer) {
-      throw PluginError("not enough memory");
-   }
+    if (mtu <= IPFIX_HEADER_SIZE) {
+        throw PluginError(
+            "IPFIX message MTU size should be at least " + std::to_string(IPFIX_HEADER_SIZE));
+    }
+    tmpltMaxBufferSize = mtu - IPFIX_HEADER_SIZE;
+    packetDataBuffer = (uint8_t*) malloc(sizeof(uint8_t) * mtu);
+    if (!packetDataBuffer) {
+        throw PluginError("not enough memory");
+    }
 
-   int ret = connect_to_collector();
-   if (ret) {
-      lastReconnect = time(nullptr);
-   }
+    int ret = connect_to_collector();
+    if (ret) {
+        lastReconnect = time(nullptr);
+    }
 
-   if (verbose) {
-      fprintf(stderr, "VERBOSE: IPFIX export plugin init end\n");
-   }
+    if (verbose) {
+        fprintf(stderr, "VERBOSE: IPFIX export plugin init end\n");
+    }
 }
 
-void IPFIXExporter::init(const char *params, Plugins &plugins)
+void IPFIXExporter::init(const char* params, Plugins& plugins)
 {
-   init(params);
+    init(params);
 
-   extension_cnt = get_extension_cnt();
-   if (extension_cnt > 64) {
-      throw PluginError("output plugin operates only with up to 64 running plugins");
-   }
-   extensions = new RecordExt*[extension_cnt];
-   for (int i = 0; i < extension_cnt; i++) {
-      extensions[i] = nullptr;
-   }
-   for (auto &it : plugins) {
-      std::string name = it.first;
-      ProcessPlugin *plugin = it.second;
-      RecordExt *ext = plugin->get_ext();
-      if (ext == nullptr) {
-         continue;
-      }
-      if (ext->m_ext_id >= 64) {
-         throw PluginError("detected plugin ID >64");
-      } else if (ext->m_ext_id >= extension_cnt) {
-         throw PluginError("detected plugin ID larger than number of extensions");
-      }
-      delete ext;
-   }
+    extension_cnt = get_extension_cnt();
+    if (extension_cnt > 64) {
+        throw PluginError("output plugin operates only with up to 64 running plugins");
+    }
+    extensions = new RecordExt*[extension_cnt];
+    for (int i = 0; i < extension_cnt; i++) {
+        extensions[i] = nullptr;
+    }
+    for (auto& it : plugins) {
+        std::string name = it.first;
+        ProcessPlugin* plugin = it.second;
+        RecordExt* ext = plugin->get_ext();
+        if (ext == nullptr) {
+            continue;
+        }
+        if (ext->m_ext_id >= 64) {
+            throw PluginError("detected plugin ID >64");
+        } else if (ext->m_ext_id >= extension_cnt) {
+            throw PluginError("detected plugin ID larger than number of extensions");
+        }
+        delete ext;
+    }
 }
 
 void IPFIXExporter::close()
 {
-   /* Try to flush any remaining data */
-   flush();
+    /* Try to flush any remaining data */
+    flush();
 
-   /* Close the connection */
-   if (fd != -1) {
-      ::close(fd);
-      freeaddrinfo(addrinfo);
-      addrinfo = nullptr;
-      fd = -1;
-   }
+    /* Close the connection */
+    if (fd != -1) {
+        ::close(fd);
+        freeaddrinfo(addrinfo);
+        addrinfo = nullptr;
+        fd = -1;
+    }
 
-   template_t *tmp = templates;
-   while (tmp != nullptr) {
-      templates = templates->next;
-      free(tmp->buffer);
-      free(tmp);
-      tmp = templates;
-   }
-   templates = nullptr;
+    template_t* tmp = templates;
+    while (tmp != nullptr) {
+        templates = templates->next;
+        free(tmp->buffer);
+        free(tmp);
+        tmp = templates;
+    }
+    templates = nullptr;
 
-   if (packetDataBuffer != nullptr) {
-      free(packetDataBuffer);
-      packetDataBuffer = nullptr;
-   }
-   if (extensions != nullptr) {
-      delete [] extensions;
-      extensions = nullptr;
-   }
+    if (packetDataBuffer != nullptr) {
+        free(packetDataBuffer);
+        packetDataBuffer = nullptr;
+    }
+    if (extensions != nullptr) {
+        delete[] extensions;
+        extensions = nullptr;
+    }
 }
 
-uint64_t IPFIXExporter::get_template_id(const Record &flow)
+uint64_t IPFIXExporter::get_template_id(const Record& flow)
 {
-   RecordExt *ext = flow.m_exts;
-   uint64_t tmpltIdx = 0;
-   while (ext != nullptr) {
-      tmpltIdx |= ((uint64_t) 1 << ext->m_ext_id);
-      ext = ext->m_next;
-   }
+    RecordExt* ext = flow.m_exts;
+    uint64_t tmpltIdx = 0;
+    while (ext != nullptr) {
+        tmpltIdx |= ((uint64_t) 1 << ext->m_ext_id);
+        ext = ext->m_next;
+    }
 
-   return tmpltIdx;
+    return tmpltIdx;
 }
 
-template_t *IPFIXExporter::get_template(const Flow &flow)
+template_t* IPFIXExporter::get_template(const Flow& flow)
 {
-   int ipTmpltIdx = flow.ip_version == IP::v6 ? TMPLT_IDX_V6 : TMPLT_IDX_V4;
-   uint64_t tmpltIdx = get_template_id(flow);
+    int ipTmpltIdx = flow.ip_version == IP::v6 ? TMPLT_IDX_V6 : TMPLT_IDX_V4;
+    uint64_t tmpltIdx = get_template_id(flow);
 
-   if (tmpltMap[ipTmpltIdx].find(tmpltIdx) == tmpltMap[ipTmpltIdx].end()) {
-      std::vector<const char *> all_fields;
+    if (tmpltMap[ipTmpltIdx].find(tmpltIdx) == tmpltMap[ipTmpltIdx].end()) {
+        std::vector<const char*> all_fields;
 
-      RecordExt *ext = flow.m_exts;
-      while (ext != nullptr) {
-         if (ext->m_ext_id < 0 || ext->m_ext_id >= extension_cnt) {
-            throw PluginError("encountered invalid extension id");
-         }
-         extensions[ext->m_ext_id] = ext;
-         ext = ext->m_next;
-      }
-      for (int i = 0; i < extension_cnt; i++) {
-         if (extensions[i] == nullptr) {
+        RecordExt* ext = flow.m_exts;
+        while (ext != nullptr) {
+            if (ext->m_ext_id < 0 || ext->m_ext_id >= extension_cnt) {
+                throw PluginError("encountered invalid extension id");
+            }
+            extensions[ext->m_ext_id] = ext;
+            ext = ext->m_next;
+        }
+        for (int i = 0; i < extension_cnt; i++) {
+            if (extensions[i] == nullptr) {
+                continue;
+            }
+            const char** fields = extensions[i]->get_ipfix_tmplt();
+            extensions[i] = nullptr;
+            if (fields == nullptr) {
+                throw PluginError(
+                    "missing template fields for extension with ID " + std::to_string(i));
+            }
+            while (*fields != nullptr) {
+                all_fields.push_back(*fields);
+                fields++;
+            }
+        }
+        all_fields.push_back(nullptr);
+
+        tmpltMap[TMPLT_IDX_V4][tmpltIdx] = create_template(basic_tmplt_v4, all_fields.data());
+        tmpltMap[TMPLT_IDX_V6][tmpltIdx] = create_template(basic_tmplt_v6, all_fields.data());
+    }
+
+    return tmpltMap[ipTmpltIdx][tmpltIdx];
+}
+
+int IPFIXExporter::fill_extensions(RecordExt* ext, uint8_t* buffer, int size)
+{
+    int length = 0;
+    int extCnt = 0;
+    while (ext != nullptr) {
+        extensions[ext->m_ext_id] = ext;
+        extCnt++;
+        ext = ext->m_next;
+    }
+    // TODO: export multiple extension header of same type
+    for (int i = 0; i < extension_cnt; i++) {
+        if (extensions[i] == nullptr) {
             continue;
-         }
-         const char **fields = extensions[i]->get_ipfix_tmplt();
-         extensions[i] = nullptr;
-         if (fields == nullptr) {
-            throw PluginError("missing template fields for extension with ID " + std::to_string(i));
-         }
-         while (*fields != nullptr) {
-            all_fields.push_back(*fields);
-            fields++;
-         }
-      }
-      all_fields.push_back(nullptr);
-
-      tmpltMap[TMPLT_IDX_V4][tmpltIdx] = create_template(basic_tmplt_v4, all_fields.data());
-      tmpltMap[TMPLT_IDX_V6][tmpltIdx] = create_template(basic_tmplt_v6, all_fields.data());
-   }
-
-   return tmpltMap[ipTmpltIdx][tmpltIdx];
+        }
+        int length_ext = extensions[i]->fill_ipfix(buffer + length, size - length);
+        extensions[i] = nullptr;
+        if (length_ext < 0) {
+            for (int j = i; j < extension_cnt; j++) {
+                extensions[j] = nullptr;
+            }
+            return -1;
+        }
+        length += length_ext;
+    }
+    return length;
 }
 
-int IPFIXExporter::fill_extensions(RecordExt *ext, uint8_t *buffer, int size)
+bool IPFIXExporter::fill_template(const Flow& flow, template_t* tmplt)
 {
-   int length = 0;
-   int extCnt = 0;
-   while (ext != nullptr) {
-      extensions[ext->m_ext_id] = ext;
-      extCnt++;
-      ext = ext->m_next;
-   }
-   // TODO: export multiple extension header of same type
-   for (int i = 0; i < extension_cnt; i++) {
-      if (extensions[i] == nullptr) {
-         continue;
-      }
-      int length_ext = extensions[i]->fill_ipfix(buffer + length, size - length);
-      extensions[i] = nullptr;
-      if (length_ext < 0) {
-         for (int j = i; j < extension_cnt; j++) {
-            extensions[j] = nullptr;
-         }
-         return -1;
-      }
-      length += length_ext;
-   }
-   return length;
+    RecordExt* ext = flow.m_exts;
+    int length = 0;
+
+    if (basic_ifc_num >= 0 && ext == nullptr) {
+        length = fill_basic_flow(flow, tmplt);
+        if (length < 0) {
+            return false;
+        }
+    } else {
+        length = fill_basic_flow(flow, tmplt);
+        if (length < 0) {
+            return false;
+        }
+
+        int ext_written = fill_extensions(
+            ext,
+            tmplt->buffer + tmplt->bufferSize + length,
+            tmpltMaxBufferSize - tmplt->bufferSize - length);
+        if (ext_written < 0) {
+            return false;
+        }
+        length += ext_written;
+    }
+
+    tmplt->bufferSize += length;
+    tmplt->recordCount++;
+    return true;
 }
 
-bool IPFIXExporter::fill_template(const Flow &flow, template_t *tmplt)
+int IPFIXExporter::export_flow(const Flow& flow)
 {
-   RecordExt *ext = flow.m_exts;
-   int length = 0;
+    m_flows_seen++;
+    template_t* tmplt = get_template(flow);
+    if (!fill_template(flow, tmplt)) {
+        flush();
 
-   if (basic_ifc_num >= 0 && ext == nullptr) {
-      length = fill_basic_flow(flow, tmplt);
-      if (length < 0) {
-         return false;
-      }
-   } else {
-      length = fill_basic_flow(flow, tmplt);
-      if (length < 0) {
-         return false;
-      }
-
-      int ext_written = fill_extensions(ext, tmplt->buffer + tmplt->bufferSize + length, tmpltMaxBufferSize - tmplt->bufferSize - length);
-      if (ext_written < 0) {
-         return false;
-      }
-      length += ext_written;
-   }
-
-   tmplt->bufferSize += length;
-   tmplt->recordCount++;
-   return true;
-}
-
-int IPFIXExporter::export_flow(const Flow &flow)
-{
-   m_flows_seen++;
-   template_t *tmplt = get_template(flow);
-   if (!fill_template(flow, tmplt)) {
-      flush();
-
-      if (!fill_template(flow, tmplt)) {
-         m_flows_dropped++;
-         return 1;
-      }
-   }
-   return 0;
+        if (!fill_template(flow, tmplt)) {
+            m_flows_dropped++;
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /**
@@ -388,12 +398,12 @@ int IPFIXExporter::export_flow(const Flow &flow)
  *
  * @param tmpl Template to init
  */
-void IPFIXExporter::init_template_buffer(template_t *tmpl)
+void IPFIXExporter::init_template_buffer(template_t* tmpl)
 {
-   *((uint16_t *) &tmpl->buffer[0]) = htons(tmpl->id);
-   /* Length will be updated later */
-   /* *((uint16_t *) &tmpl->buffer[2]) = htons(0); */
-   tmpl->bufferSize = 4;
+    *((uint16_t*) &tmpl->buffer[0]) = htons(tmpl->id);
+    /* Length will be updated later */
+    /* *((uint16_t *) &tmpl->buffer[2]) = htons(0); */
+    tmpl->bufferSize = 4;
 }
 
 /**
@@ -403,14 +413,14 @@ void IPFIXExporter::init_template_buffer(template_t *tmpl)
  * @param size Size of the template set including set header
  * @return size of the template set header
  */
-int IPFIXExporter::fill_template_set_header(uint8_t *ptr, uint16_t size)
+int IPFIXExporter::fill_template_set_header(uint8_t* ptr, uint16_t size)
 {
-   ipfix_template_set_header_t *header = (ipfix_template_set_header_t *) ptr;
+    ipfix_template_set_header_t* header = (ipfix_template_set_header_t*) ptr;
 
-   header->id = htons(TEMPLATE_SET_ID);
-   header->length = htons(size);
+    header->id = htons(TEMPLATE_SET_ID);
+    header->length = htons(size);
 
-   return IPFIX_SET_HEADER_SIZE;
+    return IPFIX_SET_HEADER_SIZE;
 }
 
 /**
@@ -418,23 +428,31 @@ int IPFIXExporter::fill_template_set_header(uint8_t *ptr, uint16_t size)
  *
  * @param tmpl Template to check
  */
-void IPFIXExporter::check_template_lifetime(template_t *tmpl)
+void IPFIXExporter::check_template_lifetime(template_t* tmpl)
 {
-   if (templateRefreshTime != 0 &&
-         (time_t) (templateRefreshTime + tmpl->exportTime) <= time(nullptr)) {
-      if (verbose) {
-         fprintf(stderr, "VERBOSE: Template %i refresh time expired (%is)\n", tmpl->id, templateRefreshTime);
-      }
-      tmpl->exported = 0;
-   }
+    if (templateRefreshTime != 0
+        && (time_t) (templateRefreshTime + tmpl->exportTime) <= time(nullptr)) {
+        if (verbose) {
+            fprintf(
+                stderr,
+                "VERBOSE: Template %i refresh time expired (%is)\n",
+                tmpl->id,
+                templateRefreshTime);
+        }
+        tmpl->exported = 0;
+    }
 
-   if (templateRefreshPackets != 0 &&
-         templateRefreshPackets + tmpl->exportPacket <= exportedPackets) {
-      if (verbose) {
-         fprintf(stderr, "VERBOSE: Template %i refresh packets expired (%i packets)\n", tmpl->id, templateRefreshPackets);
-      }
-      tmpl->exported = 0;
-   }
+    if (templateRefreshPackets != 0
+        && templateRefreshPackets + tmpl->exportPacket <= exportedPackets) {
+        if (verbose) {
+            fprintf(
+                stderr,
+                "VERBOSE: Template %i refresh packets expired (%i packets)\n",
+                tmpl->id,
+                templateRefreshPackets);
+        }
+        tmpl->exported = 0;
+    }
 }
 
 /**
@@ -444,17 +462,17 @@ void IPFIXExporter::check_template_lifetime(template_t *tmpl)
  * @param size Size of the IPFIX packet not including the header.
  * @return Returns size of the header
  */
-int IPFIXExporter::fill_ipfix_header(uint8_t *ptr, uint16_t size)
+int IPFIXExporter::fill_ipfix_header(uint8_t* ptr, uint16_t size)
 {
-   ipfix_header_t *header = (ipfix_header_t *)ptr;
+    ipfix_header_t* header = (ipfix_header_t*) ptr;
 
-   header->version = htons(IPFIX_VERISON);
-   header->length = htons(size);
-   header->exportTime = htonl(time(nullptr));
-   header->sequenceNumber = htonl(sequenceNum);
-   header->observationDomainId = htonl(odid);
+    header->version = htons(IPFIX_VERISON);
+    header->length = htons(size);
+    header->exportTime = htonl(time(nullptr));
+    header->sequenceNumber = htonl(sequenceNum);
+    header->observationDomainId = htonl(odid);
 
-   return IPFIX_HEADER_SIZE;
+    return IPFIX_HEADER_SIZE;
 }
 
 /**
@@ -463,25 +481,25 @@ int IPFIXExporter::fill_ipfix_header(uint8_t *ptr, uint16_t size)
  * @param name Name of the record to find
  * @return Template File Record with matching name or nullptr when non exists
  */
-template_file_record_t *IPFIXExporter::get_template_record_by_name(const char *name)
+template_file_record_t* IPFIXExporter::get_template_record_by_name(const char* name)
 {
-   template_file_record_t *tmpFileRecord = *ipfix_fields;
+    template_file_record_t* tmpFileRecord = *ipfix_fields;
 
-   if (name == nullptr) {
-      if (verbose) {
-         fprintf(stderr, "VERBOSE: Cannot get template for nullptr name\n");
-      }
-      return nullptr;
-   }
+    if (name == nullptr) {
+        if (verbose) {
+            fprintf(stderr, "VERBOSE: Cannot get template for nullptr name\n");
+        }
+        return nullptr;
+    }
 
-   while (tmpFileRecord && tmpFileRecord->name) {
-      if (strcmp(name, tmpFileRecord->name) == 0) {
-         return tmpFileRecord;
-      }
-      tmpFileRecord++;
-   }
+    while (tmpFileRecord && tmpFileRecord->name) {
+        if (strcmp(name, tmpFileRecord->name) == 0) {
+            return tmpFileRecord;
+        }
+        tmpFileRecord++;
+    }
 
-   return nullptr;
+    return nullptr;
 }
 
 /**
@@ -489,14 +507,14 @@ template_file_record_t *IPFIXExporter::get_template_record_by_name(const char *n
  */
 void IPFIXExporter::expire_templates()
 {
-   template_t *tmp;
-   for (tmp = templates; tmp != nullptr; tmp = tmp->next) {
-      tmp->exported = 0;
-      if (protocol == IPPROTO_UDP) {
-         tmp->exportTime = time(nullptr);
-         tmp->exportPacket = exportedPackets;
-      }
-   }
+    template_t* tmp;
+    for (tmp = templates; tmp != nullptr; tmp = tmp->next) {
+        tmp->exported = 0;
+        if (protocol == IPPROTO_UDP) {
+            tmp->exportTime = time(nullptr);
+            tmp->exportPacket = exportedPackets;
+        }
+    }
 }
 
 /**
@@ -512,120 +530,127 @@ void IPFIXExporter::expire_templates()
  * @param ext Template extension fields string
  * @return Created template on success, nullptr otherwise
  */
-template_t *IPFIXExporter::create_template(const char **tmplt, const char **ext)
+template_t* IPFIXExporter::create_template(const char** tmplt, const char** ext)
 {
-   uint16_t maxID = FIRST_TEMPLATE_ID;
-   uint16_t len;
-   template_t *tmpTemplate = templates;
-   template_t *newTemplate;
-   const char **tmp = tmplt;
+    uint16_t maxID = FIRST_TEMPLATE_ID;
+    uint16_t len;
+    template_t* tmpTemplate = templates;
+    template_t* newTemplate;
+    const char** tmp = tmplt;
 
-   /* Create new template structure */
-   newTemplate = (template_t *) malloc(sizeof(template_t));
-   if (!newTemplate) {
-      fprintf(stderr, "Error: Not enough memory for IPFIX template.\n");
-      return nullptr;
-   }
+    /* Create new template structure */
+    newTemplate = (template_t*) malloc(sizeof(template_t));
+    if (!newTemplate) {
+        fprintf(stderr, "Error: Not enough memory for IPFIX template.\n");
+        return nullptr;
+    }
 
-   newTemplate->fieldCount = 0;
-   newTemplate->recordCount = 0;
-   newTemplate->buffer = (uint8_t *) malloc(sizeof(uint8_t) * tmpltMaxBufferSize);
-   if (!newTemplate->buffer) {
-      free(newTemplate);
-      fprintf(stderr, "Error: Not enough memory for IPFIX template buffer.\n");
-      return nullptr;
-   }
+    newTemplate->fieldCount = 0;
+    newTemplate->recordCount = 0;
+    newTemplate->buffer = (uint8_t*) malloc(sizeof(uint8_t) * tmpltMaxBufferSize);
+    if (!newTemplate->buffer) {
+        free(newTemplate);
+        fprintf(stderr, "Error: Not enough memory for IPFIX template buffer.\n");
+        return nullptr;
+    }
 
-   /* Set template ID to maximum + 1 */
-   while (tmpTemplate != nullptr) {
-      if (tmpTemplate->id >= maxID) maxID = tmpTemplate->id + 1;
-      tmpTemplate = tmpTemplate->next;
-   }
-   newTemplate->id = maxID;
-   ((uint16_t *) newTemplate->templateRecord)[0] = htons(newTemplate->id);
+    /* Set template ID to maximum + 1 */
+    while (tmpTemplate != nullptr) {
+        if (tmpTemplate->id >= maxID)
+            maxID = tmpTemplate->id + 1;
+        tmpTemplate = tmpTemplate->next;
+    }
+    newTemplate->id = maxID;
+    ((uint16_t*) newTemplate->templateRecord)[0] = htons(newTemplate->id);
 
-   if (verbose) {
-      fprintf(stderr, "VERBOSE: Creating new template id %u\n", newTemplate->id);
-   }
+    if (verbose) {
+        fprintf(stderr, "VERBOSE: Creating new template id %u\n", newTemplate->id);
+    }
 
-   /* Template header size */
-   newTemplate->templateSize = 4;
+    /* Template header size */
+    newTemplate->templateSize = 4;
 
-   while (1) {
-      while (tmp && *tmp) {
-         assert(newTemplate->templateSize + 8u < sizeof(newTemplate->templateRecord));
-         /* Find appropriate template file record */
-         template_file_record_t *tmpFileRecord = get_template_record_by_name(*tmp);
-         if (tmpFileRecord != nullptr) {
-            if (verbose) {
-               fprintf(stderr, "VERBOSE: Adding template field name=%s EN=%u ID=%u len=%d\n",
-                  tmpFileRecord->name, tmpFileRecord->enterpriseNumber, tmpFileRecord->elementID, tmpFileRecord->length);
-            }
+    while (1) {
+        while (tmp && *tmp) {
+            assert(newTemplate->templateSize + 8u < sizeof(newTemplate->templateRecord));
+            /* Find appropriate template file record */
+            template_file_record_t* tmpFileRecord = get_template_record_by_name(*tmp);
+            if (tmpFileRecord != nullptr) {
+                if (verbose) {
+                    fprintf(
+                        stderr,
+                        "VERBOSE: Adding template field name=%s EN=%u ID=%u len=%d\n",
+                        tmpFileRecord->name,
+                        tmpFileRecord->enterpriseNumber,
+                        tmpFileRecord->elementID,
+                        tmpFileRecord->length);
+                }
 
-            /* Set information element ID */
-            uint16_t eID = tmpFileRecord->elementID;
-            if (tmpFileRecord->enterpriseNumber != 0) {
-               eID |= 0x8000;
-            }
-            *((uint16_t *) &newTemplate->templateRecord[newTemplate->templateSize]) = htons(eID);
+                /* Set information element ID */
+                uint16_t eID = tmpFileRecord->elementID;
+                if (tmpFileRecord->enterpriseNumber != 0) {
+                    eID |= 0x8000;
+                }
+                *((uint16_t*) &newTemplate->templateRecord[newTemplate->templateSize]) = htons(eID);
 
-            /* Set element length */
-            if (tmpFileRecord->length == 0) {
-               fprintf(stderr, "Error: Template field cannot be zero length.\n");
-               free(newTemplate);
-               return nullptr;
+                /* Set element length */
+                if (tmpFileRecord->length == 0) {
+                    fprintf(stderr, "Error: Template field cannot be zero length.\n");
+                    free(newTemplate);
+                    return nullptr;
+                } else {
+                    len = tmpFileRecord->length;
+                }
+                *((uint16_t*) &newTemplate->templateRecord[newTemplate->templateSize + 2])
+                    = htons(len);
+
+                /* Update template size */
+                newTemplate->templateSize += 4;
+
+                /* Add enterprise number if required */
+                if (tmpFileRecord->enterpriseNumber != 0) {
+                    *((uint32_t*) &newTemplate->templateRecord[newTemplate->templateSize])
+                        = htonl(tmpFileRecord->enterpriseNumber);
+                    newTemplate->templateSize += 4;
+                }
+
+                /* Increase field count */
+                newTemplate->fieldCount++;
             } else {
-               len = tmpFileRecord->length;
-            }
-            *((uint16_t *) &newTemplate->templateRecord[newTemplate->templateSize + 2]) = htons(len);
-
-            /* Update template size */
-            newTemplate->templateSize += 4;
-
-            /* Add enterprise number if required */
-            if (tmpFileRecord->enterpriseNumber != 0) {
-               *((uint32_t *) &newTemplate->templateRecord[newTemplate->templateSize]) =
-                  htonl(tmpFileRecord->enterpriseNumber);
-               newTemplate->templateSize += 4;
+                fprintf(stderr, "Error: Cannot find field specification for name %s\n", *tmp);
+                free(newTemplate);
+                return nullptr;
             }
 
-            /* Increase field count */
-            newTemplate->fieldCount++;
-         } else {
-            fprintf(stderr, "Error: Cannot find field specification for name %s\n", *tmp);
-            free(newTemplate);
-            return nullptr;
-         }
+            tmp++;
+        }
 
-         tmp++;
-      }
+        if (ext == nullptr) {
+            break;
+        }
+        tmp = ext;
+        ext = nullptr;
+    }
 
-      if (ext == nullptr) {
-         break;
-      }
-      tmp = ext;
-      ext = nullptr;
-   }
+    /* Set field count */
+    ((uint16_t*) newTemplate->templateRecord)[1] = htons(newTemplate->fieldCount);
 
-   /* Set field count */
-   ((uint16_t *) newTemplate->templateRecord)[1] = htons(newTemplate->fieldCount);
+    /* Initialize buffer for records */
+    init_template_buffer(newTemplate);
 
-   /* Initialize buffer for records */
-   init_template_buffer(newTemplate);
+    /* Update total template size */
+    templatesDataSize += newTemplate->bufferSize;
 
-   /* Update total template size */
-   templatesDataSize += newTemplate->bufferSize;
+    /* The template was not exported yet */
+    newTemplate->exported = 0;
+    newTemplate->exportTime = time(nullptr);
+    newTemplate->exportPacket = exportedPackets;
 
-   /* The template was not exported yet */
-   newTemplate->exported = 0;
-   newTemplate->exportTime = time(nullptr);
-   newTemplate->exportPacket = exportedPackets;
+    /* Add the new template to the list */
+    newTemplate->next = templates;
+    templates = newTemplate;
 
-   /* Add the new template to the list */
-   newTemplate->next = templates;
-   templates = newTemplate;
-
-   return newTemplate;
+    return newTemplate;
 }
 
 /**
@@ -636,62 +661,61 @@ template_t *IPFIXExporter::create_template(const char **tmplt, const char **ext)
  * @param packet Pointer to packet to fill
  * @return IPFIX packet with templates to export or nullptr on failure
  */
-uint16_t IPFIXExporter::create_template_packet(ipfix_packet_t *packet)
+uint16_t IPFIXExporter::create_template_packet(ipfix_packet_t* packet)
 {
-   template_t *tmp = templates;
-   uint16_t totalSize = 0;
-   uint8_t *ptr;
+    template_t* tmp = templates;
+    uint16_t totalSize = 0;
+    uint8_t* ptr;
 
-   /* Get total size */
-   while (tmp != nullptr) {
-      /* Check UDP template lifetime */
-      if (protocol == IPPROTO_UDP) {
-         check_template_lifetime(tmp);
-      }
-      if (tmp->exported == 0) {
-         totalSize += tmp->templateSize;
-      }
-      tmp = tmp->next;
-   }
+    /* Get total size */
+    while (tmp != nullptr) {
+        /* Check UDP template lifetime */
+        if (protocol == IPPROTO_UDP) {
+            check_template_lifetime(tmp);
+        }
+        if (tmp->exported == 0) {
+            totalSize += tmp->templateSize;
+        }
+        tmp = tmp->next;
+    }
 
-   /* Check that there are templates to export */
-   if (totalSize == 0) {
-      return 0;
-   }
+    /* Check that there are templates to export */
+    if (totalSize == 0) {
+        return 0;
+    }
 
-   totalSize += IPFIX_HEADER_SIZE + IPFIX_SET_HEADER_SIZE;
+    totalSize += IPFIX_HEADER_SIZE + IPFIX_SET_HEADER_SIZE;
 
-   /* Allocate memory for the packet */
-   packet->data = (uint8_t *) malloc(sizeof(uint8_t)*(totalSize));
-   if (!packet->data) {
-      return 0;
-   }
-   ptr = packet->data;
+    /* Allocate memory for the packet */
+    packet->data = (uint8_t*) malloc(sizeof(uint8_t) * (totalSize));
+    if (!packet->data) {
+        return 0;
+    }
+    ptr = packet->data;
 
-   /* Create ipfix message header */
-   ptr += fill_ipfix_header(ptr, totalSize);
-   /* Create template set header */
-   ptr += fill_template_set_header(ptr, totalSize - IPFIX_HEADER_SIZE);
+    /* Create ipfix message header */
+    ptr += fill_ipfix_header(ptr, totalSize);
+    /* Create template set header */
+    ptr += fill_template_set_header(ptr, totalSize - IPFIX_HEADER_SIZE);
 
+    /* Copy the templates to the packet */
+    tmp = templates;
+    while (tmp != nullptr) {
+        if (tmp->exported == 0) {
+            memcpy(ptr, tmp->templateRecord, tmp->templateSize);
+            ptr += tmp->templateSize;
+            /* Set the templates as exported, store time and serial number */
+            tmp->exported = 1;
+            tmp->exportTime = time(nullptr);
+            tmp->exportPacket = exportedPackets;
+        }
+        tmp = tmp->next;
+    }
 
-   /* Copy the templates to the packet */
-   tmp = templates;
-   while (tmp != nullptr) {
-      if (tmp->exported == 0) {
-         memcpy(ptr, tmp->templateRecord, tmp->templateSize);
-         ptr += tmp->templateSize;
-         /* Set the templates as exported, store time and serial number */
-         tmp->exported = 1;
-         tmp->exportTime = time(nullptr);
-         tmp->exportPacket = exportedPackets;
-      }
-      tmp = tmp->next;
-   }
+    packet->length = totalSize;
+    packet->flows = 0;
 
-   packet->length = totalSize;
-   packet->flows = 0;
-
-   return totalSize;
+    return totalSize;
 }
 
 /**
@@ -702,55 +726,59 @@ uint16_t IPFIXExporter::create_template_packet(ipfix_packet_t *packet)
  * @param packet Pointer to packet to fill
  * @return length of the IPFIX data packet on success, 0 otherwise
  */
-uint16_t IPFIXExporter::create_data_packet(ipfix_packet_t *packet)
+uint16_t IPFIXExporter::create_data_packet(ipfix_packet_t* packet)
 {
-   template_t *tmp = templates;
-   uint16_t totalSize = IPFIX_HEADER_SIZE; /* Include IPFIX header to total size */
-   uint32_t deltaSequenceNum = 0; /* Number of exported records in this packet */
-   uint8_t *ptr;
+    template_t* tmp = templates;
+    uint16_t totalSize = IPFIX_HEADER_SIZE; /* Include IPFIX header to total size */
+    uint32_t deltaSequenceNum = 0; /* Number of exported records in this packet */
+    uint8_t* ptr;
 
-   /* Start adding data after the header */
-   ptr = packet->data + totalSize;
+    /* Start adding data after the header */
+    ptr = packet->data + totalSize;
 
-   /* Copy the data sets to the packet */
-   templatesDataSize = 0; /* Erase total data size */
-   while (tmp != nullptr) {
-      /* Add only templates with data that fits to one packet */
-      if (tmp->recordCount > 0 && totalSize + tmp->bufferSize <= mtu) {
-         memcpy(ptr, tmp->buffer, tmp->bufferSize);
-         /* Set SET length */
-         ((ipfix_template_set_header_t *) ptr)->length = htons(tmp->bufferSize);
-         if (verbose) {
-            fprintf(stderr, "VERBOSE: Adding template %i of length %i to data packet\n", tmp->id, tmp->bufferSize);
-         }
-         ptr += tmp->bufferSize;
-         /* Count size of the data copied to buffer */
-         totalSize += tmp->bufferSize;
-         /* Delete data from buffer */
-         tmp->bufferSize = IPFIX_SET_HEADER_SIZE;
+    /* Copy the data sets to the packet */
+    templatesDataSize = 0; /* Erase total data size */
+    while (tmp != nullptr) {
+        /* Add only templates with data that fits to one packet */
+        if (tmp->recordCount > 0 && totalSize + tmp->bufferSize <= mtu) {
+            memcpy(ptr, tmp->buffer, tmp->bufferSize);
+            /* Set SET length */
+            ((ipfix_template_set_header_t*) ptr)->length = htons(tmp->bufferSize);
+            if (verbose) {
+                fprintf(
+                    stderr,
+                    "VERBOSE: Adding template %i of length %i to data packet\n",
+                    tmp->id,
+                    tmp->bufferSize);
+            }
+            ptr += tmp->bufferSize;
+            /* Count size of the data copied to buffer */
+            totalSize += tmp->bufferSize;
+            /* Delete data from buffer */
+            tmp->bufferSize = IPFIX_SET_HEADER_SIZE;
 
-         /* Store number of exported records  */
-         deltaSequenceNum += tmp->recordCount;
-         tmp->recordCount = 0;
-      }
-      /* Update total data size, include empty template buffers (only set headers) */
-      templatesDataSize += tmp->bufferSize;
-      tmp = tmp->next;
-   }
+            /* Store number of exported records  */
+            deltaSequenceNum += tmp->recordCount;
+            tmp->recordCount = 0;
+        }
+        /* Update total data size, include empty template buffers (only set headers) */
+        templatesDataSize += tmp->bufferSize;
+        tmp = tmp->next;
+    }
 
-   /* Check that there are packets to export */
-   if (totalSize == IPFIX_HEADER_SIZE) {
-      return 0;
-   }
+    /* Check that there are packets to export */
+    if (totalSize == IPFIX_HEADER_SIZE) {
+        return 0;
+    }
 
-   /* Create ipfix message header at the beginning */
-   fill_ipfix_header(packet->data, totalSize);
+    /* Create ipfix message header at the beginning */
+    fill_ipfix_header(packet->data, totalSize);
 
-   /* Fill number of flows and size of the packet */
-   packet->flows = deltaSequenceNum;
-   packet->length = totalSize;
+    /* Fill number of flows and size of the packet */
+    packet->flows = deltaSequenceNum;
+    packet->length = totalSize;
 
-   return totalSize;
+    return totalSize;
 }
 
 /**
@@ -758,17 +786,17 @@ uint16_t IPFIXExporter::create_data_packet(ipfix_packet_t *packet)
  */
 void IPFIXExporter::send_templates()
 {
-   ipfix_packet_t pkt;
+    ipfix_packet_t pkt;
 
-   /* Send all new templates */
-   if (create_template_packet(&pkt)) {
-      /* Send template packet */
-      /* After error, the plugin sends all templates after reconnection,
-       * so we need not concern about it here */
-      send_packet(&pkt);
+    /* Send all new templates */
+    if (create_template_packet(&pkt)) {
+        /* Send template packet */
+        /* After error, the plugin sends all templates after reconnection,
+         * so we need not concern about it here */
+        send_packet(&pkt);
 
-      free(pkt.data);
-   }
+        free(pkt.data);
+    }
 }
 
 /**
@@ -776,20 +804,20 @@ void IPFIXExporter::send_templates()
  */
 void IPFIXExporter::send_data()
 {
-   ipfix_packet_t pkt;
-   pkt.data = packetDataBuffer;
+    ipfix_packet_t pkt;
+    pkt.data = packetDataBuffer;
 
-   /* Send all new templates */
-   while (create_data_packet(&pkt)) {
-      int ret = send_packet(&pkt);
-      if (ret == 1) {
-         /* Collector reconnected, resend the packet */
-         ret = send_packet(&pkt);
-      }
-      if (ret != 0) {
-         m_flows_dropped += pkt.flows;
-      }
-   }
+    /* Send all new templates */
+    while (create_data_packet(&pkt)) {
+        int ret = send_packet(&pkt);
+        if (ret == 1) {
+            /* Collector reconnected, resend the packet */
+            ret = send_packet(&pkt);
+        }
+        if (ret != 0) {
+            m_flows_dropped += pkt.flows;
+        }
+    }
 }
 
 /**
@@ -797,11 +825,11 @@ void IPFIXExporter::send_data()
  */
 void IPFIXExporter::flush()
 {
-   /* Send all new templates */
-   send_templates();
+    /* Send all new templates */
+    send_templates();
 
-   /* Send the data packet */
-   send_data();
+    /* Send the data packet */
+    send_data();
 }
 
 /**
@@ -812,82 +840,95 @@ void IPFIXExporter::flush()
  * \param packet Packet to send
  * \return 0 on success, -1 on socket error, 1 when data needs to be resent (after reconnect)
  */
-int IPFIXExporter::send_packet(ipfix_packet_t *packet)
+int IPFIXExporter::send_packet(ipfix_packet_t* packet)
 {
-   int ret; /* Return value of sendto */
-   int sent = 0; /* Sent data size */
+    int ret; /* Return value of sendto */
+    int sent = 0; /* Sent data size */
 
-   /* Check that connection is OK or drop packet */
-   if (reconnect()) {
-      return -1;
-   }
+    /* Check that connection is OK or drop packet */
+    if (reconnect()) {
+        return -1;
+    }
 
-   /* sendto() does not guarantee that everything will be send in one piece */
-   while (sent < packet->length) {
-      /* Send data to collector (TCP and SCTP ignores last two arguments) */
-      ret = sendto(fd, (void *) (packet->data + sent), packet->length - sent, 0,
-            addrinfo->ai_addr, addrinfo->ai_addrlen);
+    /* sendto() does not guarantee that everything will be send in one piece */
+    while (sent < packet->length) {
+        /* Send data to collector (TCP and SCTP ignores last two arguments) */
+        ret = sendto(
+            fd,
+            (void*) (packet->data + sent),
+            packet->length - sent,
+            0,
+            addrinfo->ai_addr,
+            addrinfo->ai_addrlen);
 
-      /* Check that the data were sent correctly */
-      if (ret == -1) {
-         switch (errno) {
-         case 0: break; /* OK */
-         case ECONNRESET:
-         case EINTR:
-         case ENOTCONN:
-         case ENOTSOCK:
-         case EPIPE:
-         case EHOSTUNREACH:
-         case ENETDOWN:
-         case ENETUNREACH:
-         case ENOBUFS:
-         case ENOMEM:
+        /* Check that the data were sent correctly */
+        if (ret == -1) {
+            switch (errno) {
+            case 0:
+                break; /* OK */
+            case ECONNRESET:
+            case EINTR:
+            case ENOTCONN:
+            case ENOTSOCK:
+            case EPIPE:
+            case EHOSTUNREACH:
+            case ENETDOWN:
+            case ENETUNREACH:
+            case ENOBUFS:
+            case ENOMEM:
 
-            /* The connection is broken */
-            if (verbose) {
-               fprintf(stderr, "VERBOSE: Collector closed connection\n");
+                /* The connection is broken */
+                if (verbose) {
+                    fprintf(stderr, "VERBOSE: Collector closed connection\n");
+                }
+
+                /* free resources */
+                ::close(fd);
+                fd = -1;
+                freeaddrinfo(addrinfo);
+                addrinfo = nullptr;
+
+                /* Set last connection try time so that we would reconnect immediatelly */
+                lastReconnect = 1;
+
+                /* Reset the sequences number since it is unique per connection */
+                sequenceNum = 0;
+                ((ipfix_header_t*) packet->data)->sequenceNumber
+                    = 0; /* no need to change byteorder of 0 */
+
+                /* Say that we should try to connect and send data again */
+                return 1;
+            default:
+                /* Unknown error */
+                if (verbose) {
+                    perror("VERBOSE: Cannot send data to collector");
+                }
+                return -1;
             }
+        }
 
-            /* free resources */
-            ::close(fd);
-            fd = -1;
-            freeaddrinfo(addrinfo);
-            addrinfo = nullptr;
+        /* No error from sendto(), add sent data count to total */
+        sent += ret;
+    }
 
-            /* Set last connection try time so that we would reconnect immediatelly */
-            lastReconnect = 1;
+    /* Update sequence number for next packet */
+    sequenceNum += packet->flows;
 
-            /* Reset the sequences number since it is unique per connection */
-            sequenceNum = 0;
-            ((ipfix_header_t *) packet->data)->sequenceNumber = 0; /* no need to change byteorder of 0 */
+    /* Increase packet counter */
+    exportedPackets++;
 
-            /* Say that we should try to connect and send data again */
-            return 1;
-         default:
-            /* Unknown error */
-            if (verbose) {
-               perror("VERBOSE: Cannot send data to collector");
-            }
-            return -1;
-         }
-      }
+    if (verbose) {
+        fprintf(
+            stderr,
+            "VERBOSE: Packet (%" PRIu64 ") sent to %s on port %" PRIu16
+            ". Next sequence number is %i\n",
+            exportedPackets,
+            host.c_str(),
+            port,
+            sequenceNum);
+    }
 
-      /* No error from sendto(), add sent data count to total */
-      sent += ret;
-   }
-
-   /* Update sequence number for next packet */
-   sequenceNum += packet->flows;
-
-   /* Increase packet counter */
-   exportedPackets++;
-
-   if (verbose) {
-      fprintf(stderr, "VERBOSE: Packet (%" PRIu64 ") sent to %s on port %" PRIu16 ". Next sequence number is %i\n",
-            exportedPackets, host.c_str(), port, sequenceNum);
-   }
-
-   return 0;
+    return 0;
 }
 
 /**
@@ -900,87 +941,91 @@ int IPFIXExporter::send_packet(ipfix_packet_t *packet)
  */
 int IPFIXExporter::connect_to_collector()
 {
-   struct addrinfo hints, *tmp;
-   int err;
+    struct addrinfo hints, *tmp;
+    int err;
 
-   memset(&hints, 0, sizeof(hints));
-   hints.ai_family = ip;
-   hints.ai_socktype = protocol == IPPROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
-   hints.ai_protocol = protocol;
-   hints.ai_flags = AI_ADDRCONFIG | flags;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = ip;
+    hints.ai_socktype = protocol == IPPROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
+    hints.ai_protocol = protocol;
+    hints.ai_flags = AI_ADDRCONFIG | flags;
 
-   err = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &addrinfo);
-   if (err) {
-      const char *err_msg = nullptr;
-      if (err == EAI_SYSTEM) {
-         err_msg = strerror(errno);
-      } else {
-         err_msg = gai_strerror(err);
-      }
-      if (verbose) {
-         fprintf(stderr, "Cannot get server info: %s\n", err_msg);
-      }
-      return 1;
-   }
+    err = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &addrinfo);
+    if (err) {
+        const char* err_msg = nullptr;
+        if (err == EAI_SYSTEM) {
+            err_msg = strerror(errno);
+        } else {
+            err_msg = gai_strerror(err);
+        }
+        if (verbose) {
+            fprintf(stderr, "Cannot get server info: %s\n", err_msg);
+        }
+        return 1;
+    }
 
-   /* Try addrinfo strucutres one by one */
-   for (tmp = addrinfo; tmp != nullptr; tmp = tmp->ai_next) {
-      if (tmp->ai_family != AF_INET && tmp->ai_family != AF_INET6) {
-         continue;
-      }
+    /* Try addrinfo strucutres one by one */
+    for (tmp = addrinfo; tmp != nullptr; tmp = tmp->ai_next) {
+        if (tmp->ai_family != AF_INET && tmp->ai_family != AF_INET6) {
+            continue;
+        }
 
-      /* Print information about target address */
-      char buff[INET6_ADDRSTRLEN];
-      inet_ntop(tmp->ai_family,
-            (tmp->ai_family == AF_INET) ?
-                  (void *) &((struct sockaddr_in *) tmp->ai_addr)->sin_addr :
-                  (void *) &((struct sockaddr_in6 *) tmp->ai_addr)->sin6_addr,
-            (char *) &buff, sizeof(buff));
+        /* Print information about target address */
+        char buff[INET6_ADDRSTRLEN];
+        inet_ntop(
+            tmp->ai_family,
+            (tmp->ai_family == AF_INET) ? (void*) &((struct sockaddr_in*) tmp->ai_addr)->sin_addr
+                                        : (void*) &((struct sockaddr_in6*) tmp->ai_addr)->sin6_addr,
+            (char*) &buff,
+            sizeof(buff));
 
-      if (verbose) {
-         fprintf(stderr, "VERBOSE: Connecting to IP %s\n", buff);
-         fprintf(stderr, "VERBOSE: Socket configuration: AI Family: %i, AI Socktype: %i, AI Protocol: %i\n",
-               tmp->ai_family, tmp->ai_socktype, tmp->ai_protocol);
-      }
+        if (verbose) {
+            fprintf(stderr, "VERBOSE: Connecting to IP %s\n", buff);
+            fprintf(
+                stderr,
+                "VERBOSE: Socket configuration: AI Family: %i, AI Socktype: %i, AI Protocol: %i\n",
+                tmp->ai_family,
+                tmp->ai_socktype,
+                tmp->ai_protocol);
+        }
 
-      /* create socket */
-      fd = socket(tmp->ai_family, tmp->ai_socktype, tmp->ai_protocol);
-      if (fd == -1) {
-         if (verbose) {
-            perror("VERBOSE: Cannot create new socket");
-         }
-         continue;
-      }
+        /* create socket */
+        fd = socket(tmp->ai_family, tmp->ai_socktype, tmp->ai_protocol);
+        if (fd == -1) {
+            if (verbose) {
+                perror("VERBOSE: Cannot create new socket");
+            }
+            continue;
+        }
 
-      /* connect to server with TCP and SCTP */
-      if (protocol != IPPROTO_UDP &&
-            connect(fd, tmp->ai_addr, tmp->ai_addrlen) == -1) {
-         if (verbose) {
-            perror("VERBOSE: Cannot connect to collector");
-         }
-         ::close(fd);
-         fd = -1;
-         continue;
-      }
+        /* connect to server with TCP and SCTP */
+        if (protocol != IPPROTO_UDP && connect(fd, tmp->ai_addr, tmp->ai_addrlen) == -1) {
+            if (verbose) {
+                perror("VERBOSE: Cannot connect to collector");
+            }
+            ::close(fd);
+            fd = -1;
+            continue;
+        }
 
-      /* Connected, meaningless for UDP */
-      if (protocol != IPPROTO_UDP) {
-         if (verbose) {
-            fprintf(stderr, "VERBOSE: Successfully connected to collector\n");
-         }
-      }
-      break;
-   }
+        /* Connected, meaningless for UDP */
+        if (protocol != IPPROTO_UDP) {
+            if (verbose) {
+                fprintf(stderr, "VERBOSE: Successfully connected to collector\n");
+            }
+        }
+        break;
+    }
 
-   /* Return error when all addrinfo structures were tried*/
-   if (tmp == nullptr) {
-      /* Free allocated resources */
-      freeaddrinfo(addrinfo);
-      addrinfo = nullptr;
-      return 2;
-   }
+    /* Return error when all addrinfo structures were tried*/
+    if (tmp == nullptr) {
+        /* Free allocated resources */
+        freeaddrinfo(addrinfo);
+        addrinfo = nullptr;
+        return 2;
+    }
 
-   return 0;
+    return 0;
 }
 
 /**
@@ -990,42 +1035,43 @@ int IPFIXExporter::connect_to_collector()
  */
 int IPFIXExporter::reconnect()
 {
-   /* Check for broken connection */
-   if (lastReconnect != 0) {
-      /* Check whether we need to attempt reconnection */
-      if ((time_t) (lastReconnect + reconnectTimeout) <= time(nullptr)) {
-         /* Try to reconnect */
-         if (connect_to_collector() == 0) {
-            lastReconnect = 0;
-            /* Resend all templates */
-            expire_templates();
-            send_templates();
-         } else {
-            /* Set new reconnect time and drop packet */
-            lastReconnect = time(nullptr);
+    /* Check for broken connection */
+    if (lastReconnect != 0) {
+        /* Check whether we need to attempt reconnection */
+        if ((time_t) (lastReconnect + reconnectTimeout) <= time(nullptr)) {
+            /* Try to reconnect */
+            if (connect_to_collector() == 0) {
+                lastReconnect = 0;
+                /* Resend all templates */
+                expire_templates();
+                send_templates();
+            } else {
+                /* Set new reconnect time and drop packet */
+                lastReconnect = time(nullptr);
+                return 1;
+            }
+        } else {
+            /* Timeout not reached, drop packet */
             return 1;
-         }
-      } else {
-         /* Timeout not reached, drop packet */
-         return 1;
-      }
-   }
+        }
+    }
 
-   return 0;
+    return 0;
 }
 
 #define GEN_FIELDS_SUMLEN_INT(FIELD) FIELD_LEN(FIELD) +
 #define GEN_FILLFIELDS_INT(TMPLT) IPFIX_FILL_FIELD(p, TMPLT);
 #define GEN_FILLFIELDS_MAXLEN(TMPLT) IPFIX_FILL_FIELD(p, TMPLT);
 
+#define GENERATE_FILL_FIELDS_V4()                                                                  \
+    do {                                                                                           \
+        BASIC_TMPLT_V4(GEN_FILLFIELDS_INT)                                                         \
+    } while (0)
 
-#define GENERATE_FILL_FIELDS_V4() do { \
-BASIC_TMPLT_V4(GEN_FILLFIELDS_INT) \
-} while (0)
-
-#define GENERATE_FILL_FIELDS_V6() do { \
-BASIC_TMPLT_V6(GEN_FILLFIELDS_INT) \
-} while (0)
+#define GENERATE_FILL_FIELDS_V6()                                                                  \
+    do {                                                                                           \
+        BASIC_TMPLT_V6(GEN_FILLFIELDS_INT)                                                         \
+    } while (0)
 
 #define GENERATE_FIELDS_SUMLEN(TMPL) TMPL(GEN_FIELDS_SUMLEN_INT) 0
 
@@ -1035,54 +1081,54 @@ BASIC_TMPLT_V6(GEN_FILLFIELDS_INT) \
  * @param tmplt Template containing buffer
  * @return Number of written bytes or -1 if buffer is not big enough
  */
-int IPFIXExporter::fill_basic_flow(const Flow &flow, template_t *tmplt)
+int IPFIXExporter::fill_basic_flow(const Flow& flow, template_t* tmplt)
 {
-   uint8_t *buffer, *p;
-   int length;
-   uint64_t temp;
+    uint8_t *buffer, *p;
+    int length;
+    uint64_t temp;
 
-   buffer = tmplt->buffer + tmplt->bufferSize;
-   p = buffer;
-   if (flow.ip_version == IP::v4) {
-      if (tmplt->bufferSize + GENERATE_FIELDS_SUMLEN(BASIC_TMPLT_V4) > tmpltMaxBufferSize) {
-         return -1;
-      }
+    buffer = tmplt->buffer + tmplt->bufferSize;
+    p = buffer;
+    if (flow.ip_version == IP::v4) {
+        if (tmplt->bufferSize + GENERATE_FIELDS_SUMLEN(BASIC_TMPLT_V4) > tmpltMaxBufferSize) {
+            return -1;
+        }
 
-      /* Temporary disable warnings about breaking string-aliasing, since it is produced by
-       * if-branches that are never going to be used - generated by C-preprocessor.
-       */
+        /* Temporary disable warnings about breaking string-aliasing, since it is produced by
+         * if-branches that are never going to be used - generated by C-preprocessor.
+         */
 #if GCC_CHECK_PRAGMA
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
-		/* Generate code for copying values of IPv4 template into IPFIX message. */
-      GENERATE_FILL_FIELDS_V4();
+        /* Generate code for copying values of IPv4 template into IPFIX message. */
+        GENERATE_FILL_FIELDS_V4();
 #if GCC_CHECK_PRAGMA
-# pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
-   } else {
-      if (tmplt->bufferSize + GENERATE_FIELDS_SUMLEN(BASIC_TMPLT_V6) > tmpltMaxBufferSize) {
-         return -1;
-      }
+    } else {
+        if (tmplt->bufferSize + GENERATE_FIELDS_SUMLEN(BASIC_TMPLT_V6) > tmpltMaxBufferSize) {
+            return -1;
+        }
 
-      /* Temporary disable warnings about breaking string-aliasing, since it is produced by
-       * if-branches that are never going to be used - generated by C-preprocessor.
-       */
+        /* Temporary disable warnings about breaking string-aliasing, since it is produced by
+         * if-branches that are never going to be used - generated by C-preprocessor.
+         */
 #if GCC_CHECK_PRAGMA
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
-		/* Generate code for copying values of IPv6 template into IPFIX message. */
-      GENERATE_FILL_FIELDS_V6();
+        /* Generate code for copying values of IPv6 template into IPFIX message. */
+        GENERATE_FILL_FIELDS_V6();
 #if GCC_CHECK_PRAGMA
-# pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
-   }
+    }
 
-   length = p - buffer;
+    length = p - buffer;
 
-   return length;
+    return length;
 }
 
-}
+} // namespace ipxp

--- a/output/ipfix.hpp
+++ b/output/ipfix.hpp
@@ -33,22 +33,22 @@
  * in contract, strict liability, or tort (including negligence or
  * otherwise) arising in any way out of the use of this software, even
  * if advised of the possibility of such damage.
-*/
+ */
 
 #ifndef IPXP_OUTPUT_IPFIX_H
 #define IPXP_OUTPUT_IPFIX_H
 
-#include <vector>
 #include <map>
+#include <vector>
 
-#include <ipfixprobe/output.hpp>
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/options.hpp>
-#include <ipfixprobe/utils.hpp>
 #include <ipfixprobe/flowifc.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/output.hpp>
+#include <ipfixprobe/process.hpp>
+#include <ipfixprobe/utils.hpp>
 
-#define COUNT_IPFIX_TEMPLATES(T) + 1
+#define COUNT_IPFIX_TEMPLATES(T) +1
 
 #define TEMPLATE_SET_ID 2
 #define FIRST_TEMPLATE_ID 258
@@ -59,81 +59,169 @@
 #define IPFIX_SET_HEADER_SIZE 4
 #define TEMPLATE_BUFFER_SIZE (PACKET_DATA_SIZE - IPFIX_HEADER_SIZE)
 #define TEMPLATE_FIELD_COUNT (0 IPFIX_ENABLED_TEMPLATES(COUNT_IPFIX_TEMPLATES))
-#define TEMPLATE_RECORD_SIZE ((TEMPLATE_FIELD_COUNT) * 8) // 2B eNum, 2B eID, 4B length
+#define TEMPLATE_RECORD_SIZE ((TEMPLATE_FIELD_COUNT) *8) // 2B eNum, 2B eID, 4B length
 #define RECONNECT_TIMEOUT 60
 #define TEMPLATE_REFRESH_TIME 600
 #define TEMPLATE_REFRESH_PACKETS 0
 
 namespace ipxp {
 
-class IpfixOptParser : public OptionsParser
-{
+class IpfixOptParser : public OptionsParser {
 public:
-   std::string m_host;
-   uint16_t m_port;
-   uint16_t m_mtu;
-   bool m_udp;
-   uint64_t m_id;
-   uint32_t m_dir;
-   uint32_t m_template_refresh_time;
-   bool m_verbose;
+    std::string m_host;
+    uint16_t m_port;
+    uint16_t m_mtu;
+    bool m_udp;
+    uint64_t m_id;
+    uint32_t m_dir;
+    uint32_t m_template_refresh_time;
+    bool m_verbose;
 
-   IpfixOptParser() : OptionsParser("ipfix", "Output plugin for ipfix export"),
-      m_host("127.0.0.1"), m_port(4739), m_mtu(DEFAULT_MTU), m_udp(false), m_id(DEFAULT_EXPORTER_ID), m_dir(0), 
-      m_template_refresh_time(TEMPLATE_REFRESH_TIME), m_verbose(false)
-   {
-      register_option("h", "host", "ADDR", "Remote collector address", [this](const char *arg){m_host = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("p", "port", "PORT", "Remote collector port",
-         [this](const char *arg){try {m_port = str2num<decltype(m_port)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("m", "mtu", "SIZE", "Maximum size of ipfix packet payload sent",
-         [this](const char *arg){try {m_mtu = str2num<decltype(m_mtu)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("u", "udp", "", "Use UDP protocol", [this](const char *arg){m_udp = true; return true;}, OptionFlags::NoArgument);
-      register_option("I", "id", "NUM", "Exporter identification",
-         [this](const char *arg){try {m_id = str2num<decltype(m_id)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("d", "dir", "NUM", "Dir bit field value",
-         [this](const char *arg){try {m_dir = str2num<decltype(m_dir)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("t", "template", "NUM", "Template refresh rate (sec)",
-         [this](const char *arg){try {m_template_refresh_time = str2num<decltype(m_template_refresh_time)>(arg);} 
-         catch(std::invalid_argument &e) {return false;} return true;}, OptionFlags::RequiredArgument);
-      register_option("v", "verbose", "", "Enable verbose mode", [this](const char *arg){m_verbose = true; return true;}, OptionFlags::NoArgument);
-   }
+    IpfixOptParser()
+        : OptionsParser("ipfix", "Output plugin for ipfix export")
+        , m_host("127.0.0.1")
+        , m_port(4739)
+        , m_mtu(DEFAULT_MTU)
+        , m_udp(false)
+        , m_id(DEFAULT_EXPORTER_ID)
+        , m_dir(0)
+        , m_template_refresh_time(TEMPLATE_REFRESH_TIME)
+        , m_verbose(false)
+    {
+        register_option(
+            "h",
+            "host",
+            "ADDR",
+            "Remote collector address",
+            [this](const char* arg) {
+                m_host = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "p",
+            "port",
+            "PORT",
+            "Remote collector port",
+            [this](const char* arg) {
+                try {
+                    m_port = str2num<decltype(m_port)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "m",
+            "mtu",
+            "SIZE",
+            "Maximum size of ipfix packet payload sent",
+            [this](const char* arg) {
+                try {
+                    m_mtu = str2num<decltype(m_mtu)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "u",
+            "udp",
+            "",
+            "Use UDP protocol",
+            [this](const char* arg) {
+                m_udp = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "I",
+            "id",
+            "NUM",
+            "Exporter identification",
+            [this](const char* arg) {
+                try {
+                    m_id = str2num<decltype(m_id)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "d",
+            "dir",
+            "NUM",
+            "Dir bit field value",
+            [this](const char* arg) {
+                try {
+                    m_dir = str2num<decltype(m_dir)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "t",
+            "template",
+            "NUM",
+            "Template refresh rate (sec)",
+            [this](const char* arg) {
+                try {
+                    m_template_refresh_time = str2num<decltype(m_template_refresh_time)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "v",
+            "verbose",
+            "",
+            "Enable verbose mode",
+            [this](const char* arg) {
+                m_verbose = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
 typedef struct {
-	char *name; /**< Record name */
-	uint16_t enterpriseNumber; /**< Enterprise Number */
-	uint16_t elementID; /**< Information Element ID */
-	int32_t length; /**< Element export length. -1 for variable*/
+    char* name; /**< Record name */
+    uint16_t enterpriseNumber; /**< Enterprise Number */
+    uint16_t elementID; /**< Information Element ID */
+    int32_t length; /**< Element export length. -1 for variable*/
 } template_file_record_t;
 
 /**
  * \brief Structure to hold template record
  */
 typedef struct template_t {
-	uint16_t id; /**< Template ID */
-	uint8_t templateRecord[TEMPLATE_RECORD_SIZE]; /**< Buffer for template record */
-	uint16_t templateSize; /**< Size of template record buffer */
-	uint8_t *buffer; /**< Buffer with data for template */
-	uint16_t bufferSize; /**< Size of data buffer */
-	uint16_t recordCount; /**< Number of records in buffer */
-	uint16_t fieldCount; /**< Number of elements in template */
-	uint8_t exported; /**< 1 indicates that the template was exported to collector*/
-	time_t exportTime; /**< Time when the template was last exported */
-	uint64_t exportPacket; /**< Number of packet when the template was last exported */
-	struct template_t *next;
+    uint16_t id; /**< Template ID */
+    uint8_t templateRecord[TEMPLATE_RECORD_SIZE]; /**< Buffer for template record */
+    uint16_t templateSize; /**< Size of template record buffer */
+    uint8_t* buffer; /**< Buffer with data for template */
+    uint16_t bufferSize; /**< Size of data buffer */
+    uint16_t recordCount; /**< Number of records in buffer */
+    uint16_t fieldCount; /**< Number of elements in template */
+    uint8_t exported; /**< 1 indicates that the template was exported to collector*/
+    time_t exportTime; /**< Time when the template was last exported */
+    uint64_t exportPacket; /**< Number of packet when the template was last exported */
+    struct template_t* next;
 } template_t;
 
 /**
  * \brief Structure of ipfix packet used by send functions
  */
 typedef struct {
-	uint8_t *data; /**< Buffer for data */
-	uint16_t length; /**< Length of data */
-	uint16_t flows; /**< Number of flow records in the packet */
+    uint8_t* data; /**< Buffer for data */
+    uint16_t length; /**< Length of data */
+    uint16_t flows; /**< Number of flow records in the packet */
 } ipfix_packet_t;
 
 /**
@@ -153,50 +241,50 @@ typedef struct {
  *
  */
 typedef struct ipfix_header {
-	/**
-	 * Version of Flow Record format exported in this message. The value of this
-	 * field is 0x000a for the current version, incrementing by one the version
-	 * used in the NetFlow services export version 9.
-	 */
-	uint16_t version;
+    /**
+     * Version of Flow Record format exported in this message. The value of this
+     * field is 0x000a for the current version, incrementing by one the version
+     * used in the NetFlow services export version 9.
+     */
+    uint16_t version;
 
-	/**
-	 * Total length of the IPFIX Message, measured in octets, including Message
-	 * Header and Set(s).
-	 */
-	uint16_t length;
+    /**
+     * Total length of the IPFIX Message, measured in octets, including Message
+     * Header and Set(s).
+     */
+    uint16_t length;
 
-	/**
-	 * Time, in seconds, since 0000 UTC Jan 1, 1970, at which the IPFIX Message
-	 * Header leaves the Exporter.
-	 */
-	uint32_t exportTime;
+    /**
+     * Time, in seconds, since 0000 UTC Jan 1, 1970, at which the IPFIX Message
+     * Header leaves the Exporter.
+     */
+    uint32_t exportTime;
 
-	/**
-	 * Incremental sequence counter modulo 2^32 of all IPFIX Data Records sent
-	 * on this PR-SCTP stream from the current Observation Domain by the
-	 * Exporting Process. Check the specific meaning of this field in the
-	 * subsections of Section 10 when UDP or TCP is selected as the transport
-	 * protocol. This value SHOULD be used by the Collecting Process to
-	 * identify whether any IPFIX Data Records have been missed. Template and
-	 * Options Template Records do not increase the Sequence Number.
-	 */
-	uint32_t sequenceNumber;
+    /**
+     * Incremental sequence counter modulo 2^32 of all IPFIX Data Records sent
+     * on this PR-SCTP stream from the current Observation Domain by the
+     * Exporting Process. Check the specific meaning of this field in the
+     * subsections of Section 10 when UDP or TCP is selected as the transport
+     * protocol. This value SHOULD be used by the Collecting Process to
+     * identify whether any IPFIX Data Records have been missed. Template and
+     * Options Template Records do not increase the Sequence Number.
+     */
+    uint32_t sequenceNumber;
 
-	/**
-	 * A 32-bit identifier of the Observation Domain that is locally unique to
-	 * the Exporting Process. The Exporting Process uses the Observation Domain
-	 * ID to uniquely identify to the Collecting Process the Observation Domain
-	 * that metered the Flows. It is RECOMMENDED that this identifier also be
-	 * unique per IPFIX Device. Collecting Processes SHOULD use the Transport
-	 * Session and the Observation Domain ID field to separate different export
-	 * streams originating from the same Exporting Process. The Observation
-	 * Domain ID SHOULD be 0 when no specific Observation Domain ID is relevant
-	 * for the entire IPFIX Message, for example, when exporting the Exporting
-	 * Process Statistics, or in case of a hierarchy of Collectors when
-	 * aggregated Data Records are exported.
-	 */
-	uint32_t observationDomainId;
+    /**
+     * A 32-bit identifier of the Observation Domain that is locally unique to
+     * the Exporting Process. The Exporting Process uses the Observation Domain
+     * ID to uniquely identify to the Collecting Process the Observation Domain
+     * that metered the Flows. It is RECOMMENDED that this identifier also be
+     * unique per IPFIX Device. Collecting Processes SHOULD use the Transport
+     * Session and the Observation Domain ID field to separate different export
+     * streams originating from the same Exporting Process. The Observation
+     * Domain ID SHOULD be 0 when no specific Observation Domain ID is relevant
+     * for the entire IPFIX Message, for example, when exporting the Exporting
+     * Process Statistics, or in case of a hierarchy of Collectors when
+     * aggregated Data Records are exported.
+     */
+    uint32_t observationDomainId;
 } ipfix_header_t;
 
 /**
@@ -210,98 +298,93 @@ typedef struct ipfix_header {
  *
  */
 typedef struct ipfix_template_set_header {
-	/**
-	 * Set ID value identifies the Set.  A value of 2 is reserved for the
-	 * Template Set. A value of 3 is reserved for the Option Template Set. All
-	 * other values from 4 to 255 are reserved for future use. Values above 255
-	 * are used for Data Sets. The Set ID values of 0 and 1 are not used for
-	 * historical reasons [<a href="http://tools.ietf.org/html/rfc3954">RFC3954</a>].
-	 */
-	uint16_t id;
+    /**
+     * Set ID value identifies the Set.  A value of 2 is reserved for the
+     * Template Set. A value of 3 is reserved for the Option Template Set. All
+     * other values from 4 to 255 are reserved for future use. Values above 255
+     * are used for Data Sets. The Set ID values of 0 and 1 are not used for
+     * historical reasons [<a href="http://tools.ietf.org/html/rfc3954">RFC3954</a>].
+     */
+    uint16_t id;
 
-	/**
-	 * Total length of the Set, in octets, including the Set Header, all
-	 * records, and the optional padding.  Because an individual Set MAY contain
-	 * multiple records, the Length value MUST be used to determine the position
-	 * of the next Set.
-	 */
-	uint16_t length;
+    /**
+     * Total length of the Set, in octets, including the Set Header, all
+     * records, and the optional padding.  Because an individual Set MAY contain
+     * multiple records, the Length value MUST be used to determine the position
+     * of the next Set.
+     */
+    uint16_t length;
 
 } ipfix_template_set_header_t;
 
-class IPFIXExporter : public OutputPlugin
-{
+class IPFIXExporter : public OutputPlugin {
 public:
-   IPFIXExporter();
-   ~IPFIXExporter();
-   void init(const char *params);
-   void init(const char *params, Plugins &plugins);
-   void close();
-   OptionsParser *get_parser() const { return new IpfixOptParser(); }
-   std::string get_name() const { return "ipfix"; }
-   int export_flow(const Flow &flow);
+    IPFIXExporter();
+    ~IPFIXExporter();
+    void init(const char* params);
+    void init(const char* params, Plugins& plugins);
+    void close();
+    OptionsParser* get_parser() const { return new IpfixOptParser(); }
+    std::string get_name() const { return "ipfix"; }
+    int export_flow(const Flow& flow);
 
 private:
-   /* Templates */
-   enum TmpltMapIdx {
-      TMPLT_IDX_V4 = 0,
-      TMPLT_IDX_V6 = 1,
-      TMPLT_MAP_IDX_CNT
-   };
-   RecordExt **extensions;
-   int extension_cnt;
-   std::map<uint64_t, template_t *> tmpltMap[TMPLT_MAP_IDX_CNT];
-   template_t *templates; /**< Templates in use by plugin */
-	uint16_t templatesDataSize; /**< Total data size stored in templates */
-   int basic_ifc_num;
-   bool verbose;
+    /* Templates */
+    enum TmpltMapIdx { TMPLT_IDX_V4 = 0, TMPLT_IDX_V6 = 1, TMPLT_MAP_IDX_CNT };
+    RecordExt** extensions;
+    int extension_cnt;
+    std::map<uint64_t, template_t*> tmpltMap[TMPLT_MAP_IDX_CNT];
+    template_t* templates; /**< Templates in use by plugin */
+    uint16_t templatesDataSize; /**< Total data size stored in templates */
+    int basic_ifc_num;
+    bool verbose;
 
-   uint32_t sequenceNum; /**< Number of exported flows */
-   uint64_t exportedPackets; /**< Number of exported packets */
-   int fd; /**< Socket used to send data */
-   struct addrinfo *addrinfo; /**< Info about the connection used by sendto */
+    uint32_t sequenceNum; /**< Number of exported flows */
+    uint64_t exportedPackets; /**< Number of exported packets */
+    int fd; /**< Socket used to send data */
+    struct addrinfo* addrinfo; /**< Info about the connection used by sendto */
 
-	/* Parameters */
-   std::string host; /**< Collector address */
-   uint16_t port; /**< Collector port */
-   int protocol; /**< Collector connection protocol */
-   int ip; /**< IP protocol version (AF_INET, ...) */
-   int flags; /**< getaddrinfo flags */
+    /* Parameters */
+    std::string host; /**< Collector address */
+    uint16_t port; /**< Collector port */
+    int protocol; /**< Collector connection protocol */
+    int ip; /**< IP protocol version (AF_INET, ...) */
+    int flags; /**< getaddrinfo flags */
 
-   uint32_t reconnectTimeout; /**< Timeout between connection retries */
-   time_t lastReconnect; /**< Time in seconds of last connection retry */
-   uint32_t odid; /**< Observation Domain ID */
-   uint32_t templateRefreshTime; /**< UDP template refresh time interval */
-   uint32_t templateRefreshPackets; /**< UDP template refresh packet interval */
-   uint32_t dir_bit_field;     /**< Direction bit field value. */
+    uint32_t reconnectTimeout; /**< Timeout between connection retries */
+    time_t lastReconnect; /**< Time in seconds of last connection retry */
+    uint32_t odid; /**< Observation Domain ID */
+    uint32_t templateRefreshTime; /**< UDP template refresh time interval */
+    uint32_t templateRefreshPackets; /**< UDP template refresh packet interval */
+    uint32_t dir_bit_field; /**< Direction bit field value. */
 
-   uint16_t mtu; /**< Max size of packet payload sent */
-   uint8_t *packetDataBuffer; /**< Data buffer to store packet */
-   uint16_t tmpltMaxBufferSize; /**< Size of template buffer, tmpltBufferSize < packetDataBuffer */
+    uint16_t mtu; /**< Max size of packet payload sent */
+    uint8_t* packetDataBuffer; /**< Data buffer to store packet */
+    uint16_t tmpltMaxBufferSize; /**< Size of template buffer, tmpltBufferSize < packetDataBuffer */
 
-   void init_template_buffer(template_t *tmpl);
-   int fill_template_set_header(uint8_t *ptr, uint16_t size);
-   void check_template_lifetime(template_t *tmpl);
-   int fill_ipfix_header(uint8_t *ptr, uint16_t size);
-   template_file_record_t *get_template_record_by_name(const char *name);
-   void expire_templates();
-   template_t *create_template(const char **tmplt, const char **ext);
-   uint16_t create_template_packet(ipfix_packet_t *packet);
-   uint16_t create_data_packet(ipfix_packet_t *packet);
-   void send_templates();
-   void send_data();
-   int send_packet(ipfix_packet_t *packet);
-   int connect_to_collector();
-   int reconnect();
-   int fill_basic_flow(const Flow &flow, template_t *tmplt);
-   int fill_extensions(RecordExt *ext, uint8_t *buffer, int size);
+    void init_template_buffer(template_t* tmpl);
+    int fill_template_set_header(uint8_t* ptr, uint16_t size);
+    void check_template_lifetime(template_t* tmpl);
+    int fill_ipfix_header(uint8_t* ptr, uint16_t size);
+    template_file_record_t* get_template_record_by_name(const char* name);
+    void expire_templates();
+    template_t* create_template(const char** tmplt, const char** ext);
+    uint16_t create_template_packet(ipfix_packet_t* packet);
+    uint16_t create_data_packet(ipfix_packet_t* packet);
+    void send_templates();
+    void send_data();
+    int send_packet(ipfix_packet_t* packet);
+    int connect_to_collector();
+    int reconnect();
+    int fill_basic_flow(const Flow& flow, template_t* tmplt);
+    int fill_extensions(RecordExt* ext, uint8_t* buffer, int size);
 
-   uint64_t get_template_id(const Record &flow);
-   template_t *get_template(const Flow &flow);
-   bool fill_template(const Flow &flow, template_t *tmplt);
-   void flush();
-   void shutdown();
+    uint64_t get_template_id(const Record& flow);
+    template_t* get_template(const Flow& flow);
+    bool fill_template(const Flow& flow, template_t* tmplt);
+    void flush();
+    void shutdown();
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_OUTPUT_IPFIX_HPP */

--- a/output/text.cpp
+++ b/output/text.cpp
@@ -28,11 +28,11 @@
 
 #include <config.h>
 
-#include <string>
-#include <ostream>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <ostream>
+#include <string>
 
 #include "text.hpp"
 
@@ -40,124 +40,134 @@ namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("text", [](){return new TextExporter();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("text", []() { return new TextExporter(); });
+    register_plugin(&rec);
 }
 
-TextExporter::TextExporter() : m_out(&std::cout), m_hide_mac(false)
+TextExporter::TextExporter()
+    : m_out(&std::cout)
+    , m_hide_mac(false)
 {
 }
 
 TextExporter::~TextExporter()
 {
-   close();
+    close();
 }
 
-void TextExporter::init(const char *params)
+void TextExporter::init(const char* params)
 {
-   TextOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    TextOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   if (parser.m_to_file) {
-      std::ofstream *file = new std::ofstream(parser.m_file, std::ofstream::out);
-      if (file->fail()) {
-         throw PluginError("failed to open output file");
-      }
-      m_out = file;
-   }
-   m_hide_mac = parser.m_hide_mac;
+    if (parser.m_to_file) {
+        std::ofstream* file = new std::ofstream(parser.m_file, std::ofstream::out);
+        if (file->fail()) {
+            throw PluginError("failed to open output file");
+        }
+        m_out = file;
+    }
+    m_hide_mac = parser.m_hide_mac;
 
-   if (!m_hide_mac) {
-      *m_out << "mac ";
-   }
-   *m_out << "conversation packets bytes tcp-flags time extensions" << std::endl;
+    if (!m_hide_mac) {
+        *m_out << "mac ";
+    }
+    *m_out << "conversation packets bytes tcp-flags time extensions" << std::endl;
 }
 
-void TextExporter::init(const char *params, Plugins &plugins)
+void TextExporter::init(const char* params, Plugins& plugins)
 {
-   init(params);
+    init(params);
 }
 
 void TextExporter::close()
 {
-   if (m_out != &std::cout) {
-      delete m_out;
-      m_out = &std::cout;
-   }
+    if (m_out != &std::cout) {
+        delete m_out;
+        m_out = &std::cout;
+    }
 }
 
-int TextExporter::export_flow(const Flow &flow)
+int TextExporter::export_flow(const Flow& flow)
 {
-   RecordExt *ext = flow.m_exts;
+    RecordExt* ext = flow.m_exts;
 
-   m_flows_seen++;
-   print_basic_flow(flow);
-   while (ext != nullptr) {
-      *m_out << " " << ext->get_text();
-      ext = ext->m_next;
-   }
-   *m_out << std::endl;
+    m_flows_seen++;
+    print_basic_flow(flow);
+    while (ext != nullptr) {
+        *m_out << " " << ext->get_text();
+        ext = ext->m_next;
+    }
+    *m_out << std::endl;
 
-   return 0;
+    return 0;
 }
 
-void TextExporter::print_basic_flow(const Flow &flow)
+void TextExporter::print_basic_flow(const Flow& flow)
 {
-   time_t sec;
-   char time_begin[100];
-   char time_end[100];
-   char src_mac[18];
-   char dst_mac[18];
-   char tmp[50];
-   char src_ip[INET6_ADDRSTRLEN];
-   char dst_ip[INET6_ADDRSTRLEN];
-   std::string lb = "";
-   std::string rb = "";
+    time_t sec;
+    char time_begin[100];
+    char time_end[100];
+    char src_mac[18];
+    char dst_mac[18];
+    char tmp[50];
+    char src_ip[INET6_ADDRSTRLEN];
+    char dst_ip[INET6_ADDRSTRLEN];
+    std::string lb = "";
+    std::string rb = "";
 
-   sec = flow.time_first.tv_sec;
-   strftime(tmp, sizeof(tmp), "%FT%T", localtime(&sec));
-   snprintf(time_begin, sizeof(time_begin), "%s.%06ld", tmp, flow.time_first.tv_usec);
-   sec = flow.time_last.tv_sec;
-   strftime(tmp, sizeof(tmp), "%FT%T", localtime(&sec));
-   snprintf(time_end, sizeof(time_end), "%s.%06ld", tmp, flow.time_last.tv_usec);
+    sec = flow.time_first.tv_sec;
+    strftime(tmp, sizeof(tmp), "%FT%T", localtime(&sec));
+    snprintf(time_begin, sizeof(time_begin), "%s.%06ld", tmp, flow.time_first.tv_usec);
+    sec = flow.time_last.tv_sec;
+    strftime(tmp, sizeof(tmp), "%FT%T", localtime(&sec));
+    snprintf(time_end, sizeof(time_end), "%s.%06ld", tmp, flow.time_last.tv_usec);
 
-   const uint8_t *p = const_cast<uint8_t *>(flow.src_mac);
-   snprintf(src_mac, sizeof(src_mac), "%02x:%02x:%02x:%02x:%02x:%02x", p[0], p[1], p[2], p[3], p[4], p[5]);
-   p = const_cast<uint8_t *>(flow.dst_mac);
-   snprintf(dst_mac, sizeof(dst_mac), "%02x:%02x:%02x:%02x:%02x:%02x", p[0], p[1], p[2], p[3], p[4], p[5]);
+    const uint8_t* p = const_cast<uint8_t*>(flow.src_mac);
+    snprintf(
+        src_mac,
+        sizeof(src_mac),
+        "%02x:%02x:%02x:%02x:%02x:%02x",
+        p[0],
+        p[1],
+        p[2],
+        p[3],
+        p[4],
+        p[5]);
+    p = const_cast<uint8_t*>(flow.dst_mac);
+    snprintf(
+        dst_mac,
+        sizeof(dst_mac),
+        "%02x:%02x:%02x:%02x:%02x:%02x",
+        p[0],
+        p[1],
+        p[2],
+        p[3],
+        p[4],
+        p[5]);
 
-   if (flow.ip_version == IP::v4) {
-      inet_ntop(AF_INET, (const void *) &flow.src_ip.v4, src_ip, INET6_ADDRSTRLEN);
-      inet_ntop(AF_INET, (const void *) &flow.dst_ip.v4, dst_ip, INET6_ADDRSTRLEN);
-   } else if (flow.ip_version == IP::v6) {
-      inet_ntop(AF_INET6, (const void *) &flow.src_ip.v6, src_ip, INET6_ADDRSTRLEN);
-      inet_ntop(AF_INET6, (const void *) &flow.dst_ip.v6, dst_ip, INET6_ADDRSTRLEN);
-      lb = "[";
-      rb = "]";
-   }
+    if (flow.ip_version == IP::v4) {
+        inet_ntop(AF_INET, (const void*) &flow.src_ip.v4, src_ip, INET6_ADDRSTRLEN);
+        inet_ntop(AF_INET, (const void*) &flow.dst_ip.v4, dst_ip, INET6_ADDRSTRLEN);
+    } else if (flow.ip_version == IP::v6) {
+        inet_ntop(AF_INET6, (const void*) &flow.src_ip.v6, src_ip, INET6_ADDRSTRLEN);
+        inet_ntop(AF_INET6, (const void*) &flow.dst_ip.v6, dst_ip, INET6_ADDRSTRLEN);
+        lb = "[";
+        rb = "]";
+    }
 
-   if (!m_hide_mac) {
-      *m_out << src_mac << "->" << dst_mac << " ";
-   }
-   *m_out <<
-      std::setw(2) << static_cast<unsigned>(flow.ip_proto) <<
-      "@" <<
-      lb << src_ip << rb << ":" << flow.src_port <<
-      "->" <<
-      lb << dst_ip << rb << ":" << flow.dst_port <<
-      " " <<
-      flow.src_packets << "->" << flow.dst_packets <<
-      " " <<
-      flow.src_bytes << "->" << flow.dst_bytes <<
-      " " <<
-      static_cast<unsigned>(flow.src_tcp_flags) << "->" << static_cast<unsigned>(flow.dst_tcp_flags) <<
-      " " <<
-      time_begin << "->" << time_end;
-
+    if (!m_hide_mac) {
+        *m_out << src_mac << "->" << dst_mac << " ";
+    }
+    *m_out << std::setw(2) << static_cast<unsigned>(flow.ip_proto) << "@" << lb << src_ip << rb
+           << ":" << flow.src_port << "->" << lb << dst_ip << rb << ":" << flow.dst_port << " "
+           << flow.src_packets << "->" << flow.dst_packets << " " << flow.src_bytes << "->"
+           << flow.dst_bytes << " " << static_cast<unsigned>(flow.src_tcp_flags) << "->"
+           << static_cast<unsigned>(flow.dst_tcp_flags) << " " << time_begin << "->" << time_end;
 }
 
-}
+} // namespace ipxp

--- a/output/text.hpp
+++ b/output/text.hpp
@@ -33,49 +33,67 @@
 
 #include <string>
 
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
 #include <ipfixprobe/output.hpp>
 #include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
 #include <ipfixprobe/utils.hpp>
-#include <ipfixprobe/options.hpp>
 
 namespace ipxp {
 
-class TextOptParser : public OptionsParser
-{
+class TextOptParser : public OptionsParser {
 public:
-   std::string m_file;
-   bool m_to_file;
-   bool m_hide_mac;
+    std::string m_file;
+    bool m_to_file;
+    bool m_hide_mac;
 
-   TextOptParser() : OptionsParser("text", "Output plugin for text export"),
-      m_file(""), m_to_file(false), m_hide_mac(false)
-   {
-      register_option("f", "file", "PATH", "Print output to file",
-         [this](const char *arg){m_file = arg; m_to_file = true; return true;}, OptionFlags::RequiredArgument);
-      register_option("m", "mac", "", "Hide mac addresses",
-         [this](const char *arg){m_hide_mac = true; return true;}, OptionFlags::NoArgument);
-   }
+    TextOptParser()
+        : OptionsParser("text", "Output plugin for text export")
+        , m_file("")
+        , m_to_file(false)
+        , m_hide_mac(false)
+    {
+        register_option(
+            "f",
+            "file",
+            "PATH",
+            "Print output to file",
+            [this](const char* arg) {
+                m_file = arg;
+                m_to_file = true;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "m",
+            "mac",
+            "",
+            "Hide mac addresses",
+            [this](const char* arg) {
+                m_hide_mac = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-class TextExporter : public OutputPlugin
-{
+class TextExporter : public OutputPlugin {
 public:
-   TextExporter();
-   ~TextExporter();
-   void init(const char *params);
-   void init(const char *params, Plugins &plugins);
-   void close();
-   OptionsParser *get_parser() const { return new TextOptParser(); }
-   std::string get_name() const { return "text"; }
-   int export_flow(const Flow &flow);
+    TextExporter();
+    ~TextExporter();
+    void init(const char* params);
+    void init(const char* params, Plugins& plugins);
+    void close();
+    OptionsParser* get_parser() const { return new TextOptParser(); }
+    std::string get_name() const { return "text"; }
+    int export_flow(const Flow& flow);
 
 private:
-   std::ostream *m_out;
-   bool m_hide_mac;
+    std::ostream* m_out;
+    bool m_hide_mac;
 
-   void print_basic_flow(const Flow &flow);
+    void print_basic_flow(const Flow& flow);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_OUTPUT_TEXT_HPP */

--- a/output/unirec.cpp
+++ b/output/unirec.cpp
@@ -33,62 +33,72 @@
 
 #ifdef WITH_NEMEA
 
-#include <string>
-#include <vector>
 #include <algorithm>
 #include <libtrap/trap.h>
+#include <string>
 #include <unirec/unirec.h>
+#include <vector>
 
-#include "unirec.hpp"
 #include "fields.h"
+#include "unirec.hpp"
 
 namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("unirec", [](){return new UnirecExporter();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("unirec", []() { return new UnirecExporter(); });
+    register_plugin(&rec);
 }
 
-#define BASIC_FLOW_TEMPLATE "SRC_IP,DST_IP,SRC_PORT,DST_PORT,PROTOCOL,PACKETS,BYTES,PACKETS_REV,BYTES_REV,TIME_FIRST,TIME_LAST,TCP_FLAGS,TCP_FLAGS_REV,DIR_BIT_FIELD,SRC_MAC,DST_MAC" /* LINK_BIT_FIELD or ODID will be added at init. */
+#define BASIC_FLOW_TEMPLATE                                                                        \
+    "SRC_IP,DST_IP,SRC_PORT,DST_PORT,PROTOCOL,PACKETS,BYTES,PACKETS_REV,BYTES_REV,TIME_FIRST,"     \
+    "TIME_LAST,TCP_FLAGS,TCP_FLAGS_REV,DIR_BIT_FIELD,SRC_MAC,DST_MAC" /* LINK_BIT_FIELD or ODID    \
+                                                                         will be added at init. */
 
 #define PACKET_TEMPLATE "SRC_MAC,DST_MAC,ETHERTYPE,TIME"
 
-UR_FIELDS (
-   ipaddr DST_IP,
-   ipaddr SRC_IP,
-   uint64 BYTES,
-   uint64 BYTES_REV,
-   uint64 LINK_BIT_FIELD,
-   uint32 ODID,
-   time TIME_FIRST,
-   time TIME_LAST,
-   uint32 PACKETS,
-   uint32 PACKETS_REV,
-   uint16 DST_PORT,
-   uint16 SRC_PORT,
-   uint8 DIR_BIT_FIELD,
-   uint8 PROTOCOL,
-   uint8 TCP_FLAGS,
-   uint8 TCP_FLAGS_REV,
+UR_FIELDS(
+    ipaddr DST_IP,
+    ipaddr SRC_IP,
+    uint64 BYTES,
+    uint64 BYTES_REV,
+    uint64 LINK_BIT_FIELD,
+    uint32 ODID,
+    time TIME_FIRST,
+    time TIME_LAST,
+    uint32 PACKETS,
+    uint32 PACKETS_REV,
+    uint16 DST_PORT,
+    uint16 SRC_PORT,
+    uint8 DIR_BIT_FIELD,
+    uint8 PROTOCOL,
+    uint8 TCP_FLAGS,
+    uint8 TCP_FLAGS_REV,
 
-   macaddr SRC_MAC,
-   macaddr DST_MAC
-)
+    macaddr SRC_MAC,
+    macaddr DST_MAC)
 
 /**
  * \brief Constructor.
  */
-UnirecExporter::UnirecExporter() : m_basic_idx(-1), m_ext_cnt(0),
-   m_ifc_map(nullptr), m_tmplts(nullptr), m_records(nullptr), m_ifc_cnt(0),
-   m_ext_id_flgs(nullptr), m_eof(false), m_odid(false), m_link_bit_field(0),
-   m_dir_bit_field(0)
+UnirecExporter::UnirecExporter()
+    : m_basic_idx(-1)
+    , m_ext_cnt(0)
+    , m_ifc_map(nullptr)
+    , m_tmplts(nullptr)
+    , m_records(nullptr)
+    , m_ifc_cnt(0)
+    , m_ext_id_flgs(nullptr)
+    , m_eof(false)
+    , m_odid(false)
+    , m_link_bit_field(0)
+    , m_dir_bit_field(0)
 {
 }
 
 UnirecExporter::~UnirecExporter()
 {
-   close();
+    close();
 }
 
 /**
@@ -97,209 +107,212 @@ UnirecExporter::~UnirecExporter()
  * \param [in] argv Pointer to parameters.
  * \return Number of trap interfaces.
  */
-static int count_trap_interfaces(const char *spec)
+static int count_trap_interfaces(const char* spec)
 {
-   int ifc_cnt = 1;
-   if (spec != nullptr) {
-      while(*spec) { // Count number of specified interfaces.
-         if (*(spec++) == TRAP_IFC_DELIMITER) {
-            ifc_cnt++;
-         }
-      }
-      return ifc_cnt;
-   }
-
-   return ifc_cnt;
-}
-
-int UnirecExporter::init_trap(std::string &ifcs, int verbosity)
-{
-   trap_ifc_spec_t ifc_spec;
-   std::vector<char> spec_str(ifcs.c_str(), ifcs.c_str() + ifcs.size() + 1);
-   char *argv[] = {"-i", spec_str.data()};
-   int argc = 2;
-   int ifc_cnt = count_trap_interfaces(ifcs.c_str());
-
-   if (trap_parse_params(&argc, argv, &ifc_spec) != TRAP_E_OK) {
-      trap_free_ifc_spec(ifc_spec);
-      std::string err_msg = "parsing parameters for TRAP failed";
-      if (trap_last_error_msg) {
-         err_msg += std::string(": ") + trap_last_error_msg;
-      }
-      throw PluginError(err_msg);
-   }
-   trap_module_info_t module_info = {"ipfixprobe", "Output plugin for ipfixprobe", 0, ifc_cnt};
-   if (trap_init(&module_info, ifc_spec) != TRAP_E_OK) {
-      trap_free_ifc_spec(ifc_spec);
-      std::string err_msg = "error in TRAP initialization: ";
-      if (trap_last_error_msg) {
-         err_msg += std::string(": ") + trap_last_error_msg;
-      }
-      throw PluginError(err_msg);
-   }
-   trap_free_ifc_spec(ifc_spec);
-
-   if (verbosity > 0) {
-      trap_set_verbose_level(verbosity - 1);
-   }
-   for (int i = 0; i < ifc_cnt; i++) {
-      trap_ifcctl(TRAPIFC_OUTPUT, i, TRAPCTL_SETTIMEOUT, TRAP_HALFWAIT);
-   }
-   return ifc_cnt;
-}
-
-void UnirecExporter::init(const char *params)
-{
-   UnirecOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
-
-   if (parser.m_help) {
-      trap_print_ifc_spec_help();
-      throw PluginExit();
-   }
-   if (parser.m_ifc.empty()) {
-      throw PluginError("specify libtrap interface specifier");
-   }
-   m_odid = parser.m_odid;
-   m_eof = parser.m_eof;
-   m_link_bit_field = parser.m_id;
-   m_dir_bit_field = parser.m_dir;
-   m_group_map = parser.m_ifc_map;
-   m_ifc_cnt = init_trap(parser.m_ifc, parser.m_verbose);
-   m_ext_cnt = get_extension_cnt();
-
-   try {
-      m_tmplts = new ur_template_t*[m_ifc_cnt];
-      m_records = new void*[m_ifc_cnt];
-      m_ifc_map = new int[m_ext_cnt];
-      m_ext_id_flgs = new int[m_ext_cnt];
-   } catch (std::bad_alloc &e) {
-      throw PluginError("not enough memory");
-   }
-   for (size_t i = 0; i < m_ifc_cnt; i++) {
-      m_tmplts[i] = nullptr;
-      m_records[i] = nullptr;
-   }
-   for (size_t i = 0; i < m_ext_cnt; i++) {
-      m_ifc_map[i] = -1;
-   }
-}
-
-void UnirecExporter::create_tmplt(int ifc_idx, const char *tmplt_str)
-{
-   char *error = nullptr;
-   m_tmplts[ifc_idx] = ur_create_output_template(ifc_idx, tmplt_str, &error);
-   if (m_tmplts[ifc_idx] == nullptr) {
-      std::string tmp = error;
-      free(error);
-      free_unirec_resources();
-      throw PluginError(tmp);
-   }
-}
-
-void UnirecExporter::init(const char *params, Plugins &plugins)
-{
-   init(params);
-
-   std::string basic_tmplt = BASIC_FLOW_TEMPLATE;
-   if (m_odid) {
-      basic_tmplt += ",ODID";
-   } else {
-      basic_tmplt += ",LINK_BIT_FIELD";
-   }
-
-   if (m_group_map.empty()) {
-      if (m_ifc_cnt == 1 && plugins.empty()) {
-         m_basic_idx = 0;
-
-         create_tmplt(m_basic_idx, basic_tmplt.c_str());
-      } else if (m_ifc_cnt == 1 && plugins.size() == 1) {
-         m_group_map[0] = std::vector<std::string>({plugins[0].first});
-      } else {
-         throw PluginError("specify plugin-interface mapping");
-      }
-   }
-
-   if (m_ifc_cnt != 1 && m_ifc_cnt != m_group_map.size()) {
-      throw PluginError("number of interfaces and plugin groups differ");
-   }
-
-   for (auto &m : m_group_map) {
-      unsigned ifc_idx = m.first;
-      std::vector<std::string> &group = m.second;
-
-      // Find plugin for each plugin in group
-      std::vector<ProcessPlugin *> plugin_group;
-      for (auto &g : group) {
-         ProcessPlugin *plugin = nullptr;
-         for (auto &p : plugins) {
-            std::string name = p.first;
-            if (g == name) {
-               plugin = p.second;
-               break;
+    int ifc_cnt = 1;
+    if (spec != nullptr) {
+        while (*spec) { // Count number of specified interfaces.
+            if (*(spec++) == TRAP_IFC_DELIMITER) {
+                ifc_cnt++;
             }
-         }
-         if (m_tmplts[ifc_idx] != nullptr || (m_basic_idx >= 0 && g == BASIC_PLUGIN_NAME)) {
-            throw PluginError("plugin can be specified only one time");
-         }
-         if (group.size() == 1 && g == BASIC_PLUGIN_NAME) {
-            m_basic_idx = ifc_idx;
-            break;
-         }
-         if (plugin == nullptr) {
-            throw PluginError(g + " plugin is not activated");
-         }
-         plugin_group.push_back(plugin);
-      }
+        }
+        return ifc_cnt;
+    }
 
-      // Create output template string and extension->ifc map
-      std::string tmplt_str = basic_tmplt;
-      for (auto &p : plugin_group) {
-         RecordExt *ext = p->get_ext();
-         tmplt_str += std::string(",") + ext->get_unirec_tmplt();
-         int ext_id = ext->m_ext_id;
-         delete ext;
-         if (ext_id < 0) {
-            continue;
-         }
-         if (m_ifc_map[ext_id] >= 0) {
-            throw PluginError("plugin output can be exported only to one interface at the moment");
-         }
-         m_ifc_map[ext_id] = ifc_idx;
-      }
+    return ifc_cnt;
+}
 
-      create_tmplt(ifc_idx, tmplt_str.c_str());
-   }
+int UnirecExporter::init_trap(std::string& ifcs, int verbosity)
+{
+    trap_ifc_spec_t ifc_spec;
+    std::vector<char> spec_str(ifcs.c_str(), ifcs.c_str() + ifcs.size() + 1);
+    char* argv[] = {"-i", spec_str.data()};
+    int argc = 2;
+    int ifc_cnt = count_trap_interfaces(ifcs.c_str());
 
-   for (size_t i = 0; i < m_ifc_cnt; i++) { // Create unirec records.
-      m_records[i] = ur_create_record(m_tmplts[i], (static_cast<ssize_t>(i) == m_basic_idx ? 0 : UR_MAX_SIZE));
+    if (trap_parse_params(&argc, argv, &ifc_spec) != TRAP_E_OK) {
+        trap_free_ifc_spec(ifc_spec);
+        std::string err_msg = "parsing parameters for TRAP failed";
+        if (trap_last_error_msg) {
+            err_msg += std::string(": ") + trap_last_error_msg;
+        }
+        throw PluginError(err_msg);
+    }
+    trap_module_info_t module_info = {"ipfixprobe", "Output plugin for ipfixprobe", 0, ifc_cnt};
+    if (trap_init(&module_info, ifc_spec) != TRAP_E_OK) {
+        trap_free_ifc_spec(ifc_spec);
+        std::string err_msg = "error in TRAP initialization: ";
+        if (trap_last_error_msg) {
+            err_msg += std::string(": ") + trap_last_error_msg;
+        }
+        throw PluginError(err_msg);
+    }
+    trap_free_ifc_spec(ifc_spec);
 
-      if (m_records[i] == nullptr) {
-         free_unirec_resources();
-         throw PluginError("not enough memory");
-      }
-   }
+    if (verbosity > 0) {
+        trap_set_verbose_level(verbosity - 1);
+    }
+    for (int i = 0; i < ifc_cnt; i++) {
+        trap_ifcctl(TRAPIFC_OUTPUT, i, TRAPCTL_SETTIMEOUT, TRAP_HALFWAIT);
+    }
+    return ifc_cnt;
+}
 
-   m_group_map.clear();
+void UnirecExporter::init(const char* params)
+{
+    UnirecOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
+
+    if (parser.m_help) {
+        trap_print_ifc_spec_help();
+        throw PluginExit();
+    }
+    if (parser.m_ifc.empty()) {
+        throw PluginError("specify libtrap interface specifier");
+    }
+    m_odid = parser.m_odid;
+    m_eof = parser.m_eof;
+    m_link_bit_field = parser.m_id;
+    m_dir_bit_field = parser.m_dir;
+    m_group_map = parser.m_ifc_map;
+    m_ifc_cnt = init_trap(parser.m_ifc, parser.m_verbose);
+    m_ext_cnt = get_extension_cnt();
+
+    try {
+        m_tmplts = new ur_template_t*[m_ifc_cnt];
+        m_records = new void*[m_ifc_cnt];
+        m_ifc_map = new int[m_ext_cnt];
+        m_ext_id_flgs = new int[m_ext_cnt];
+    } catch (std::bad_alloc& e) {
+        throw PluginError("not enough memory");
+    }
+    for (size_t i = 0; i < m_ifc_cnt; i++) {
+        m_tmplts[i] = nullptr;
+        m_records[i] = nullptr;
+    }
+    for (size_t i = 0; i < m_ext_cnt; i++) {
+        m_ifc_map[i] = -1;
+    }
+}
+
+void UnirecExporter::create_tmplt(int ifc_idx, const char* tmplt_str)
+{
+    char* error = nullptr;
+    m_tmplts[ifc_idx] = ur_create_output_template(ifc_idx, tmplt_str, &error);
+    if (m_tmplts[ifc_idx] == nullptr) {
+        std::string tmp = error;
+        free(error);
+        free_unirec_resources();
+        throw PluginError(tmp);
+    }
+}
+
+void UnirecExporter::init(const char* params, Plugins& plugins)
+{
+    init(params);
+
+    std::string basic_tmplt = BASIC_FLOW_TEMPLATE;
+    if (m_odid) {
+        basic_tmplt += ",ODID";
+    } else {
+        basic_tmplt += ",LINK_BIT_FIELD";
+    }
+
+    if (m_group_map.empty()) {
+        if (m_ifc_cnt == 1 && plugins.empty()) {
+            m_basic_idx = 0;
+
+            create_tmplt(m_basic_idx, basic_tmplt.c_str());
+        } else if (m_ifc_cnt == 1 && plugins.size() == 1) {
+            m_group_map[0] = std::vector<std::string>({plugins[0].first});
+        } else {
+            throw PluginError("specify plugin-interface mapping");
+        }
+    }
+
+    if (m_ifc_cnt != 1 && m_ifc_cnt != m_group_map.size()) {
+        throw PluginError("number of interfaces and plugin groups differ");
+    }
+
+    for (auto& m : m_group_map) {
+        unsigned ifc_idx = m.first;
+        std::vector<std::string>& group = m.second;
+
+        // Find plugin for each plugin in group
+        std::vector<ProcessPlugin*> plugin_group;
+        for (auto& g : group) {
+            ProcessPlugin* plugin = nullptr;
+            for (auto& p : plugins) {
+                std::string name = p.first;
+                if (g == name) {
+                    plugin = p.second;
+                    break;
+                }
+            }
+            if (m_tmplts[ifc_idx] != nullptr || (m_basic_idx >= 0 && g == BASIC_PLUGIN_NAME)) {
+                throw PluginError("plugin can be specified only one time");
+            }
+            if (group.size() == 1 && g == BASIC_PLUGIN_NAME) {
+                m_basic_idx = ifc_idx;
+                break;
+            }
+            if (plugin == nullptr) {
+                throw PluginError(g + " plugin is not activated");
+            }
+            plugin_group.push_back(plugin);
+        }
+
+        // Create output template string and extension->ifc map
+        std::string tmplt_str = basic_tmplt;
+        for (auto& p : plugin_group) {
+            RecordExt* ext = p->get_ext();
+            tmplt_str += std::string(",") + ext->get_unirec_tmplt();
+            int ext_id = ext->m_ext_id;
+            delete ext;
+            if (ext_id < 0) {
+                continue;
+            }
+            if (m_ifc_map[ext_id] >= 0) {
+                throw PluginError(
+                    "plugin output can be exported only to one interface at the moment");
+            }
+            m_ifc_map[ext_id] = ifc_idx;
+        }
+
+        create_tmplt(ifc_idx, tmplt_str.c_str());
+    }
+
+    for (size_t i = 0; i < m_ifc_cnt; i++) { // Create unirec records.
+        m_records[i] = ur_create_record(
+            m_tmplts[i],
+            (static_cast<ssize_t>(i) == m_basic_idx ? 0 : UR_MAX_SIZE));
+
+        if (m_records[i] == nullptr) {
+            free_unirec_resources();
+            throw PluginError("not enough memory");
+        }
+    }
+
+    m_group_map.clear();
 }
 
 void UnirecExporter::close()
 {
-   if (m_eof) {
-      for (size_t i = 0; i < m_ifc_cnt; i++) {
-         trap_send(i, "", 1);
-      }
-   }
-   trap_finalize();
-   free_unirec_resources();
+    if (m_eof) {
+        for (size_t i = 0; i < m_ifc_cnt; i++) {
+            trap_send(i, "", 1);
+        }
+    }
+    trap_finalize();
+    free_unirec_resources();
 
-   m_basic_idx = -1;
-   m_ifc_cnt = 0;
-   delete [] m_ext_id_flgs;
+    m_basic_idx = -1;
+    m_ifc_cnt = 0;
+    delete[] m_ext_id_flgs;
 }
 
 /**
@@ -307,84 +320,93 @@ void UnirecExporter::close()
  */
 void UnirecExporter::free_unirec_resources()
 {
-   if (m_tmplts) {
-      for (size_t i = 0; i < m_ifc_cnt; i++) {
-         if (m_tmplts[i] != nullptr) {
-            ur_free_template(m_tmplts[i]);
-         }
-      }
-      delete [] m_tmplts;
-      m_tmplts = nullptr;
-   }
-   if (m_records) {
-      for (size_t i = 0; i < m_ifc_cnt; i++) {
-         if (m_records[i] != nullptr) {
-            ur_free_record(m_records[i]);
-         }
-      }
-      delete [] m_records;
-      m_records = nullptr;
-   }
-   if (m_ifc_map) {
-      delete [] m_ifc_map;
-      m_ifc_map = nullptr;
-   }
+    if (m_tmplts) {
+        for (size_t i = 0; i < m_ifc_cnt; i++) {
+            if (m_tmplts[i] != nullptr) {
+                ur_free_template(m_tmplts[i]);
+            }
+        }
+        delete[] m_tmplts;
+        m_tmplts = nullptr;
+    }
+    if (m_records) {
+        for (size_t i = 0; i < m_ifc_cnt; i++) {
+            if (m_records[i] != nullptr) {
+                ur_free_record(m_records[i]);
+            }
+        }
+        delete[] m_records;
+        m_records = nullptr;
+    }
+    if (m_ifc_map) {
+        delete[] m_ifc_map;
+        m_ifc_map = nullptr;
+    }
 }
 
-int UnirecExporter::export_flow(const Flow &flow)
+int UnirecExporter::export_flow(const Flow& flow)
 {
-   RecordExt *ext = flow.m_exts;
-   ur_template_t *tmplt_ptr = nullptr;
-   void *record_ptr = nullptr;
+    RecordExt* ext = flow.m_exts;
+    ur_template_t* tmplt_ptr = nullptr;
+    void* record_ptr = nullptr;
 
-   if (m_basic_idx >= 0) { // Process basic flow.
-      tmplt_ptr = m_tmplts[m_basic_idx];
-      record_ptr = m_records[m_basic_idx];
+    if (m_basic_idx >= 0) { // Process basic flow.
+        tmplt_ptr = m_tmplts[m_basic_idx];
+        record_ptr = m_records[m_basic_idx];
 
-      ur_clear_varlen(tmplt_ptr, record_ptr);
-      fill_basic_flow(flow, tmplt_ptr, record_ptr);
-      trap_send(m_basic_idx, record_ptr, ur_rec_fixlen_size(tmplt_ptr) + ur_rec_varlen_size(tmplt_ptr, record_ptr));
-   }
+        ur_clear_varlen(tmplt_ptr, record_ptr);
+        fill_basic_flow(flow, tmplt_ptr, record_ptr);
+        trap_send(
+            m_basic_idx,
+            record_ptr,
+            ur_rec_fixlen_size(tmplt_ptr) + ur_rec_varlen_size(tmplt_ptr, record_ptr));
+    }
 
-   m_flows_seen++;
-   uint64_t tmplt_dbits = 0; // templates dirty bits
-   memset(m_ext_id_flgs, 0, sizeof(int) * m_ext_cnt); // in case one flow has multiple extension of same type
-   int ext_processed_cnd = 0;
-   while (ext != nullptr) {
-      if (ext->m_ext_id >= static_cast<int>(m_ext_cnt)) {
-         throw PluginError("encountered invalid extension id");
-      }
-      ext_processed_cnd++;
-      int ifc_num = m_ifc_map[ext->m_ext_id];
-      if (ifc_num >= 0) {
-         tmplt_ptr = m_tmplts[ifc_num];
-         record_ptr = m_records[ifc_num];
+    m_flows_seen++;
+    uint64_t tmplt_dbits = 0; // templates dirty bits
+    memset(
+        m_ext_id_flgs,
+        0,
+        sizeof(int) * m_ext_cnt); // in case one flow has multiple extension of same type
+    int ext_processed_cnd = 0;
+    while (ext != nullptr) {
+        if (ext->m_ext_id >= static_cast<int>(m_ext_cnt)) {
+            throw PluginError("encountered invalid extension id");
+        }
+        ext_processed_cnd++;
+        int ifc_num = m_ifc_map[ext->m_ext_id];
+        if (ifc_num >= 0) {
+            tmplt_ptr = m_tmplts[ifc_num];
+            record_ptr = m_records[ifc_num];
 
-         if ((tmplt_dbits & (1 << ifc_num)) == 0) {
-            ur_clear_varlen(tmplt_ptr, record_ptr);
-            memset(record_ptr, 0, ur_rec_fixlen_size(tmplt_ptr));
-            tmplt_dbits |= (1 << ifc_num);
-         }
+            if ((tmplt_dbits & (1 << ifc_num)) == 0) {
+                ur_clear_varlen(tmplt_ptr, record_ptr);
+                memset(record_ptr, 0, ur_rec_fixlen_size(tmplt_ptr));
+                tmplt_dbits |= (1 << ifc_num);
+            }
 
-         if (m_ext_id_flgs[ext->m_ext_id] == 1) {
-            // send the previously filled unirec record
-            trap_send(ifc_num, record_ptr, ur_rec_size(tmplt_ptr, record_ptr));
-         } else {
-            m_ext_id_flgs[ext->m_ext_id] = 1;
-         }
+            if (m_ext_id_flgs[ext->m_ext_id] == 1) {
+                // send the previously filled unirec record
+                trap_send(ifc_num, record_ptr, ur_rec_size(tmplt_ptr, record_ptr));
+            } else {
+                m_ext_id_flgs[ext->m_ext_id] = 1;
+            }
 
-         fill_basic_flow(flow, tmplt_ptr, record_ptr);
-         ext->fill_unirec(tmplt_ptr, record_ptr); /* Add each extension header into unirec record. */
-      }
-      ext = ext->m_next;
-   }
-   //send the last record with all plugin data
-   for (size_t ifc_num = 0; ifc_num < m_ifc_cnt && !(m_basic_idx >= 0) && ext_processed_cnd > 0; ifc_num++) {
-      tmplt_ptr = m_tmplts[ifc_num];
-      record_ptr = m_records[ifc_num];
-      trap_send(ifc_num, record_ptr, ur_rec_size(tmplt_ptr, record_ptr));
-   }
-   return 0;
+            fill_basic_flow(flow, tmplt_ptr, record_ptr);
+            ext->fill_unirec(
+                tmplt_ptr,
+                record_ptr); /* Add each extension header into unirec record. */
+        }
+        ext = ext->m_next;
+    }
+    // send the last record with all plugin data
+    for (size_t ifc_num = 0; ifc_num < m_ifc_cnt && !(m_basic_idx >= 0) && ext_processed_cnd > 0;
+         ifc_num++) {
+        tmplt_ptr = m_tmplts[ifc_num];
+        record_ptr = m_records[ifc_num];
+        trap_send(ifc_num, record_ptr, ur_rec_size(tmplt_ptr, record_ptr));
+    }
+    return 0;
 }
 
 /**
@@ -393,43 +415,43 @@ int UnirecExporter::export_flow(const Flow &flow)
  * \param [in] tmplt_ptr Pointer to unirec template.
  * \param [out] record_ptr Pointer to unirec record.
  */
-void UnirecExporter::fill_basic_flow(const Flow &flow, ur_template_t *tmplt_ptr, void *record_ptr)
+void UnirecExporter::fill_basic_flow(const Flow& flow, ur_template_t* tmplt_ptr, void* record_ptr)
 {
-   ur_time_t tmp_time;
+    ur_time_t tmp_time;
 
-   if (flow.ip_version == IP::v4) {
-      ur_set(tmplt_ptr, record_ptr, F_SRC_IP, ip_from_4_bytes_be((char *) &flow.src_ip.v4));
-      ur_set(tmplt_ptr, record_ptr, F_DST_IP, ip_from_4_bytes_be((char *) &flow.dst_ip.v4));
-   } else {
-      ur_set(tmplt_ptr, record_ptr, F_SRC_IP, ip_from_16_bytes_be((char *) flow.src_ip.v6));
-      ur_set(tmplt_ptr, record_ptr, F_DST_IP, ip_from_16_bytes_be((char *) flow.dst_ip.v6));
-   }
+    if (flow.ip_version == IP::v4) {
+        ur_set(tmplt_ptr, record_ptr, F_SRC_IP, ip_from_4_bytes_be((char*) &flow.src_ip.v4));
+        ur_set(tmplt_ptr, record_ptr, F_DST_IP, ip_from_4_bytes_be((char*) &flow.dst_ip.v4));
+    } else {
+        ur_set(tmplt_ptr, record_ptr, F_SRC_IP, ip_from_16_bytes_be((char*) flow.src_ip.v6));
+        ur_set(tmplt_ptr, record_ptr, F_DST_IP, ip_from_16_bytes_be((char*) flow.dst_ip.v6));
+    }
 
-   tmp_time = ur_time_from_sec_usec(flow.time_first.tv_sec, flow.time_first.tv_usec);
-   ur_set(tmplt_ptr, record_ptr, F_TIME_FIRST, tmp_time);
+    tmp_time = ur_time_from_sec_usec(flow.time_first.tv_sec, flow.time_first.tv_usec);
+    ur_set(tmplt_ptr, record_ptr, F_TIME_FIRST, tmp_time);
 
-   tmp_time = ur_time_from_sec_usec(flow.time_last.tv_sec, flow.time_last.tv_usec);
-   ur_set(tmplt_ptr, record_ptr, F_TIME_LAST, tmp_time);
+    tmp_time = ur_time_from_sec_usec(flow.time_last.tv_sec, flow.time_last.tv_usec);
+    ur_set(tmplt_ptr, record_ptr, F_TIME_LAST, tmp_time);
 
-   if (m_odid) {
-      ur_set(tmplt_ptr, record_ptr, F_ODID, m_link_bit_field);
-   } else {
-      ur_set(tmplt_ptr, record_ptr, F_LINK_BIT_FIELD, m_link_bit_field);
-   }
-   ur_set(tmplt_ptr, record_ptr, F_DIR_BIT_FIELD, m_dir_bit_field);
-   ur_set(tmplt_ptr, record_ptr, F_PROTOCOL, flow.ip_proto);
-   ur_set(tmplt_ptr, record_ptr, F_SRC_PORT, flow.src_port);
-   ur_set(tmplt_ptr, record_ptr, F_DST_PORT, flow.dst_port);
-   ur_set(tmplt_ptr, record_ptr, F_PACKETS, flow.src_packets);
-   ur_set(tmplt_ptr, record_ptr, F_BYTES, flow.src_bytes);
-   ur_set(tmplt_ptr, record_ptr, F_TCP_FLAGS, flow.src_tcp_flags);
-   ur_set(tmplt_ptr, record_ptr, F_PACKETS_REV, flow.dst_packets);
-   ur_set(tmplt_ptr, record_ptr, F_BYTES_REV, flow.dst_bytes);
-   ur_set(tmplt_ptr, record_ptr, F_TCP_FLAGS_REV, flow.dst_tcp_flags);
+    if (m_odid) {
+        ur_set(tmplt_ptr, record_ptr, F_ODID, m_link_bit_field);
+    } else {
+        ur_set(tmplt_ptr, record_ptr, F_LINK_BIT_FIELD, m_link_bit_field);
+    }
+    ur_set(tmplt_ptr, record_ptr, F_DIR_BIT_FIELD, m_dir_bit_field);
+    ur_set(tmplt_ptr, record_ptr, F_PROTOCOL, flow.ip_proto);
+    ur_set(tmplt_ptr, record_ptr, F_SRC_PORT, flow.src_port);
+    ur_set(tmplt_ptr, record_ptr, F_DST_PORT, flow.dst_port);
+    ur_set(tmplt_ptr, record_ptr, F_PACKETS, flow.src_packets);
+    ur_set(tmplt_ptr, record_ptr, F_BYTES, flow.src_bytes);
+    ur_set(tmplt_ptr, record_ptr, F_TCP_FLAGS, flow.src_tcp_flags);
+    ur_set(tmplt_ptr, record_ptr, F_PACKETS_REV, flow.dst_packets);
+    ur_set(tmplt_ptr, record_ptr, F_BYTES_REV, flow.dst_bytes);
+    ur_set(tmplt_ptr, record_ptr, F_TCP_FLAGS_REV, flow.dst_tcp_flags);
 
-   ur_set(tmplt_ptr, record_ptr, F_DST_MAC, mac_from_bytes(const_cast<uint8_t*>(flow.dst_mac)));
-   ur_set(tmplt_ptr, record_ptr, F_SRC_MAC, mac_from_bytes(const_cast<uint8_t*>(flow.src_mac)));
+    ur_set(tmplt_ptr, record_ptr, F_DST_MAC, mac_from_bytes(const_cast<uint8_t*>(flow.dst_mac)));
+    ur_set(tmplt_ptr, record_ptr, F_SRC_MAC, mac_from_bytes(const_cast<uint8_t*>(flow.src_mac)));
 }
 
-}
+} // namespace ipxp
 #endif

--- a/output/unirec.hpp
+++ b/output/unirec.hpp
@@ -36,165 +36,251 @@
 
 #ifdef WITH_NEMEA
 
-#include <string>
-#include <vector>
-#include <map>
 #include <libtrap/trap.h>
+#include <map>
+#include <string>
 #include <unirec/unirec.h>
+#include <vector>
 
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
 #include <ipfixprobe/output.hpp>
 #include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
 #include <ipfixprobe/utils.hpp>
-#include <ipfixprobe/options.hpp>
 
 namespace ipxp {
 
-class UnirecOptParser : public OptionsParser
-{
+class UnirecOptParser : public OptionsParser {
 public:
-   typedef std::map<unsigned, std::vector<std::string>> IfcPluginMap;
+    typedef std::map<unsigned, std::vector<std::string>> IfcPluginMap;
 
-   std::string m_ifc;
-   IfcPluginMap m_ifc_map;
-   bool m_odid;
-   bool m_eof;
-   bool m_help;
-   uint64_t m_id;
-   uint8_t m_dir;
-   int m_verbose;
+    std::string m_ifc;
+    IfcPluginMap m_ifc_map;
+    bool m_odid;
+    bool m_eof;
+    bool m_help;
+    uint64_t m_id;
+    uint8_t m_dir;
+    int m_verbose;
 
-   UnirecOptParser() : OptionsParser("unirec", "Output plugin for unirec export"),
-      m_ifc(""), m_odid(false), m_eof(false), m_help(false), m_id(DEFAULT_EXPORTER_ID), m_dir(0), m_verbose(0)
-   {
-      register_option("i", "ifc", "SPEC", "libtrap interface specifier", [this](const char *arg){m_ifc = arg; return true;}, OptionFlags::RequiredArgument);
-      register_option("p", "plugins", "PLUGINS", "Specify plugin-interface mapping. Plugins can be grouped like '(p1,p2,p3),p4,(p5,p6)'",
-         [this](const char *arg){try {m_ifc_map = parse_ifc_map(arg);} catch(ParserError &e) {return false;} return true;}, OptionFlags::RequiredArgument);
-      register_option("o", "odid", "", "Export ODID field", [this](const char *arg){m_odid = true; return true;}, OptionFlags::NoArgument);
-      register_option("e", "eof", "", "Send EOF message on exit", [this](const char *arg){m_eof = true; return true;}, OptionFlags::NoArgument);
-      register_option("I", "id", "NUM", "Exporter identification number",
-         [this](const char *arg){try {m_id = str2num<decltype(m_id)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("d", "dir", "NUM", "Dir bit field value",
-         [this](const char *arg){try {m_dir = str2num<decltype(m_dir)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("h", "help", "", "Print libtrap help", [this](const char *arg){m_help = true; return true;}, OptionFlags::NoArgument);
-      register_option("v", "verbose", "", "Increase verbosity", [this](const char *arg){m_verbose++; return true;}, OptionFlags::NoArgument);
-   }
+    UnirecOptParser()
+        : OptionsParser("unirec", "Output plugin for unirec export")
+        , m_ifc("")
+        , m_odid(false)
+        , m_eof(false)
+        , m_help(false)
+        , m_id(DEFAULT_EXPORTER_ID)
+        , m_dir(0)
+        , m_verbose(0)
+    {
+        register_option(
+            "i",
+            "ifc",
+            "SPEC",
+            "libtrap interface specifier",
+            [this](const char* arg) {
+                m_ifc = arg;
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "p",
+            "plugins",
+            "PLUGINS",
+            "Specify plugin-interface mapping. Plugins can be grouped like '(p1,p2,p3),p4,(p5,p6)'",
+            [this](const char* arg) {
+                try {
+                    m_ifc_map = parse_ifc_map(arg);
+                } catch (ParserError& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "o",
+            "odid",
+            "",
+            "Export ODID field",
+            [this](const char* arg) {
+                m_odid = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "e",
+            "eof",
+            "",
+            "Send EOF message on exit",
+            [this](const char* arg) {
+                m_eof = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "I",
+            "id",
+            "NUM",
+            "Exporter identification number",
+            [this](const char* arg) {
+                try {
+                    m_id = str2num<decltype(m_id)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "d",
+            "dir",
+            "NUM",
+            "Dir bit field value",
+            [this](const char* arg) {
+                try {
+                    m_dir = str2num<decltype(m_dir)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "h",
+            "help",
+            "",
+            "Print libtrap help",
+            [this](const char* arg) {
+                m_help = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "v",
+            "verbose",
+            "",
+            "Increase verbosity",
+            [this](const char* arg) {
+                m_verbose++;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 
 private:
-   std::vector<std::string> parse_plugin_group(const std::string &group)
-   {
-      std::vector<std::string> plugins;
-      size_t first = 0;
-      size_t last = 0;
-      while (1) {
-         last = group.find(",", first);
-         std::string plugin = group.substr(first, (last == std::string::npos ? group.size() : last) - first);
-         trim_str(plugin);
+    std::vector<std::string> parse_plugin_group(const std::string& group)
+    {
+        std::vector<std::string> plugins;
+        size_t first = 0;
+        size_t last = 0;
+        while (1) {
+            last = group.find(",", first);
+            std::string plugin
+                = group.substr(first, (last == std::string::npos ? group.size() : last) - first);
+            trim_str(plugin);
 
-         if (plugin.empty()) {
-            throw ParserError("invalid plugin group");
-         }
+            if (plugin.empty()) {
+                throw ParserError("invalid plugin group");
+            }
 
-         plugins.push_back(plugin);
-         first = last + 1;
-         if (last == std::string::npos) {
-            break;
-         }
-      }
-      return plugins;
-   }
+            plugins.push_back(plugin);
+            first = last + 1;
+            if (last == std::string::npos) {
+                break;
+            }
+        }
+        return plugins;
+    }
 
-   UnirecOptParser::IfcPluginMap parse_ifc_map(const std::string &plugins)
-   {
-      UnirecOptParser::IfcPluginMap ifc_map;
-      size_t first = 0;
-      size_t last = 0;
-      size_t group = std::string::npos;
-      bool error = false;
-      if (plugins.empty()) {
-         throw ParserError("invalid interface-plugin mapping");
-      }
-      while (last != std::string::npos) {
-         char c = plugins[last];
-         if (c == '(') {
-            if (group != std::string::npos) {
-               error = true;
-               break;
+    UnirecOptParser::IfcPluginMap parse_ifc_map(const std::string& plugins)
+    {
+        UnirecOptParser::IfcPluginMap ifc_map;
+        size_t first = 0;
+        size_t last = 0;
+        size_t group = std::string::npos;
+        bool error = false;
+        if (plugins.empty()) {
+            throw ParserError("invalid interface-plugin mapping");
+        }
+        while (last != std::string::npos) {
+            char c = plugins[last];
+            if (c == '(') {
+                if (group != std::string::npos) {
+                    error = true;
+                    break;
+                }
+                group = last;
+                last++;
+            } else if (c == ')') {
+                if (group == std::string::npos || first != group) {
+                    error = true;
+                    break;
+                }
+                ifc_map[ifc_map.size()]
+                    = parse_plugin_group(plugins.substr(group + 1, last - group - 1));
+                group = std::string::npos;
+                first = plugins.find_first_not_of(" ,\t\n\r", last + 1);
+                last = first;
+            } else if ((c == ',' && group == std::string::npos) || last == plugins.size()) {
+                std::string tmp = plugins.substr(first, last - first);
+                ifc_map[ifc_map.size()] = parse_plugin_group(tmp);
+                first = plugins.find_first_not_of(" ,\t\n\r", last);
+                if (c == ',' && first == std::string::npos) {
+                    error = true;
+                    break;
+                }
+                if (last == plugins.size()) {
+                    break;
+                }
+                last = first;
+            } else {
+                last++;
             }
-            group = last;
-            last++;
-         } else if (c == ')') {
-            if (group == std::string::npos || first != group) {
-               error = true;
-               break;
-            }
-            ifc_map[ifc_map.size()] = parse_plugin_group(plugins.substr(group + 1, last - group - 1));
-            group = std::string::npos;
-            first = plugins.find_first_not_of(" ,\t\n\r", last + 1);
-            last = first;
-         } else if ((c == ',' && group == std::string::npos) || last == plugins.size()) {
-            std::string tmp = plugins.substr(first, last - first);
-            ifc_map[ifc_map.size()] = parse_plugin_group(tmp);
-            first = plugins.find_first_not_of(" ,\t\n\r", last);
-            if (c == ',' && first == std::string::npos) {
-               error = true;
-               break;
-            }
-            if (last == plugins.size()) {
-               break;
-            }
-            last = first;
-         } else {
-            last++;
-         }
-      }
-      if (error || group != std::string::npos) {
-         throw ParserError("invalid interface-plugin mapping " + plugins);
-      }
+        }
+        if (error || group != std::string::npos) {
+            throw ParserError("invalid interface-plugin mapping " + plugins);
+        }
 
-      return ifc_map;
-   }
+        return ifc_map;
+    }
 };
 
 /**
  * \brief Class for exporting flow records.
  */
-class UnirecExporter : public OutputPlugin
-{
+class UnirecExporter : public OutputPlugin {
 public:
-   UnirecExporter();
-   ~UnirecExporter();
-   void init(const char *params);
-   void init(const char *params, Plugins &plugins);
-   void close();
-   OptionsParser *get_parser() const { return new UnirecOptParser(); }
-   std::string get_name() const { return "unirec"; }
-   int export_flow(const Flow &flow);
+    UnirecExporter();
+    ~UnirecExporter();
+    void init(const char* params);
+    void init(const char* params, Plugins& plugins);
+    void close();
+    OptionsParser* get_parser() const { return new UnirecOptParser(); }
+    std::string get_name() const { return "unirec"; }
+    int export_flow(const Flow& flow);
 
 private:
-   int init_trap(std::string &ifcs, int verbosity);
-   void create_tmplt(int ifc_idx, const char *tmplt_str);
-   void fill_basic_flow(const Flow &flow, ur_template_t *tmplt_ptr, void *record_ptr);
-   void free_unirec_resources();
+    int init_trap(std::string& ifcs, int verbosity);
+    void create_tmplt(int ifc_idx, const char* tmplt_str);
+    void fill_basic_flow(const Flow& flow, ur_template_t* tmplt_ptr, void* record_ptr);
+    void free_unirec_resources();
 
-   int m_basic_idx;         /**< Basic output interface number. */
-   size_t m_ext_cnt;        /**< Size of ifc map. */
-   int *m_ifc_map;          /**< Contain extension id (as index) -> output interface number mapping. */
-   UnirecOptParser::IfcPluginMap m_group_map; /**< Plugin groups mapping to interface number. */
+    int m_basic_idx; /**< Basic output interface number. */
+    size_t m_ext_cnt; /**< Size of ifc map. */
+    int* m_ifc_map; /**< Contain extension id (as index) -> output interface number mapping. */
+    UnirecOptParser::IfcPluginMap m_group_map; /**< Plugin groups mapping to interface number. */
 
-   ur_template_t **m_tmplts;    /**< Pointer to unirec templates. */
-   void          **m_records;   /**< Pointer to unirec records. */
-   size_t m_ifc_cnt;            /**< Number of output interfaces. */
-   int *m_ext_id_flgs;          /** flags of used extension during export*/
+    ur_template_t** m_tmplts; /**< Pointer to unirec templates. */
+    void** m_records; /**< Pointer to unirec records. */
+    size_t m_ifc_cnt; /**< Number of output interfaces. */
+    int* m_ext_id_flgs; /** flags of used extension during export*/
 
-   bool m_eof;                  /**< Send eof when module exits. */
-   bool m_odid;            /**< Export ODID field instead of LINK_BIT_FIELD. */
-   uint64_t m_link_bit_field;   /**< Link bit field value. */
-   uint8_t m_dir_bit_field;     /**< Direction bit field value. */
+    bool m_eof; /**< Send eof when module exits. */
+    bool m_odid; /**< Export ODID field instead of LINK_BIT_FIELD. */
+    uint64_t m_link_bit_field; /**< Link bit field value. */
+    uint8_t m_dir_bit_field; /**< Direction bit field value. */
 };
 
-}
+} // namespace ipxp
 #endif /* WITH_NEMEA */
 #endif /* IPXP_OUTPUT_UNIREC_HPP */

--- a/pluginmgr.hpp
+++ b/pluginmgr.hpp
@@ -29,47 +29,51 @@
 #ifndef IPXP_PLUGIN_MANAGER_HPP
 #define IPXP_PLUGIN_MANAGER_HPP
 
-#include <functional>
 #include <exception>
+#include <functional>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 #include <ipfixprobe/plugin.hpp>
 
 namespace ipxp {
 
-class PluginManagerError : public std::runtime_error
-{
+class PluginManagerError : public std::runtime_error {
 public:
-   explicit PluginManagerError(const std::string &msg) : std::runtime_error(msg) {}
-   explicit PluginManagerError(const char *msg) : std::runtime_error(msg) {}
+    explicit PluginManagerError(const std::string& msg)
+        : std::runtime_error(msg)
+    {
+    }
+    explicit PluginManagerError(const char* msg)
+        : std::runtime_error(msg)
+    {
+    }
 };
 
 // TODO: should be singleton
-class PluginManager
-{
+class PluginManager {
 public:
-   PluginManager();
-   ~PluginManager();
-   void register_plugin(const std::string &name, PluginGetter g);
-   Plugin *get(const std::string &name);
-   std::vector<Plugin *> get() const;
-   Plugin *load(const std::string &name);
+    PluginManager();
+    ~PluginManager();
+    void register_plugin(const std::string& name, PluginGetter g);
+    Plugin* get(const std::string& name);
+    std::vector<Plugin*> get() const;
+    Plugin* load(const std::string& name);
 
 private:
-   struct LoadedPlugin {
-      void *m_handle;
-      std::string m_file;
-   };
+    struct LoadedPlugin {
+        void* m_handle;
+        std::string m_file;
+    };
 
-   std::map<std::string, PluginGetter> m_getters;
-   std::vector<LoadedPlugin> m_loaded_so;
-   PluginRecord *m_last_rec;
+    std::map<std::string, PluginGetter> m_getters;
+    std::vector<LoadedPlugin> m_loaded_so;
+    PluginRecord* m_last_rec;
 
-   void unload();
-   void register_loaded_plugins();
+    void unload();
+    void register_loaded_plugins();
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PLUGIN_MANAGER_HPP */

--- a/process/basicplus.hpp
+++ b/process/basicplus.hpp
@@ -29,153 +29,151 @@
 #ifndef IPXP_PROCESS_BASICPLUS_HPP
 #define IPXP_PROCESS_BASICPLUS_HPP
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
- #include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/byte-utils.hpp>
+#include <ipfixprobe/flowifc.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
-#define BASICPLUS_UNIREC_TEMPLATE \
-   "IP_TTL,IP_TTL_REV,IP_FLG,IP_FLG_REV,TCP_WIN,TCP_WIN_REV,TCP_OPT,TCP_OPT_REV,TCP_MSS,TCP_MSS_REV,TCP_SYN_SIZE"
+#define BASICPLUS_UNIREC_TEMPLATE                                                                  \
+    "IP_TTL,IP_TTL_REV,IP_FLG,IP_FLG_REV,TCP_WIN,TCP_WIN_REV,TCP_OPT,TCP_OPT_REV,TCP_MSS,TCP_MSS_" \
+    "REV,TCP_SYN_SIZE"
 
-UR_FIELDS (
-   uint8 IP_TTL,
-   uint8 IP_TTL_REV,
-   uint8 IP_FLG,
-   uint8 IP_FLG_REV,
-   uint16 TCP_WIN,
-   uint16 TCP_WIN_REV,
-   uint64 TCP_OPT,
-   uint64 TCP_OPT_REV,
-   uint32 TCP_MSS,
-   uint32 TCP_MSS_REV,
-   uint16 TCP_SYN_SIZE
-)
+UR_FIELDS(
+    uint8 IP_TTL,
+    uint8 IP_TTL_REV,
+    uint8 IP_FLG,
+    uint8 IP_FLG_REV,
+    uint16 TCP_WIN,
+    uint16 TCP_WIN_REV,
+    uint64 TCP_OPT,
+    uint64 TCP_OPT_REV,
+    uint32 TCP_MSS,
+    uint32 TCP_MSS_REV,
+    uint16 TCP_SYN_SIZE)
 
 /**
  * \brief Flow record extension header for storing parsed BASICPLUS packets.
  */
 struct RecordExtBASICPLUS : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint8_t  ip_ttl[2];
-   uint8_t  ip_flg[2];
-   uint16_t tcp_win[2];
-   uint64_t tcp_opt[2];
-   uint32_t tcp_mss[2];
-   uint16_t tcp_syn_size;
+    uint8_t ip_ttl[2];
+    uint8_t ip_flg[2];
+    uint16_t tcp_win[2];
+    uint64_t tcp_opt[2];
+    uint32_t tcp_mss[2];
+    uint16_t tcp_syn_size;
 
-   bool     dst_filled;
+    bool dst_filled;
 
-   RecordExtBASICPLUS() : RecordExt(REGISTERED_ID)
-   {
-      ip_ttl[0]    = 0;
-      ip_ttl[1]    = 0;
-      ip_flg[0]    = 0;
-      ip_flg[1]    = 0;
-      tcp_win[0]   = 0;
-      tcp_win[1]   = 0;
-      tcp_opt[0]   = 0;
-      tcp_opt[1]   = 0;
-      tcp_mss[0]   = 0;
-      tcp_mss[1]   = 0;
-      tcp_syn_size = 0;
+    RecordExtBASICPLUS()
+        : RecordExt(REGISTERED_ID)
+    {
+        ip_ttl[0] = 0;
+        ip_ttl[1] = 0;
+        ip_flg[0] = 0;
+        ip_flg[1] = 0;
+        tcp_win[0] = 0;
+        tcp_win[1] = 0;
+        tcp_opt[0] = 0;
+        tcp_opt[1] = 0;
+        tcp_mss[0] = 0;
+        tcp_mss[1] = 0;
+        tcp_syn_size = 0;
 
-      dst_filled = false;
-   }
+        dst_filled = false;
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_IP_TTL, ip_ttl[0]);
-      ur_set(tmplt, record, F_IP_TTL_REV, ip_ttl[1]);
-      ur_set(tmplt, record, F_IP_FLG, ip_flg[0]);
-      ur_set(tmplt, record, F_IP_FLG_REV, ip_flg[1]);
-      ur_set(tmplt, record, F_TCP_WIN, tcp_win[0]);
-      ur_set(tmplt, record, F_TCP_WIN_REV, tcp_win[1]);
-      ur_set(tmplt, record, F_TCP_OPT, tcp_opt[0]);
-      ur_set(tmplt, record, F_TCP_OPT_REV, tcp_opt[1]);
-      ur_set(tmplt, record, F_TCP_MSS, tcp_mss[0]);
-      ur_set(tmplt, record, F_TCP_MSS_REV, tcp_mss[1]);
-      ur_set(tmplt, record, F_TCP_SYN_SIZE, tcp_syn_size);
-   }
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_IP_TTL, ip_ttl[0]);
+        ur_set(tmplt, record, F_IP_TTL_REV, ip_ttl[1]);
+        ur_set(tmplt, record, F_IP_FLG, ip_flg[0]);
+        ur_set(tmplt, record, F_IP_FLG_REV, ip_flg[1]);
+        ur_set(tmplt, record, F_TCP_WIN, tcp_win[0]);
+        ur_set(tmplt, record, F_TCP_WIN_REV, tcp_win[1]);
+        ur_set(tmplt, record, F_TCP_OPT, tcp_opt[0]);
+        ur_set(tmplt, record, F_TCP_OPT_REV, tcp_opt[1]);
+        ur_set(tmplt, record, F_TCP_MSS, tcp_mss[0]);
+        ur_set(tmplt, record, F_TCP_MSS_REV, tcp_mss[1]);
+        ur_set(tmplt, record, F_TCP_SYN_SIZE, tcp_syn_size);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return BASICPLUS_UNIREC_TEMPLATE;
-   }
-   #endif // ifdef WITH_NEMEA
+    const char* get_unirec_tmplt() const { return BASICPLUS_UNIREC_TEMPLATE; }
+#endif // ifdef WITH_NEMEA
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      if (size < 34) {
-         return -1;
-      }
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        if (size < 34) {
+            return -1;
+        }
 
-      buffer[0] = ip_ttl[0];
-      buffer[1] = ip_ttl[1];
-      buffer[2] = ip_flg[0];
-      buffer[3] = ip_flg[1];
-      *(uint16_t *) (buffer + 4)  = ntohs(tcp_win[0]);
-      *(uint16_t *) (buffer + 6)  = ntohs(tcp_win[1]);
-      *(uint64_t *) (buffer + 8)  = swap_uint64(tcp_opt[0]);
-      *(uint64_t *) (buffer + 16) = swap_uint64(tcp_opt[1]);
-      *(uint32_t *) (buffer + 24) = ntohl(tcp_mss[0]);
-      *(uint32_t *) (buffer + 28) = ntohl(tcp_mss[1]);
-      *(uint16_t *) (buffer + 32) = ntohs(tcp_syn_size);
+        buffer[0] = ip_ttl[0];
+        buffer[1] = ip_ttl[1];
+        buffer[2] = ip_flg[0];
+        buffer[3] = ip_flg[1];
+        *(uint16_t*) (buffer + 4) = ntohs(tcp_win[0]);
+        *(uint16_t*) (buffer + 6) = ntohs(tcp_win[1]);
+        *(uint64_t*) (buffer + 8) = swap_uint64(tcp_opt[0]);
+        *(uint64_t*) (buffer + 16) = swap_uint64(tcp_opt[1]);
+        *(uint32_t*) (buffer + 24) = ntohl(tcp_mss[0]);
+        *(uint32_t*) (buffer + 28) = ntohl(tcp_mss[1]);
+        *(uint16_t*) (buffer + 32) = ntohs(tcp_syn_size);
 
-      return 34;
-   }
+        return 34;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_BASICPLUS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_tmplt;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_BASICPLUS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "sttl=" << (uint16_t) ip_ttl[0] << ",dttl=" << (uint16_t) ip_ttl[1]
-         << ",sflg=" << (uint16_t) ip_flg[0] << ",dflg=" << (uint16_t) ip_flg[1]
-         << ",stcpw=" << tcp_win[0] << ",dtcpw=" << tcp_win[1]
-         << ",stcpo=" << tcp_opt[0] << ",dtcpo=" << tcp_opt[1]
-         << ",stcpm=" << tcp_mss[0] << ",dtcpm=" << tcp_mss[1]
-         << ",tcpsynsize=" << tcp_syn_size;
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "sttl=" << (uint16_t) ip_ttl[0] << ",dttl=" << (uint16_t) ip_ttl[1]
+            << ",sflg=" << (uint16_t) ip_flg[0] << ",dflg=" << (uint16_t) ip_flg[1]
+            << ",stcpw=" << tcp_win[0] << ",dtcpw=" << tcp_win[1] << ",stcpo=" << tcp_opt[0]
+            << ",dtcpo=" << tcp_opt[1] << ",stcpm=" << tcp_mss[0] << ",dtcpm=" << tcp_mss[1]
+            << ",tcpsynsize=" << tcp_syn_size;
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing BASICPLUS packets.
  */
-class BASICPLUSPlugin : public ProcessPlugin
-{
+class BASICPLUSPlugin : public ProcessPlugin {
 public:
-   BASICPLUSPlugin();
-   ~BASICPLUSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("basicplus", "Extend basic fields with TTL, TCP window, options, MSS and SYN size"); }
-   std::string get_name() const { return "basicplus"; }
-   RecordExt *get_ext() const { return new RecordExtBASICPLUS(); }
-   ProcessPlugin *copy();
+    BASICPLUSPlugin();
+    ~BASICPLUSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser(
+            "basicplus",
+            "Extend basic fields with TTL, TCP window, options, MSS and SYN size");
+    }
+    std::string get_name() const { return "basicplus"; }
+    RecordExt* get_ext() const { return new RecordExtBASICPLUS(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_BASICPLUS_HPP */

--- a/process/bstats.cpp
+++ b/process/bstats.cpp
@@ -36,140 +36,145 @@ int RecordExtBSTATS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("bstats", [](){return new BSTATSPlugin();});
-   register_plugin(&rec);
-   RecordExtBSTATS::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("bstats", []() { return new BSTATSPlugin(); });
+    register_plugin(&rec);
+    RecordExtBSTATS::REGISTERED_ID = register_extension();
 }
 
-const struct timeval BSTATSPlugin::min_packet_in_burst =
-{MAXIMAL_INTERPKT_TIME / 1000, (MAXIMAL_INTERPKT_TIME % 1000) * 1000};
+const struct timeval BSTATSPlugin::min_packet_in_burst
+    = {MAXIMAL_INTERPKT_TIME / 1000, (MAXIMAL_INTERPKT_TIME % 1000) * 1000};
 
-
-BSTATSPlugin::BSTATSPlugin()
-{
-}
+BSTATSPlugin::BSTATSPlugin() {}
 
 BSTATSPlugin::~BSTATSPlugin()
 {
-   close();
+    close();
 }
 
-void BSTATSPlugin::init(const char *params)
+void BSTATSPlugin::init(const char* params) {}
+
+void BSTATSPlugin::close() {}
+
+ProcessPlugin* BSTATSPlugin::copy()
 {
+    return new BSTATSPlugin(*this);
 }
 
-void BSTATSPlugin::close()
+int BSTATSPlugin::pre_create(Packet& pkt)
 {
-}
-
-ProcessPlugin *BSTATSPlugin::copy()
-{
-   return new BSTATSPlugin(*this);
-}
-
-int BSTATSPlugin::pre_create(Packet &pkt)
-{
-   return 0;
+    return 0;
 }
 
 #define BCOUNT burst_count[direction]
-void BSTATSPlugin::initialize_new_burst(RecordExtBSTATS *bstats_record, uint8_t direction, const Packet &pkt)
+void BSTATSPlugin::initialize_new_burst(
+    RecordExtBSTATS* bstats_record,
+    uint8_t direction,
+    const Packet& pkt)
 {
-   bstats_record->brst_pkts[direction][bstats_record->BCOUNT]  = 1;
-   bstats_record->brst_bytes[direction][bstats_record->BCOUNT] = pkt.payload_len_wire;
-   bstats_record->brst_start[direction][bstats_record->BCOUNT] = pkt.ts;
-   bstats_record->brst_end[direction][bstats_record->BCOUNT]   = pkt.ts;
+    bstats_record->brst_pkts[direction][bstats_record->BCOUNT] = 1;
+    bstats_record->brst_bytes[direction][bstats_record->BCOUNT] = pkt.payload_len_wire;
+    bstats_record->brst_start[direction][bstats_record->BCOUNT] = pkt.ts;
+    bstats_record->brst_end[direction][bstats_record->BCOUNT] = pkt.ts;
 }
 
-bool BSTATSPlugin::belogsToLastRecord(RecordExtBSTATS *bstats_record, uint8_t direction, const Packet &pkt)
+bool BSTATSPlugin::belogsToLastRecord(
+    RecordExtBSTATS* bstats_record,
+    uint8_t direction,
+    const Packet& pkt)
 {
-   struct timeval timediff;
+    struct timeval timediff;
 
-   timersub(&pkt.ts, &bstats_record->brst_end[direction][bstats_record->BCOUNT], &timediff);
-   if (timercmp(&timediff, &min_packet_in_burst, <)){
-      return true;
-   }
-   return false;
+    timersub(&pkt.ts, &bstats_record->brst_end[direction][bstats_record->BCOUNT], &timediff);
+    if (timercmp(&timediff, &min_packet_in_burst, <)) {
+        return true;
+    }
+    return false;
 }
 
-bool BSTATSPlugin::isLastRecordBurst(RecordExtBSTATS *bstats_record, uint8_t direction)
+bool BSTATSPlugin::isLastRecordBurst(RecordExtBSTATS* bstats_record, uint8_t direction)
 {
-   if (bstats_record->brst_pkts[direction][bstats_record->BCOUNT] < MINIMAL_PACKETS_IN_BURST){
-      return false;
-   }
-   return true;
+    if (bstats_record->brst_pkts[direction][bstats_record->BCOUNT] < MINIMAL_PACKETS_IN_BURST) {
+        return false;
+    }
+    return true;
 }
 
-void BSTATSPlugin::process_bursts(RecordExtBSTATS *bstats_record, uint8_t direction, const Packet &pkt)
+void BSTATSPlugin::process_bursts(
+    RecordExtBSTATS* bstats_record,
+    uint8_t direction,
+    const Packet& pkt)
 {
-   if (belogsToLastRecord(bstats_record, direction, pkt)){ // does it belong to previous burst?
-      bstats_record->brst_pkts[direction][bstats_record->BCOUNT]++;
-      bstats_record->brst_bytes[direction][bstats_record->BCOUNT] += pkt.payload_len_wire;
-      bstats_record->brst_end[direction][bstats_record->BCOUNT]    = pkt.ts;
-      return;
-   }
-   // the packet does not belong to previous burst
-   if (isLastRecordBurst(bstats_record, direction)){
-      bstats_record->BCOUNT++;
-   }
-   if (bstats_record->BCOUNT < BSTATS_MAXELENCOUNT){
-      initialize_new_burst(bstats_record, direction, pkt);
-   }
+    if (belogsToLastRecord(bstats_record, direction, pkt)) { // does it belong to previous burst?
+        bstats_record->brst_pkts[direction][bstats_record->BCOUNT]++;
+        bstats_record->brst_bytes[direction][bstats_record->BCOUNT] += pkt.payload_len_wire;
+        bstats_record->brst_end[direction][bstats_record->BCOUNT] = pkt.ts;
+        return;
+    }
+    // the packet does not belong to previous burst
+    if (isLastRecordBurst(bstats_record, direction)) {
+        bstats_record->BCOUNT++;
+    }
+    if (bstats_record->BCOUNT < BSTATS_MAXELENCOUNT) {
+        initialize_new_burst(bstats_record, direction, pkt);
+    }
 }
 
-void BSTATSPlugin::update_record(RecordExtBSTATS *bstats_record, const Packet &pkt)
+void BSTATSPlugin::update_record(RecordExtBSTATS* bstats_record, const Packet& pkt)
 {
-   uint8_t direction = (uint8_t) !pkt.source_pkt;
+    uint8_t direction = (uint8_t) !pkt.source_pkt;
 
-   if (pkt.payload_len_wire == 0 || bstats_record->BCOUNT >= BSTATS_MAXELENCOUNT){
-      // zero-payload or burst array is full
-      return;
-   }
-   if (bstats_record->burst_empty[direction] == 0){
-      bstats_record->burst_empty[direction] = 1;
-      initialize_new_burst(bstats_record, direction, pkt);
-   } else {
-      process_bursts(bstats_record, direction, pkt);
-   }
+    if (pkt.payload_len_wire == 0 || bstats_record->BCOUNT >= BSTATS_MAXELENCOUNT) {
+        // zero-payload or burst array is full
+        return;
+    }
+    if (bstats_record->burst_empty[direction] == 0) {
+        bstats_record->burst_empty[direction] = 1;
+        initialize_new_burst(bstats_record, direction, pkt);
+    } else {
+        process_bursts(bstats_record, direction, pkt);
+    }
 }
 
-int BSTATSPlugin::post_create(Flow &rec, const Packet &pkt)
+int BSTATSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   RecordExtBSTATS *bstats_record = new RecordExtBSTATS();
+    RecordExtBSTATS* bstats_record = new RecordExtBSTATS();
 
-   rec.add_extension(bstats_record);
-   update_record(bstats_record, pkt);
-   return 0;
+    rec.add_extension(bstats_record);
+    update_record(bstats_record, pkt);
+    return 0;
 }
 
-int BSTATSPlugin::pre_update(Flow &rec, Packet &pkt)
+int BSTATSPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   RecordExtBSTATS *bstats_record = static_cast<RecordExtBSTATS *>(rec.get_extension(RecordExtBSTATS::REGISTERED_ID));
+    RecordExtBSTATS* bstats_record
+        = static_cast<RecordExtBSTATS*>(rec.get_extension(RecordExtBSTATS::REGISTERED_ID));
 
-   update_record(bstats_record, pkt);
-   return 0;
+    update_record(bstats_record, pkt);
+    return 0;
 }
 
-int BSTATSPlugin::post_update(Flow &rec, const Packet &pkt)
+int BSTATSPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   return 0;
+    return 0;
 }
 
-void BSTATSPlugin::pre_export(Flow &rec)
+void BSTATSPlugin::pre_export(Flow& rec)
 {
-   uint32_t packets = rec.src_packets + rec.dst_packets;
-   if (packets <= MINIMAL_PACKETS_IN_BURST ) {
-      rec.remove_extension(RecordExtBSTATS::REGISTERED_ID);
-      return;
-   }
+    uint32_t packets = rec.src_packets + rec.dst_packets;
+    if (packets <= MINIMAL_PACKETS_IN_BURST) {
+        rec.remove_extension(RecordExtBSTATS::REGISTERED_ID);
+        return;
+    }
 
-   RecordExtBSTATS *bstats_record = static_cast<RecordExtBSTATS *>(rec.get_extension(RecordExtBSTATS::REGISTERED_ID));
+    RecordExtBSTATS* bstats_record
+        = static_cast<RecordExtBSTATS*>(rec.get_extension(RecordExtBSTATS::REGISTERED_ID));
 
-   for (int direction = 0; direction < 2; direction++){
-      if (bstats_record->BCOUNT < BSTATS_MAXELENCOUNT && isLastRecordBurst(bstats_record, direction)){
-         bstats_record->BCOUNT++;
-      }
-   }
+    for (int direction = 0; direction < 2; direction++) {
+        if (bstats_record->BCOUNT < BSTATS_MAXELENCOUNT
+            && isLastRecordBurst(bstats_record, direction)) {
+            bstats_record->BCOUNT++;
+        }
+    }
 }
 
-}
+} // namespace ipxp

--- a/process/bstats.hpp
+++ b/process/bstats.hpp
@@ -29,234 +29,264 @@
 #ifndef IPXP_PROCESS_BSTATS_HPP
 #define IPXP_PROCESS_BSTATS_HPP
 
-#include <string>
 #include <cstring>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-basiclist.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #define BSTATS_MAXELENCOUNT 15
 
 // BURST CHARACTERISTIC
-#define MINIMAL_PACKETS_IN_BURST 3    // in packets
-#define MAXIMAL_INTERPKT_TIME    1000 // in miliseconds
-                                      // maximal time between consecutive in-burst packets
-#define BSTATS_SOURCE            0
-#define BSTATS_DEST              1
+#define MINIMAL_PACKETS_IN_BURST 3 // in packets
+#define MAXIMAL_INTERPKT_TIME                                                                      \
+    1000 // in miliseconds
+         // maximal time between consecutive in-burst packets
+#define BSTATS_SOURCE 0
+#define BSTATS_DEST 1
 
-#define BSTATS_UNIREC_TEMPLATE "SBI_BRST_PACKETS,SBI_BRST_BYTES,SBI_BRST_TIME_START,SBI_BRST_TIME_STOP,\
+#define BSTATS_UNIREC_TEMPLATE                                                                     \
+    "SBI_BRST_PACKETS,SBI_BRST_BYTES,SBI_BRST_TIME_START,SBI_BRST_TIME_STOP,\
                                 DBI_BRST_PACKETS,DBI_BRST_BYTES,DBI_BRST_TIME_START,DBI_BRST_TIME_STOP"
 
 UR_FIELDS(
-   uint32* SBI_BRST_BYTES,
-   uint32* SBI_BRST_PACKETS,
-   time* SBI_BRST_TIME_START,
-   time* SBI_BRST_TIME_STOP,
-   uint32* DBI_BRST_PACKETS,
-   uint32* DBI_BRST_BYTES,
-   time* DBI_BRST_TIME_START,
-   time* DBI_BRST_TIME_STOP
-)
+    uint32* SBI_BRST_BYTES,
+    uint32* SBI_BRST_PACKETS,
+    time* SBI_BRST_TIME_START,
+    time* SBI_BRST_TIME_STOP,
+    uint32* DBI_BRST_PACKETS,
+    uint32* DBI_BRST_BYTES,
+    time* DBI_BRST_TIME_START,
+    time* DBI_BRST_TIME_STOP)
 
 /**
  * \brief Flow record extension header for storing parsed BSTATS packets.
  */
 struct RecordExtBSTATS : public RecordExt {
-   typedef enum eHdrFieldID {
-      SPkts  = 1050,
-      SBytes = 1051,
-      SStart = 1052,
-      SStop  = 1053,
-      DPkts  = 1054,
-      DBytes = 1055,
-      DStart = 1056,
-      DStop  = 1057
-   } eHdrFieldID;
+    typedef enum eHdrFieldID {
+        SPkts = 1050,
+        SBytes = 1051,
+        SStart = 1052,
+        SStop = 1053,
+        DPkts = 1054,
+        DBytes = 1055,
+        DStart = 1056,
+        DStop = 1057
+    } eHdrFieldID;
 
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t       burst_count[2];
-   uint8_t        burst_empty[2];
+    uint16_t burst_count[2];
+    uint8_t burst_empty[2];
 
-   uint32_t       brst_pkts[2][BSTATS_MAXELENCOUNT];
-   uint32_t       brst_bytes[2][BSTATS_MAXELENCOUNT];
-   struct timeval brst_start[2][BSTATS_MAXELENCOUNT];
-   struct timeval brst_end[2][BSTATS_MAXELENCOUNT];
+    uint32_t brst_pkts[2][BSTATS_MAXELENCOUNT];
+    uint32_t brst_bytes[2][BSTATS_MAXELENCOUNT];
+    struct timeval brst_start[2][BSTATS_MAXELENCOUNT];
+    struct timeval brst_end[2][BSTATS_MAXELENCOUNT];
 
-   RecordExtBSTATS() : RecordExt(REGISTERED_ID)
-   {
-      memset(burst_count, 0, 2 * sizeof(uint16_t));
-      memset(burst_empty, 0, 2 * sizeof(uint8_t));
-      brst_pkts[BSTATS_DEST][0]   = 0;
-      brst_pkts[BSTATS_SOURCE][0] = 0;
-   }
+    RecordExtBSTATS()
+        : RecordExt(REGISTERED_ID)
+    {
+        memset(burst_count, 0, 2 * sizeof(uint16_t));
+        memset(burst_empty, 0, 2 * sizeof(uint8_t));
+        brst_pkts[BSTATS_DEST][0] = 0;
+        brst_pkts[BSTATS_SOURCE][0] = 0;
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_time_t ts_start, ts_stop;
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_time_t ts_start, ts_stop;
 
-      ur_array_allocate(tmplt, record, F_SBI_BRST_PACKETS, burst_count[BSTATS_SOURCE]);
-      ur_array_allocate(tmplt, record, F_SBI_BRST_BYTES, burst_count[BSTATS_SOURCE]);
-      ur_array_allocate(tmplt, record, F_SBI_BRST_TIME_START, burst_count[BSTATS_SOURCE]);
-      ur_array_allocate(tmplt, record, F_SBI_BRST_TIME_STOP, burst_count[BSTATS_SOURCE]);
+        ur_array_allocate(tmplt, record, F_SBI_BRST_PACKETS, burst_count[BSTATS_SOURCE]);
+        ur_array_allocate(tmplt, record, F_SBI_BRST_BYTES, burst_count[BSTATS_SOURCE]);
+        ur_array_allocate(tmplt, record, F_SBI_BRST_TIME_START, burst_count[BSTATS_SOURCE]);
+        ur_array_allocate(tmplt, record, F_SBI_BRST_TIME_STOP, burst_count[BSTATS_SOURCE]);
 
-      ur_array_allocate(tmplt, record, F_DBI_BRST_PACKETS, burst_count[BSTATS_DEST]);
-      ur_array_allocate(tmplt, record, F_DBI_BRST_BYTES, burst_count[BSTATS_DEST]);
-      ur_array_allocate(tmplt, record, F_DBI_BRST_TIME_START, burst_count[BSTATS_DEST]);
-      ur_array_allocate(tmplt, record, F_DBI_BRST_TIME_STOP, burst_count[BSTATS_DEST]);
+        ur_array_allocate(tmplt, record, F_DBI_BRST_PACKETS, burst_count[BSTATS_DEST]);
+        ur_array_allocate(tmplt, record, F_DBI_BRST_BYTES, burst_count[BSTATS_DEST]);
+        ur_array_allocate(tmplt, record, F_DBI_BRST_TIME_START, burst_count[BSTATS_DEST]);
+        ur_array_allocate(tmplt, record, F_DBI_BRST_TIME_STOP, burst_count[BSTATS_DEST]);
 
-      for (int i = 0; i < burst_count[BSTATS_SOURCE]; i++){
-         ts_start = ur_time_from_sec_usec(brst_start[BSTATS_SOURCE][i].tv_sec, brst_start[BSTATS_SOURCE][i].tv_usec);
-         ts_stop  = ur_time_from_sec_usec(brst_end[BSTATS_SOURCE][i].tv_sec, brst_end[BSTATS_SOURCE][i].tv_usec);
-         ur_array_set(tmplt, record, F_SBI_BRST_PACKETS, i, brst_pkts[BSTATS_SOURCE][i]);
-         ur_array_set(tmplt, record, F_SBI_BRST_BYTES, i, brst_bytes[BSTATS_SOURCE][i]);
-         ur_array_set(tmplt, record, F_SBI_BRST_TIME_START, i, ts_start);
-         ur_array_set(tmplt, record, F_SBI_BRST_TIME_STOP, i, ts_stop);
-      }
-      for (int i = 0; i < burst_count[BSTATS_DEST]; i++){
-         ts_start = ur_time_from_sec_usec(brst_start[BSTATS_DEST][i].tv_sec, brst_start[BSTATS_DEST][i].tv_usec);
-         ts_stop  = ur_time_from_sec_usec(brst_end[BSTATS_DEST][i].tv_sec, brst_end[BSTATS_DEST][i].tv_usec);
-         ur_array_set(tmplt, record, F_DBI_BRST_PACKETS, i, brst_pkts[BSTATS_DEST][i]);
-         ur_array_set(tmplt, record, F_DBI_BRST_BYTES, i, brst_bytes[BSTATS_DEST][i]);
-         ur_array_set(tmplt, record, F_DBI_BRST_TIME_START, i, ts_start);
-         ur_array_set(tmplt, record, F_DBI_BRST_TIME_STOP, i, ts_stop);
-      }
-   }
+        for (int i = 0; i < burst_count[BSTATS_SOURCE]; i++) {
+            ts_start = ur_time_from_sec_usec(
+                brst_start[BSTATS_SOURCE][i].tv_sec,
+                brst_start[BSTATS_SOURCE][i].tv_usec);
+            ts_stop = ur_time_from_sec_usec(
+                brst_end[BSTATS_SOURCE][i].tv_sec,
+                brst_end[BSTATS_SOURCE][i].tv_usec);
+            ur_array_set(tmplt, record, F_SBI_BRST_PACKETS, i, brst_pkts[BSTATS_SOURCE][i]);
+            ur_array_set(tmplt, record, F_SBI_BRST_BYTES, i, brst_bytes[BSTATS_SOURCE][i]);
+            ur_array_set(tmplt, record, F_SBI_BRST_TIME_START, i, ts_start);
+            ur_array_set(tmplt, record, F_SBI_BRST_TIME_STOP, i, ts_stop);
+        }
+        for (int i = 0; i < burst_count[BSTATS_DEST]; i++) {
+            ts_start = ur_time_from_sec_usec(
+                brst_start[BSTATS_DEST][i].tv_sec,
+                brst_start[BSTATS_DEST][i].tv_usec);
+            ts_stop = ur_time_from_sec_usec(
+                brst_end[BSTATS_DEST][i].tv_sec,
+                brst_end[BSTATS_DEST][i].tv_usec);
+            ur_array_set(tmplt, record, F_DBI_BRST_PACKETS, i, brst_pkts[BSTATS_DEST][i]);
+            ur_array_set(tmplt, record, F_DBI_BRST_BYTES, i, brst_bytes[BSTATS_DEST][i]);
+            ur_array_set(tmplt, record, F_DBI_BRST_TIME_START, i, ts_start);
+            ur_array_set(tmplt, record, F_DBI_BRST_TIME_STOP, i, ts_stop);
+        }
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return BSTATS_UNIREC_TEMPLATE;
-   }
-   #endif // ifdef WITH_NEMEA
+    const char* get_unirec_tmplt() const { return BSTATS_UNIREC_TEMPLATE; }
+#endif // ifdef WITH_NEMEA
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int32_t bufferPtr;
-      IpfixBasicList basiclist;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int32_t bufferPtr;
+        IpfixBasicList basiclist;
 
-      basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
-      // Check sufficient size of buffer
-      int req_size = 8 * basiclist.HeaderSize()             /* sizes, times, flags, dirs */
-        + 2 * burst_count[BSTATS_SOURCE] * sizeof(uint32_t) /* bytes+sizes */
-        + 2 * burst_count[BSTATS_SOURCE] * sizeof(uint64_t) /* times_start + time_end */
-        + 2 * burst_count[BSTATS_DEST] * sizeof(uint32_t)   /* bytes+sizes */
-        + 2 * burst_count[BSTATS_DEST] * sizeof(uint64_t) /* times_start + time_end */;
+        basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
+        // Check sufficient size of buffer
+        int req_size = 8 * basiclist.HeaderSize() /* sizes, times, flags, dirs */
+            + 2 * burst_count[BSTATS_SOURCE] * sizeof(uint32_t) /* bytes+sizes */
+            + 2 * burst_count[BSTATS_SOURCE] * sizeof(uint64_t) /* times_start + time_end */
+            + 2 * burst_count[BSTATS_DEST] * sizeof(uint32_t) /* bytes+sizes */
+            + 2 * burst_count[BSTATS_DEST] * sizeof(uint64_t) /* times_start + time_end */;
 
-      if (req_size > size){
-         return -1;
-      }
-      // Fill buffer
-      bufferPtr  = basiclist.FillBuffer(buffer, brst_pkts[BSTATS_SOURCE], burst_count[BSTATS_SOURCE], (uint16_t) SPkts);
-      bufferPtr +=
-        basiclist.FillBuffer(buffer + bufferPtr, brst_bytes[BSTATS_SOURCE], burst_count[BSTATS_SOURCE],
-          (uint16_t) SBytes);
-      bufferPtr +=
-        basiclist.FillBuffer(buffer + bufferPtr, brst_start[BSTATS_SOURCE], burst_count[BSTATS_SOURCE],
-          (uint16_t) SStart);
-      bufferPtr +=
-        basiclist.FillBuffer(buffer + bufferPtr, brst_end[BSTATS_SOURCE], burst_count[BSTATS_SOURCE], (uint16_t) SStop);
+        if (req_size > size) {
+            return -1;
+        }
+        // Fill buffer
+        bufferPtr = basiclist.FillBuffer(
+            buffer,
+            brst_pkts[BSTATS_SOURCE],
+            burst_count[BSTATS_SOURCE],
+            (uint16_t) SPkts);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_bytes[BSTATS_SOURCE],
+            burst_count[BSTATS_SOURCE],
+            (uint16_t) SBytes);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_start[BSTATS_SOURCE],
+            burst_count[BSTATS_SOURCE],
+            (uint16_t) SStart);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_end[BSTATS_SOURCE],
+            burst_count[BSTATS_SOURCE],
+            (uint16_t) SStop);
 
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, brst_pkts[BSTATS_DEST], burst_count[BSTATS_DEST],
-          (uint16_t) DPkts);
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, brst_bytes[BSTATS_DEST], burst_count[BSTATS_DEST],
-          (uint16_t) DBytes);
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, brst_start[BSTATS_DEST], burst_count[BSTATS_DEST],
-          (uint16_t) DStart);
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, brst_end[BSTATS_DEST], burst_count[BSTATS_DEST],
-          (uint16_t) DStop);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_pkts[BSTATS_DEST],
+            burst_count[BSTATS_DEST],
+            (uint16_t) DPkts);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_bytes[BSTATS_DEST],
+            burst_count[BSTATS_DEST],
+            (uint16_t) DBytes);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_start[BSTATS_DEST],
+            burst_count[BSTATS_DEST],
+            (uint16_t) DStart);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            brst_end[BSTATS_DEST],
+            burst_count[BSTATS_DEST],
+            (uint16_t) DStop);
 
-      return bufferPtr;
-   }
+        return bufferPtr;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_BSTATS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_tmplt;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_BSTATS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      char dirs_c[2] = {'s', 'd'};
-      int dirs[2] = {BSTATS_SOURCE, BSTATS_DEST};
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        char dirs_c[2] = {'s', 'd'};
+        int dirs[2] = {BSTATS_SOURCE, BSTATS_DEST};
 
-      for (int j = 0; j < 2; j++) {
-         int dir = dirs[j];
-         out << dirs_c[j] << "burstpkts=(";
-         for (int i = 0; i < burst_count[dir]; i++) {
-            out << brst_pkts[dir][i];
-            if (i != burst_count[dir] - 1) {
-               out << ",";
+        for (int j = 0; j < 2; j++) {
+            int dir = dirs[j];
+            out << dirs_c[j] << "burstpkts=(";
+            for (int i = 0; i < burst_count[dir]; i++) {
+                out << brst_pkts[dir][i];
+                if (i != burst_count[dir] - 1) {
+                    out << ",";
+                }
             }
-         }
-         out << ")," << dirs_c[j] << "burstbytes=(";
-         for (int i = 0; i < burst_count[dir]; i++) {
-            out << brst_bytes[dir][i];
-            if (i != burst_count[dir] - 1) {
-               out << ",";
+            out << ")," << dirs_c[j] << "burstbytes=(";
+            for (int i = 0; i < burst_count[dir]; i++) {
+                out << brst_bytes[dir][i];
+                if (i != burst_count[dir] - 1) {
+                    out << ",";
+                }
             }
-         }
-         out << ")," << dirs_c[j] << "bursttime=(";
-         for (int i = 0; i < burst_count[dir]; i++) {
-            struct timeval start = brst_start[dir][i];
-            struct timeval end = brst_end[dir][i];
-            out << start.tv_sec << "." << start.tv_usec << "-" << end.tv_sec << "." << end.tv_usec;
-            if (i != burst_count[dir] - 1) {
-               out << ",";
+            out << ")," << dirs_c[j] << "bursttime=(";
+            for (int i = 0; i < burst_count[dir]; i++) {
+                struct timeval start = brst_start[dir][i];
+                struct timeval end = brst_end[dir][i];
+                out << start.tv_sec << "." << start.tv_usec << "-" << end.tv_sec << "."
+                    << end.tv_usec;
+                if (i != burst_count[dir] - 1) {
+                    out << ",";
+                }
             }
-         }
-         out << "),";
-      }
+            out << "),";
+        }
 
-      return out.str();
-   }
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing BSTATS packets.
  */
-class BSTATSPlugin : public ProcessPlugin
-{
+class BSTATSPlugin : public ProcessPlugin {
 public:
-   BSTATSPlugin();
-   ~BSTATSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("bstats", "Compute packet bursts stats"); }
-   std::string get_name() const { return "bstats"; }
-   RecordExt *get_ext() const { return new RecordExtBSTATS(); }
-   ProcessPlugin *copy();
+    BSTATSPlugin();
+    ~BSTATSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser("bstats", "Compute packet bursts stats");
+    }
+    std::string get_name() const { return "bstats"; }
+    RecordExt* get_ext() const { return new RecordExtBSTATS(); }
+    ProcessPlugin* copy();
 
-   int pre_create(Packet &pkt);
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void pre_export(Flow &rec);
+    int pre_create(Packet& pkt);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void pre_export(Flow& rec);
 
-   static const struct timeval min_packet_in_burst;
+    static const struct timeval min_packet_in_burst;
 
 private:
-   void initialize_new_burst(RecordExtBSTATS *bstats_record, uint8_t direction, const Packet &pkt);
-   void process_bursts(RecordExtBSTATS *bstats_record, uint8_t direction, const Packet &pkt);
-   void update_record(RecordExtBSTATS *bstats_record, const Packet &pkt);
-   bool isLastRecordBurst(RecordExtBSTATS *bstats_record, uint8_t direction);
-   bool belogsToLastRecord(RecordExtBSTATS *bstats_record, uint8_t direction, const Packet &pkt);
+    void initialize_new_burst(RecordExtBSTATS* bstats_record, uint8_t direction, const Packet& pkt);
+    void process_bursts(RecordExtBSTATS* bstats_record, uint8_t direction, const Packet& pkt);
+    void update_record(RecordExtBSTATS* bstats_record, const Packet& pkt);
+    bool isLastRecordBurst(RecordExtBSTATS* bstats_record, uint8_t direction);
+    bool belogsToLastRecord(RecordExtBSTATS* bstats_record, uint8_t direction, const Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_BSTATS_HPP */

--- a/process/common.hpp
+++ b/process/common.hpp
@@ -35,7 +35,7 @@ namespace ipxp {
 
 static inline bool check_payload_len(size_t payload_len, size_t required_len) noexcept
 {
-   return payload_len < required_len;
+    return payload_len < required_len;
 }
 
 /**
@@ -45,31 +45,30 @@ static inline bool check_payload_len(size_t payload_len, size_t required_len) no
  * \param str1 C string to be scanned.
  * \param str2 C string containing the sequence of characters to match.
  * \param len Number of bytes to be analyzed.
- * 
+ *
  * \return A pointer to the first occurrence of string in str1.
  *         If the string is not found, the function returns a null pointer.
  */
-static inline const char *
-strnstr(const char *str1, const char *str2, size_t len) noexcept
+static inline const char* strnstr(const char* str1, const char* str2, size_t len) noexcept
 {
-   char c, sc;
-   size_t slen;
+    char c, sc;
+    size_t slen;
 
-   if ((c = *str2++) != '\0') {
-      slen = strlen(str2);
-      do {
-         do {
-            if (len-- < 1 || (sc = *str1++) == '\0')
-               return (NULL);
-         } while (sc != c);
-         if (slen > len)
-            return (NULL);
-      } while (strncmp(str1, str2, slen) != 0);
-      str1--;
-   }
-   return ((char *)str1);
+    if ((c = *str2++) != '\0') {
+        slen = strlen(str2);
+        do {
+            do {
+                if (len-- < 1 || (sc = *str1++) == '\0')
+                    return (NULL);
+            } while (sc != c);
+            if (slen > len)
+                return (NULL);
+        } while (strncmp(str1, str2, slen) != 0);
+        str1--;
+    }
+    return ((char*) str1);
 }
 
-}
+} // namespace ipxp
 
 #endif /* IPXP_PROCESS_COMMON_HPP */

--- a/process/dns-utils.hpp
+++ b/process/dns-utils.hpp
@@ -29,163 +29,163 @@
 #ifndef IPXP_PROCESS_DNS_UTILS_HPP
 #define IPXP_PROCESS_DNS_UTILS_HPP
 
-#include <stdint.h>
 #include <endian.h>
+#include <stdint.h>
 
 namespace ipxp {
 
-#define DNS_TYPE_A      1
-#define DNS_TYPE_NS     2
-#define DNS_TYPE_CNAME  5
-#define DNS_TYPE_SOA    6
-#define DNS_TYPE_PTR    12
-#define DNS_TYPE_HINFO  13
-#define DNS_TYPE_MINFO  14
-#define DNS_TYPE_MX     15
-#define DNS_TYPE_TXT    16
-#define DNS_TYPE_ISDN   20
-#define DNS_TYPE_AAAA   28
-#define DNS_TYPE_SRV    33
-#define DNS_TYPE_DNAME  39
-#define DNS_TYPE_DS     43
-#define DNS_TYPE_RRSIG  46
+#define DNS_TYPE_A 1
+#define DNS_TYPE_NS 2
+#define DNS_TYPE_CNAME 5
+#define DNS_TYPE_SOA 6
+#define DNS_TYPE_PTR 12
+#define DNS_TYPE_HINFO 13
+#define DNS_TYPE_MINFO 14
+#define DNS_TYPE_MX 15
+#define DNS_TYPE_TXT 16
+#define DNS_TYPE_ISDN 20
+#define DNS_TYPE_AAAA 28
+#define DNS_TYPE_SRV 33
+#define DNS_TYPE_DNAME 39
+#define DNS_TYPE_DS 43
+#define DNS_TYPE_RRSIG 46
 #define DNS_TYPE_DNSKEY 48
 
-#define DNS_TYPE_OPT    41
+#define DNS_TYPE_OPT 41
 
-#define DNS_HDR_GET_QR(flags)       (((flags) & (0x1 << 15)) >> 15) // Return question/answer bit.
-#define DNS_HDR_GET_OPCODE(flags)   (((flags) & (0xF << 11)) >> 11) // Return opcode bits.
-#define DNS_HDR_GET_AA(flags)       (((flags) & (0x1 << 10)) >> 10) // Return authoritative answer bit.
-#define DNS_HDR_GET_TC(flags)       (((flags) & (0x1 << 9)) >> 9) // Return truncation bit.
-#define DNS_HDR_GET_RD(flags)       (((flags) & (0x1 << 8)) >> 8) // Return recursion desired bit.
-#define DNS_HDR_GET_RA(flags)       (((flags) & (0x1 << 7)) >> 7) // Return recursion available bit.
-#define DNS_HDR_GET_Z(flags)        (((flags) & (0x1 << 6)) >> 6) // Return reserved bit.
-#define DNS_HDR_GET_AD(flags)       (((flags) & (0x1 << 5)) >> 5) // Return authentication data bit.
-#define DNS_HDR_GET_CD(flags)       (((flags) & (0x1 << 4)) >> 4) // Return checking disabled bit.
-#define DNS_HDR_GET_RESPCODE(flags) ((flags) & 0xF) // Return response code bits.
+#define DNS_HDR_GET_QR(flags) (((flags) & (0x1 << 15)) >> 15) // Return question/answer bit.
+#define DNS_HDR_GET_OPCODE(flags) (((flags) & (0xF << 11)) >> 11) // Return opcode bits.
+#define DNS_HDR_GET_AA(flags) (((flags) & (0x1 << 10)) >> 10) // Return authoritative answer bit.
+#define DNS_HDR_GET_TC(flags) (((flags) & (0x1 << 9)) >> 9) // Return truncation bit.
+#define DNS_HDR_GET_RD(flags) (((flags) & (0x1 << 8)) >> 8) // Return recursion desired bit.
+#define DNS_HDR_GET_RA(flags) (((flags) & (0x1 << 7)) >> 7) // Return recursion available bit.
+#define DNS_HDR_GET_Z(flags) (((flags) & (0x1 << 6)) >> 6) // Return reserved bit.
+#define DNS_HDR_GET_AD(flags) (((flags) & (0x1 << 5)) >> 5) // Return authentication data bit.
+#define DNS_HDR_GET_CD(flags) (((flags) & (0x1 << 4)) >> 4) // Return checking disabled bit.
+#define DNS_HDR_GET_RESPCODE(flags) ((flags) &0xF) // Return response code bits.
 
 #define DNS_HDR_LENGTH 12
 
 /**
  * \brief Struct containing DNS header fields.
  */
-struct __attribute__ ((packed)) dns_hdr {
-   uint16_t id;
-   union {
-      struct {
+struct __attribute__((packed)) dns_hdr {
+    uint16_t id;
+    union {
+        struct {
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-         uint16_t recursion_desired:1;
-         uint16_t truncation:1;
-         uint16_t authoritative_answer:1;
-         uint16_t op_code:4;
-         uint16_t query_response:1;
-         uint16_t response_code:4;
-         uint16_t checking_disabled:1;
-         uint16_t auth_data:1;
-         uint16_t reserved:1;
-         uint16_t recursion_available:1;
+            uint16_t recursion_desired : 1;
+            uint16_t truncation : 1;
+            uint16_t authoritative_answer : 1;
+            uint16_t op_code : 4;
+            uint16_t query_response : 1;
+            uint16_t response_code : 4;
+            uint16_t checking_disabled : 1;
+            uint16_t auth_data : 1;
+            uint16_t reserved : 1;
+            uint16_t recursion_available : 1;
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-         uint16_t query_response:1;
-         uint16_t op_code:4;
-         uint16_t authoritative_answer:1;
-         uint16_t truncation:1;
-         uint16_t recursion_desired:1;
-         uint16_t recursion_available:1;
-         uint16_t reserved:1;
-         uint16_t auth_data:1;
-         uint16_t checking_disabled:1;
-         uint16_t response_code:4;
-# else
-#  error  "Please fix <endian.h>"
-# endif
-      };
-      uint16_t flags;
-   };
-   uint16_t question_rec_cnt;
-   uint16_t answer_rec_cnt;
-   uint16_t name_server_rec_cnt;
-   uint16_t additional_rec_cnt;
+            uint16_t query_response : 1;
+            uint16_t op_code : 4;
+            uint16_t authoritative_answer : 1;
+            uint16_t truncation : 1;
+            uint16_t recursion_desired : 1;
+            uint16_t recursion_available : 1;
+            uint16_t reserved : 1;
+            uint16_t auth_data : 1;
+            uint16_t checking_disabled : 1;
+            uint16_t response_code : 4;
+#else
+#error "Please fix <endian.h>"
+#endif
+        };
+        uint16_t flags;
+    };
+    uint16_t question_rec_cnt;
+    uint16_t answer_rec_cnt;
+    uint16_t name_server_rec_cnt;
+    uint16_t additional_rec_cnt;
 };
 
 /**
  * \brief Struct containing DNS question.
  */
-struct __attribute__ ((packed)) dns_question {
-   /* name */
-   uint16_t qtype;
-   uint16_t qclass;
+struct __attribute__((packed)) dns_question {
+    /* name */
+    uint16_t qtype;
+    uint16_t qclass;
 };
 
 /**
  * \brief Struct containing DNS answer.
  */
-struct __attribute__ ((packed)) dns_answer {
-   /* name */
-   uint16_t atype;
-   uint16_t aclass;
-   uint32_t ttl;
-   uint16_t rdlength;
-   /* rdata */
+struct __attribute__((packed)) dns_answer {
+    /* name */
+    uint16_t atype;
+    uint16_t aclass;
+    uint32_t ttl;
+    uint16_t rdlength;
+    /* rdata */
 };
 
 /**
  * \brief Struct containing DNS SOA record.
  */
-struct __attribute__ ((packed)) dns_soa {
-   /* primary NS */
-   /* admin MB */
-   uint32_t serial;
-   uint32_t refresh;
-   uint32_t retry;
-   uint32_t expiration;
-   uint32_t ttl;
+struct __attribute__((packed)) dns_soa {
+    /* primary NS */
+    /* admin MB */
+    uint32_t serial;
+    uint32_t refresh;
+    uint32_t retry;
+    uint32_t expiration;
+    uint32_t ttl;
 };
 
 /**
  * \brief Struct containing DNS SRV record.
  */
-struct __attribute__ ((packed)) dns_srv {
-   /* _service._proto.name*/
-   uint16_t priority;
-   uint16_t weight;
-   uint16_t port;
-   /* target */
+struct __attribute__((packed)) dns_srv {
+    /* _service._proto.name*/
+    uint16_t priority;
+    uint16_t weight;
+    uint16_t port;
+    /* target */
 };
 
 /**
  * \brief Struct containing DNS DS record.
  */
-struct __attribute__ ((packed)) dns_ds {
-   uint16_t keytag;
-   uint8_t algorithm;
-   uint8_t digest_type;
-   /* digest */
+struct __attribute__((packed)) dns_ds {
+    uint16_t keytag;
+    uint8_t algorithm;
+    uint8_t digest_type;
+    /* digest */
 };
 
 /**
  * \brief Struct containing DNS RRSIG record.
  */
-struct __attribute__ ((packed)) dns_rrsig {
-   uint16_t type;
-   uint8_t algorithm;
-   uint8_t labels;
-   uint32_t ttl;
-   uint32_t sig_expiration;
-   uint32_t sig_inception;
-   uint16_t keytag;
-   /* signer's name */
-   /* signature */
+struct __attribute__((packed)) dns_rrsig {
+    uint16_t type;
+    uint8_t algorithm;
+    uint8_t labels;
+    uint32_t ttl;
+    uint32_t sig_expiration;
+    uint32_t sig_inception;
+    uint16_t keytag;
+    /* signer's name */
+    /* signature */
 };
 
 /**
  * \brief Struct containing DNS DNSKEY record.
  */
-struct __attribute__ ((packed)) dns_dnskey {
-   uint16_t flags;
-   uint8_t protocol;
-   uint8_t algorithm;
-   /* public key */
+struct __attribute__((packed)) dns_dnskey {
+    uint16_t flags;
+    uint8_t protocol;
+    uint8_t algorithm;
+    /* public key */
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_DNS_UTILS_HPP */

--- a/process/dns.cpp
+++ b/process/dns.cpp
@@ -27,11 +27,11 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <arpa/inet.h>
 #include <iostream>
 #include <sstream>
-#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #ifdef WITH_NEMEA
 #include <unirec/unirec.h>
@@ -45,12 +45,12 @@ int RecordExtDNS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("dns", [](){return new DNSPlugin();});
-   register_plugin(&rec);
-   RecordExtDNS::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("dns", []() { return new DNSPlugin(); });
+    register_plugin(&rec);
+    RecordExtDNS::REGISTERED_ID = register_extension();
 }
 
-//#define DEBUG_DNS
+// #define DEBUG_DNS
 
 // Print debug message if debugging is allowed.
 #ifdef DEBUG_DNS
@@ -76,62 +76,75 @@ __attribute__((constructor)) static void register_this_plugin()
 /**
  * \brief Get offset from 2 byte pointer.
  */
-#define GET_OFFSET(half1, half2) ((((uint8_t)(half1) & 0x3F) << 8) | (uint8_t)(half2))
+#define GET_OFFSET(half1, half2) ((((uint8_t) (half1) &0x3F) << 8) | (uint8_t) (half2))
 
-DNSPlugin::DNSPlugin() : queries(0), responses(0), total(0), data_begin(nullptr), data_len(0)
+DNSPlugin::DNSPlugin()
+    : queries(0)
+    , responses(0)
+    , total(0)
+    , data_begin(nullptr)
+    , data_len(0)
 {
 }
 
 DNSPlugin::~DNSPlugin()
 {
-   close();
+    close();
 }
 
-void DNSPlugin::init(const char *params)
+void DNSPlugin::init(const char* params) {}
+
+void DNSPlugin::close() {}
+
+ProcessPlugin* DNSPlugin::copy()
 {
+    return new DNSPlugin(*this);
 }
 
-void DNSPlugin::close()
+int DNSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
+    if (pkt.dst_port == 53 || pkt.src_port == 53) {
+        return add_ext_dns(
+            reinterpret_cast<const char*>(pkt.payload),
+            pkt.payload_len,
+            pkt.ip_proto == IPPROTO_TCP,
+            rec);
+    }
+
+    return 0;
 }
 
-ProcessPlugin *DNSPlugin::copy()
+int DNSPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   return new DNSPlugin(*this);
-}
+    if (pkt.dst_port == 53 || pkt.src_port == 53) {
+        RecordExt* ext = rec.get_extension(RecordExtDNS::REGISTERED_ID);
+        if (ext == nullptr) {
+            return add_ext_dns(
+                reinterpret_cast<const char*>(pkt.payload),
+                pkt.payload_len,
+                pkt.ip_proto == IPPROTO_TCP,
+                rec);
+        } else {
+            parse_dns(
+                reinterpret_cast<const char*>(pkt.payload),
+                pkt.payload_len,
+                pkt.ip_proto == IPPROTO_TCP,
+                static_cast<RecordExtDNS*>(ext));
+        }
+        return FLOW_FLUSH;
+    }
 
-int DNSPlugin::post_create(Flow &rec, const Packet &pkt)
-{
-   if (pkt.dst_port == 53 || pkt.src_port == 53) {
-      return add_ext_dns(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.ip_proto == IPPROTO_TCP, rec);
-   }
-
-   return 0;
-}
-
-int DNSPlugin::post_update(Flow &rec, const Packet &pkt)
-{
-   if (pkt.dst_port == 53 || pkt.src_port == 53) {
-      RecordExt *ext = rec.get_extension(RecordExtDNS::REGISTERED_ID);
-      if (ext == nullptr) {
-         return add_ext_dns(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.ip_proto == IPPROTO_TCP, rec);
-      } else {
-         parse_dns(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.ip_proto == IPPROTO_TCP, static_cast<RecordExtDNS *>(ext));
-      }
-      return FLOW_FLUSH;
-   }
-
-   return 0;
+    return 0;
 }
 
 void DNSPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "DNS plugin stats:" << std::endl;
-      std::cout << "   Parsed dns queries: " << queries << std::endl;
-      std::cout << "   Parsed dns responses: " << responses << std::endl;
-      std::cout << "   Total dns packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "DNS plugin stats:" << std::endl;
+        std::cout << "   Parsed dns queries: " << queries << std::endl;
+        std::cout << "   Parsed dns responses: " << responses << std::endl;
+        std::cout << "   Total dns packets processed: " << total << std::endl;
+    }
 }
 
 /**
@@ -139,26 +152,26 @@ void DNSPlugin::finish(bool print_stats)
  * \param [in] data Pointer to string.
  * \return Number of characters in string.
  */
-size_t DNSPlugin::get_name_length(const char *data) const
+size_t DNSPlugin::get_name_length(const char* data) const
 {
-   size_t len = 0;
+    size_t len = 0;
 
-   while (1) {
-      if ((uint32_t) (data - data_begin) + 1 > data_len) {
-         throw "Error: overflow";
-      }
-      if (!data[0]) {
-         break;
-      }
-      if (IS_POINTER(data[0])) {
-         return len + 2;
-      }
+    while (1) {
+        if ((uint32_t) (data - data_begin) + 1 > data_len) {
+            throw "Error: overflow";
+        }
+        if (!data[0]) {
+            break;
+        }
+        if (IS_POINTER(data[0])) {
+            return len + 2;
+        }
 
-      len += (uint8_t) data[0] + 1;
-      data += (uint8_t) data[0] + 1;
-   }
+        len += (uint8_t) data[0] + 1;
+        data += (uint8_t) data[0] + 1;
+    }
 
-   return len + 1;
+    return len + 1;
 }
 
 /**
@@ -166,69 +179,69 @@ size_t DNSPlugin::get_name_length(const char *data) const
  * \param [in] data Pointer to compressed data.
  * \return String with decompressed dns name.
  */
-std::string DNSPlugin::get_name(const char *data) const
+std::string DNSPlugin::get_name(const char* data) const
 {
-   std::string name = "";
-   int label_cnt = 0;
+    std::string name = "";
+    int label_cnt = 0;
 
-   if ((uint32_t) (data - data_begin) > data_len) {
-      throw "Error: overflow";
-   }
+    if ((uint32_t) (data - data_begin) > data_len) {
+        throw "Error: overflow";
+    }
 
-   while (data[0]) { /* Check for terminating character. */
-      if (IS_POINTER(data[0])) { /* Check for label pointer (11xxxxxx byte) */
-         data = data_begin + GET_OFFSET(data[0], data[1]);
+    while (data[0]) { /* Check for terminating character. */
+        if (IS_POINTER(data[0])) { /* Check for label pointer (11xxxxxx byte) */
+            data = data_begin + GET_OFFSET(data[0], data[1]);
 
-         /* Check for possible errors.*/
-         if (label_cnt++ > MAX_LABEL_CNT || (uint32_t) (data - data_begin) > data_len) {
+            /* Check for possible errors.*/
+            if (label_cnt++ > MAX_LABEL_CNT || (uint32_t) (data - data_begin) > data_len) {
+                throw "Error: label count exceed or overflow";
+            }
+
+            continue;
+        }
+
+        /* Check for possible errors.*/
+        if (label_cnt++ > MAX_LABEL_CNT || (uint8_t) data[0] > 63
+            || (uint32_t) ((data - data_begin) + (uint8_t) data[0] + 2) > data_len) {
             throw "Error: label count exceed or overflow";
-         }
+        }
 
-         continue;
-      }
+        name += '.' + std::string(data + 1, (uint8_t) data[0]);
+        data += ((uint8_t) data[0] + 1);
+    }
 
-      /* Check for possible errors.*/
-      if (label_cnt++ > MAX_LABEL_CNT || (uint8_t) data[0] > 63 ||
-         (uint32_t) ((data - data_begin) + (uint8_t) data[0] + 2) > data_len) {
-         throw "Error: label count exceed or overflow";
-      }
+    if (name[0] == '.') {
+        name.erase(0, 1);
+    }
 
-      name += '.' + std::string(data + 1, (uint8_t) data[0]);
-      data += ((uint8_t) data[0] + 1);
-   }
-
-   if (name[0] == '.') {
-      name.erase(0, 1);
-   }
-
-   return name;
+    return name;
 }
 
 /**
  * \brief Process SRV strings.
  * \param [in,out] str Raw SRV string.
  */
-void DNSPlugin::process_srv(std::string &str) const
+void DNSPlugin::process_srv(std::string& str) const
 {
-   bool underline_found = false;
-   for (int i = 0; str[i]; i++) {
-      if (str[i] == '_') {
-         str.erase(i--, 1);
-         if (underline_found) {
-            break;
-         }
-         underline_found = true;
-      }
-   }
-   size_t pos = str.find('.');
-   if (pos != std::string::npos) {
-      str[pos] = ' ';
+    bool underline_found = false;
+    for (int i = 0; str[i]; i++) {
+        if (str[i] == '_') {
+            str.erase(i--, 1);
+            if (underline_found) {
+                break;
+            }
+            underline_found = true;
+        }
+    }
+    size_t pos = str.find('.');
+    if (pos != std::string::npos) {
+        str[pos] = ' ';
 
-      pos = str.find('.', pos);
-      if (pos != std::string::npos) {
-         str[pos] = ' ';
-      }
-   }
+        pos = str.find('.', pos);
+        if (pos != std::string::npos) {
+            str[pos] = ' ';
+        }
+    }
 }
 
 /**
@@ -239,180 +252,172 @@ void DNSPlugin::process_srv(std::string &str) const
  * \param [in] type Type of RDATA section.
  * \param [in] length Length of RDATA section.
  */
-void DNSPlugin::process_rdata(const char *record_begin, const char *data, std::ostringstream &rdata, uint16_t type, size_t length) const
+void DNSPlugin::process_rdata(
+    const char* record_begin,
+    const char* data,
+    std::ostringstream& rdata,
+    uint16_t type,
+    size_t length) const
 {
-   rdata.str("");
-   rdata.clear();
+    rdata.str("");
+    rdata.clear();
 
-   switch (type){
-   case DNS_TYPE_A:
-      rdata << inet_ntoa(*(struct in_addr *) (data));
-      DEBUG_MSG("\tData A:\t\t\t%s\n",       rdata.str().c_str());
-      break;
-   case DNS_TYPE_AAAA:
-      {
-         char addr[INET6_ADDRSTRLEN];
-         inet_ntop(AF_INET6, (const void *) data, addr, INET6_ADDRSTRLEN);
-         rdata << addr;
-         DEBUG_MSG("\tData AAAA:\t\t%s\n",   rdata.str().c_str());
-      }
-      break;
-   case DNS_TYPE_NS:
-      rdata << get_name(data);
-      DEBUG_MSG("\tData NS:\t\t\t%s\n",      rdata.str().c_str());
-      break;
-   case DNS_TYPE_CNAME:
-      rdata << get_name(data);
-      DEBUG_MSG("\tData CNAME:\t\t%s\n",     rdata.str().c_str());
-      break;
-   case DNS_TYPE_PTR:
-      rdata << get_name(data);
-      DEBUG_MSG("\tData PTR:\t\t%s\n",       rdata.str().c_str());
-      break;
-   case DNS_TYPE_DNAME:
-      rdata << get_name(data);
-      DEBUG_MSG("\tData DNAME:\t\t%s\n",     rdata.str().c_str());
-      break;
-   case DNS_TYPE_SOA:
-      {
-         rdata << get_name(data);
-         data += get_name_length(data);
-         std::string tmp = get_name(data);
-         data += get_name_length(data);
+    switch (type) {
+    case DNS_TYPE_A:
+        rdata << inet_ntoa(*(struct in_addr*) (data));
+        DEBUG_MSG("\tData A:\t\t\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_AAAA: {
+        char addr[INET6_ADDRSTRLEN];
+        inet_ntop(AF_INET6, (const void*) data, addr, INET6_ADDRSTRLEN);
+        rdata << addr;
+        DEBUG_MSG("\tData AAAA:\t\t%s\n", rdata.str().c_str());
+    } break;
+    case DNS_TYPE_NS:
+        rdata << get_name(data);
+        DEBUG_MSG("\tData NS:\t\t\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_CNAME:
+        rdata << get_name(data);
+        DEBUG_MSG("\tData CNAME:\t\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_PTR:
+        rdata << get_name(data);
+        DEBUG_MSG("\tData PTR:\t\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_DNAME:
+        rdata << get_name(data);
+        DEBUG_MSG("\tData DNAME:\t\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_SOA: {
+        rdata << get_name(data);
+        data += get_name_length(data);
+        std::string tmp = get_name(data);
+        data += get_name_length(data);
 
-         DEBUG_MSG("\t\tMName:\t\t%s\n",     rdata.str().c_str());
-         DEBUG_MSG("\t\tRName:\t\t%s\n",     tmp.c_str());
+        DEBUG_MSG("\t\tMName:\t\t%s\n", rdata.str().c_str());
+        DEBUG_MSG("\t\tRName:\t\t%s\n", tmp.c_str());
 
-         rdata << " " << tmp;
+        rdata << " " << tmp;
 
-         struct dns_soa *soa = (struct dns_soa *) data;
-         DEBUG_MSG("\t\tSerial:\t\t%u\n",    ntohl(soa->serial));
-         DEBUG_MSG("\t\tRefresh:\t%u\n",     ntohl(soa->refresh));
-         DEBUG_MSG("\t\tRetry:\t\t%u\n",     ntohl(soa->retry));
-         DEBUG_MSG("\t\tExpiration:\t%u\n",  ntohl(soa->expiration));
-         DEBUG_MSG("\t\tMin TTL:\t%u\n",     ntohl(soa->ttl));
-         rdata << " " << ntohl(soa->serial) << " " << ntohl(soa->refresh) << " "
-               << ntohl(soa->retry) << " " << ntohl(soa->expiration) << " " << ntohl(soa->ttl);
-      }
-      break;
-   case DNS_TYPE_SRV:
-      {
-         DEBUG_MSG("\tData SRV:\n");
-         std::string tmp = get_name(record_begin);
-         process_srv(tmp);
-         struct dns_srv *srv = (struct dns_srv *) data;
+        struct dns_soa* soa = (struct dns_soa*) data;
+        DEBUG_MSG("\t\tSerial:\t\t%u\n", ntohl(soa->serial));
+        DEBUG_MSG("\t\tRefresh:\t%u\n", ntohl(soa->refresh));
+        DEBUG_MSG("\t\tRetry:\t\t%u\n", ntohl(soa->retry));
+        DEBUG_MSG("\t\tExpiration:\t%u\n", ntohl(soa->expiration));
+        DEBUG_MSG("\t\tMin TTL:\t%u\n", ntohl(soa->ttl));
+        rdata << " " << ntohl(soa->serial) << " " << ntohl(soa->refresh) << " " << ntohl(soa->retry)
+              << " " << ntohl(soa->expiration) << " " << ntohl(soa->ttl);
+    } break;
+    case DNS_TYPE_SRV: {
+        DEBUG_MSG("\tData SRV:\n");
+        std::string tmp = get_name(record_begin);
+        process_srv(tmp);
+        struct dns_srv* srv = (struct dns_srv*) data;
 
-         DEBUG_MSG("\t\tPriority:\t%u\n",    ntohs(srv->priority));
-         DEBUG_MSG("\t\tWeight:\t\t%u\n",    ntohs(srv->weight));
-         DEBUG_MSG("\t\tPort:\t\t%u\n",      ntohs(srv->port));
+        DEBUG_MSG("\t\tPriority:\t%u\n", ntohs(srv->priority));
+        DEBUG_MSG("\t\tWeight:\t\t%u\n", ntohs(srv->weight));
+        DEBUG_MSG("\t\tPort:\t\t%u\n", ntohs(srv->port));
 
-         rdata << tmp << " ";
-         tmp = get_name(data + 6);
+        rdata << tmp << " ";
+        tmp = get_name(data + 6);
 
-         DEBUG_MSG("\t\tTarget:\t\t%s\n", tmp.c_str());
-         rdata << tmp << " " << ntohs(srv->priority) << " " <<  ntohs(srv->weight) << " " << ntohs(srv->port);
-      }
-      break;
-   case DNS_TYPE_MX:
-      {
-         uint16_t preference = ntohs(*(uint16_t *) data);
-         rdata << preference << " " << get_name(data + 2);
-         DEBUG_MSG("\tData MX:\n");
-         DEBUG_MSG("\t\tPreference:\t%u\n",     preference);
-         DEBUG_MSG("\t\tMail exchanger:\t%s\n", get_name(data + 2).c_str());
-      }
-      break;
-   case DNS_TYPE_TXT:
-      {
-         DEBUG_MSG("\tData TXT:\n");
+        DEBUG_MSG("\t\tTarget:\t\t%s\n", tmp.c_str());
+        rdata << tmp << " " << ntohs(srv->priority) << " " << ntohs(srv->weight) << " "
+              << ntohs(srv->port);
+    } break;
+    case DNS_TYPE_MX: {
+        uint16_t preference = ntohs(*(uint16_t*) data);
+        rdata << preference << " " << get_name(data + 2);
+        DEBUG_MSG("\tData MX:\n");
+        DEBUG_MSG("\t\tPreference:\t%u\n", preference);
+        DEBUG_MSG("\t\tMail exchanger:\t%s\n", get_name(data + 2).c_str());
+    } break;
+    case DNS_TYPE_TXT: {
+        DEBUG_MSG("\tData TXT:\n");
 
-         size_t len = (uint8_t) *(data++);
-         size_t total_len = len + 1;
+        size_t len = (uint8_t) * (data++);
+        size_t total_len = len + 1;
 
-         while (length != 0 && total_len <= length) {
-            DEBUG_MSG("\t\tTXT data:\t%s\n",    std::string(data, len).c_str());
+        while (length != 0 && total_len <= length) {
+            DEBUG_MSG("\t\tTXT data:\t%s\n", std::string(data, len).c_str());
             rdata << std::string(data, len);
 
             data += len;
-            len = (uint8_t) *(data++);
+            len = (uint8_t) * (data++);
             total_len += len + 1;
 
             if (total_len <= length) {
-               rdata << " ";
+                rdata << " ";
             }
-         }
-      }
-      break;
-   case DNS_TYPE_MINFO:
-      DEBUG_MSG("\tData MINFO:\n");
-      rdata << get_name(data);
-      DEBUG_MSG("\t\tRMAILBX:\t%s\n",  rdata.str().c_str());
-      data += get_name_length(data);
+        }
+    } break;
+    case DNS_TYPE_MINFO:
+        DEBUG_MSG("\tData MINFO:\n");
+        rdata << get_name(data);
+        DEBUG_MSG("\t\tRMAILBX:\t%s\n", rdata.str().c_str());
+        data += get_name_length(data);
 
-      rdata << get_name(data);
-      DEBUG_MSG("\t\tEMAILBX:\t%s\n",  get_name(data).c_str());
-      break;
-   case DNS_TYPE_HINFO:
-      DEBUG_MSG("\tData HINFO:\n");
-      rdata << std::string(data, length);
-      DEBUG_MSG("\t\tData:\t%s\n", rdata.str().c_str());
-      break;
-   case DNS_TYPE_ISDN:
-      DEBUG_MSG("\tData ISDN:\n");
-      rdata << std::string(data, length);
-      DEBUG_MSG("\t\tData:\t%s\n", rdata.str().c_str());
-      break;
-   case DNS_TYPE_DS:
-      {
-         struct dns_ds *ds = (struct dns_ds *) data;
-         DEBUG_MSG("\tData DS:\n");
-         DEBUG_MSG("\t\tKey tag:\t%u\n",        ntohs(ds->keytag));
-         DEBUG_MSG("\t\tAlgorithm:\t%u\n",      ds->algorithm);
-         DEBUG_MSG("\t\tDigest type:\t%u\n",    ds->digest_type);
-         DEBUG_MSG("\t\tDigest:\t\t(binary)\n");
-         rdata << ntohs(ds->keytag) << " " << (uint16_t) ds->keytag << " "
-               << (uint16_t) ds->digest_type << " <key>";
-      }
-      break;
-   case DNS_TYPE_RRSIG:
-      {
-         struct dns_rrsig *rrsig = (struct dns_rrsig *) data;
-         std::string tmp = "";
-         DEBUG_MSG("\tData RRSIG:\n");
-         DEBUG_MSG("\t\tType:\t\t%u\n",         ntohs(rrsig->type));
-         DEBUG_MSG("\t\tAlgorithm:\t%u\n",      rrsig->algorithm);
-         DEBUG_MSG("\t\tLabels:\t\t%u\n",       rrsig->labels);
-         DEBUG_MSG("\t\tTTL:\t\t%u\n",          ntohl(rrsig->ttl));
-         DEBUG_MSG("\t\tSig expiration:\t%u\n", ntohl(rrsig->sig_expiration));
-         DEBUG_MSG("\t\tSig inception:\t%u\n",  ntohl(rrsig->sig_inception));
-         DEBUG_MSG("\t\tKey tag:\t%u\n",        ntohs(rrsig->keytag));
-         rdata << ntohs(rrsig->type) << " " << (uint16_t) rrsig->algorithm << " " // Conversion needed, otherwise uint8_t will be threated as a char.
-               << (uint16_t) rrsig->labels << " " << ntohl(rrsig->ttl) << " "
-               << ntohl(rrsig->sig_expiration) << " " << ntohl(rrsig->sig_inception)
-               << " " << ntohs(rrsig->keytag) << " <key>";
+        rdata << get_name(data);
+        DEBUG_MSG("\t\tEMAILBX:\t%s\n", get_name(data).c_str());
+        break;
+    case DNS_TYPE_HINFO:
+        DEBUG_MSG("\tData HINFO:\n");
+        rdata << std::string(data, length);
+        DEBUG_MSG("\t\tData:\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_ISDN:
+        DEBUG_MSG("\tData ISDN:\n");
+        rdata << std::string(data, length);
+        DEBUG_MSG("\t\tData:\t%s\n", rdata.str().c_str());
+        break;
+    case DNS_TYPE_DS: {
+        struct dns_ds* ds = (struct dns_ds*) data;
+        DEBUG_MSG("\tData DS:\n");
+        DEBUG_MSG("\t\tKey tag:\t%u\n", ntohs(ds->keytag));
+        DEBUG_MSG("\t\tAlgorithm:\t%u\n", ds->algorithm);
+        DEBUG_MSG("\t\tDigest type:\t%u\n", ds->digest_type);
+        DEBUG_MSG("\t\tDigest:\t\t(binary)\n");
+        rdata << ntohs(ds->keytag) << " " << (uint16_t) ds->keytag << " "
+              << (uint16_t) ds->digest_type << " <key>";
+    } break;
+    case DNS_TYPE_RRSIG: {
+        struct dns_rrsig* rrsig = (struct dns_rrsig*) data;
+        std::string tmp = "";
+        DEBUG_MSG("\tData RRSIG:\n");
+        DEBUG_MSG("\t\tType:\t\t%u\n", ntohs(rrsig->type));
+        DEBUG_MSG("\t\tAlgorithm:\t%u\n", rrsig->algorithm);
+        DEBUG_MSG("\t\tLabels:\t\t%u\n", rrsig->labels);
+        DEBUG_MSG("\t\tTTL:\t\t%u\n", ntohl(rrsig->ttl));
+        DEBUG_MSG("\t\tSig expiration:\t%u\n", ntohl(rrsig->sig_expiration));
+        DEBUG_MSG("\t\tSig inception:\t%u\n", ntohl(rrsig->sig_inception));
+        DEBUG_MSG("\t\tKey tag:\t%u\n", ntohs(rrsig->keytag));
+        rdata << ntohs(rrsig->type) << " " << (uint16_t) rrsig->algorithm
+              << " " // Conversion needed, otherwise uint8_t will be threated as a char.
+              << (uint16_t) rrsig->labels << " " << ntohl(rrsig->ttl) << " "
+              << ntohl(rrsig->sig_expiration) << " " << ntohl(rrsig->sig_inception) << " "
+              << ntohs(rrsig->keytag) << " <key>";
 
-         tmp = get_name(data + 18);
-         DEBUG_MSG("\t\tSigner's name:\t%s\n",  tmp.c_str());
-         DEBUG_MSG("\t\tSignature:\t(binary)\n");
-      }
-      break;
-   case DNS_TYPE_DNSKEY:
-      {
-         struct dns_dnskey *dnskey = (struct dns_dnskey *) data;
-         DEBUG_MSG("\tData DNSKEY:\n");
-         DEBUG_MSG("\t\tFlags:\t\t%u\n",        ntohs(dnskey->flags));
-         DEBUG_MSG("\t\tProtocol:\t%u\n",       dnskey->protocol);
-         DEBUG_MSG("\t\tAlgorithm:\t%u\n",      dnskey->algorithm);
+        tmp = get_name(data + 18);
+        DEBUG_MSG("\t\tSigner's name:\t%s\n", tmp.c_str());
+        DEBUG_MSG("\t\tSignature:\t(binary)\n");
+    } break;
+    case DNS_TYPE_DNSKEY: {
+        struct dns_dnskey* dnskey = (struct dns_dnskey*) data;
+        DEBUG_MSG("\tData DNSKEY:\n");
+        DEBUG_MSG("\t\tFlags:\t\t%u\n", ntohs(dnskey->flags));
+        DEBUG_MSG("\t\tProtocol:\t%u\n", dnskey->protocol);
+        DEBUG_MSG("\t\tAlgorithm:\t%u\n", dnskey->algorithm);
 
-         rdata << ntohs(dnskey->flags) << " " << (uint16_t) dnskey->protocol << " " << (uint16_t) dnskey->algorithm << " <key>";
-         DEBUG_MSG("\t\tPublic key:\t(binary data)\n");
-      }
-      break;
-   default:
-      DEBUG_MSG("\tData:\t\t\t(format not supported yet)\n");
-      rdata << "(not_impl)";
-      break;
-   }
+        rdata << ntohs(dnskey->flags) << " " << (uint16_t) dnskey->protocol << " "
+              << (uint16_t) dnskey->algorithm << " <key>";
+        DEBUG_MSG("\t\tPublic key:\t(binary data)\n");
+    } break;
+    default:
+        DEBUG_MSG("\tData:\t\t\t(format not supported yet)\n");
+        rdata << "(not_impl)";
+        break;
+    }
 }
 
 #ifdef DEBUG_DNS
@@ -428,232 +433,241 @@ uint32_t s_responses = 0;
  * \param [out] rec Output Flow extension header.
  * \return True if DNS was parsed.
  */
-bool DNSPlugin::parse_dns(const char *data, unsigned int payload_len, bool tcp, RecordExtDNS *rec)
+bool DNSPlugin::parse_dns(const char* data, unsigned int payload_len, bool tcp, RecordExtDNS* rec)
 {
-   try {
-      total++;
+    try {
+        total++;
 
-      DEBUG_MSG("---------- dns parser #%u ----------\n", total);
-      DEBUG_MSG("Payload length: %u\n", payload_len);
+        DEBUG_MSG("---------- dns parser #%u ----------\n", total);
+        DEBUG_MSG("Payload length: %u\n", payload_len);
 
-      if (tcp) {
-         payload_len -= 2;
-         if (ntohs(*(uint16_t *) data) != payload_len) {
-            DEBUG_MSG("parser quits: fragmented tcp pkt");
+        if (tcp) {
+            payload_len -= 2;
+            if (ntohs(*(uint16_t*) data) != payload_len) {
+                DEBUG_MSG("parser quits: fragmented tcp pkt");
+                return false;
+            }
+            data += 2;
+        }
+
+        if (payload_len < sizeof(struct dns_hdr)) {
+            DEBUG_MSG("parser quits: payload length < %ld\n", sizeof(struct dns_hdr));
             return false;
-         }
-         data += 2;
-      }
+        }
 
-      if (payload_len < sizeof(struct dns_hdr)) {
-         DEBUG_MSG("parser quits: payload length < %ld\n", sizeof(struct dns_hdr));
-         return false;
-      }
+        data_begin = data;
+        data_len = payload_len;
 
-      data_begin = data;
-      data_len = payload_len;
+        struct dns_hdr* dns = (struct dns_hdr*) data;
+        uint16_t flags = ntohs(dns->flags);
+        uint16_t question_cnt = ntohs(dns->question_rec_cnt);
+        uint16_t answer_rr_cnt = ntohs(dns->answer_rec_cnt);
+        uint16_t authority_rr_cnt = ntohs(dns->name_server_rec_cnt);
+        uint16_t additional_rr_cnt = ntohs(dns->additional_rec_cnt);
 
-      struct dns_hdr *dns = (struct dns_hdr *) data;
-      uint16_t flags = ntohs(dns->flags);
-      uint16_t question_cnt = ntohs(dns->question_rec_cnt);
-      uint16_t answer_rr_cnt = ntohs(dns->answer_rec_cnt);
-      uint16_t authority_rr_cnt = ntohs(dns->name_server_rec_cnt);
-      uint16_t additional_rr_cnt = ntohs(dns->additional_rec_cnt);
+        rec->answers = answer_rr_cnt;
+        rec->id = ntohs(dns->id);
+        rec->rcode = DNS_HDR_GET_RESPCODE(flags);
 
-      rec->answers = answer_rr_cnt;
-      rec->id = ntohs(dns->id);
-      rec->rcode = DNS_HDR_GET_RESPCODE(flags);
+        DEBUG_MSG(
+            "%s number: %u\n",
+            DNS_HDR_GET_QR(flags) ? "Response" : "Query",
+            DNS_HDR_GET_QR(flags) ? s_queries++ : s_responses++);
+        DEBUG_MSG("DNS message header\n");
+        DEBUG_MSG("\tTransaction ID:\t\t%#06x\n", ntohs(dns->id));
+        DEBUG_MSG("\tFlags:\t\t\t%#06x\n", ntohs(dns->flags));
 
-      DEBUG_MSG("%s number: %u\n",                    DNS_HDR_GET_QR(flags) ? "Response" : "Query",
-                                                      DNS_HDR_GET_QR(flags) ? s_queries++ : s_responses++);
-      DEBUG_MSG("DNS message header\n");
-      DEBUG_MSG("\tTransaction ID:\t\t%#06x\n",       ntohs(dns->id));
-      DEBUG_MSG("\tFlags:\t\t\t%#06x\n",              ntohs(dns->flags));
+        DEBUG_MSG("\t\tQuestion/reply:\t\t%u\n", DNS_HDR_GET_QR(flags));
+        DEBUG_MSG("\t\tOP code:\t\t%u\n", DNS_HDR_GET_OPCODE(flags));
+        DEBUG_MSG("\t\tAuthoritative answer:\t%u\n", DNS_HDR_GET_AA(flags));
+        DEBUG_MSG("\t\tTruncation:\t\t%u\n", DNS_HDR_GET_TC(flags));
+        DEBUG_MSG("\t\tRecursion desired:\t%u\n", DNS_HDR_GET_RD(flags));
+        DEBUG_MSG("\t\tRecursion available:\t%u\n", DNS_HDR_GET_RA(flags));
+        DEBUG_MSG("\t\tReserved:\t\t%u\n", DNS_HDR_GET_Z(flags));
+        DEBUG_MSG("\t\tAuth data:\t\t%u\n", DNS_HDR_GET_AD(flags));
+        DEBUG_MSG("\t\tChecking disabled:\t%u\n", DNS_HDR_GET_CD(flags));
+        DEBUG_MSG("\t\tResponse code:\t\t%u\n", DNS_HDR_GET_RESPCODE(flags));
 
-      DEBUG_MSG("\t\tQuestion/reply:\t\t%u\n",        DNS_HDR_GET_QR(flags));
-      DEBUG_MSG("\t\tOP code:\t\t%u\n",               DNS_HDR_GET_OPCODE(flags));
-      DEBUG_MSG("\t\tAuthoritative answer:\t%u\n",    DNS_HDR_GET_AA(flags));
-      DEBUG_MSG("\t\tTruncation:\t\t%u\n",            DNS_HDR_GET_TC(flags));
-      DEBUG_MSG("\t\tRecursion desired:\t%u\n",       DNS_HDR_GET_RD(flags));
-      DEBUG_MSG("\t\tRecursion available:\t%u\n",     DNS_HDR_GET_RA(flags));
-      DEBUG_MSG("\t\tReserved:\t\t%u\n",              DNS_HDR_GET_Z(flags));
-      DEBUG_MSG("\t\tAuth data:\t\t%u\n",             DNS_HDR_GET_AD(flags));
-      DEBUG_MSG("\t\tChecking disabled:\t%u\n",       DNS_HDR_GET_CD(flags));
-      DEBUG_MSG("\t\tResponse code:\t\t%u\n",         DNS_HDR_GET_RESPCODE(flags));
+        DEBUG_MSG("\tQuestions:\t\t%u\n", question_cnt);
+        DEBUG_MSG("\tAnswer RRs:\t\t%u\n", answer_rr_cnt);
+        DEBUG_MSG("\tAuthority RRs:\t\t%u\n", authority_rr_cnt);
+        DEBUG_MSG("\tAdditional RRs:\t\t%u\n", additional_rr_cnt);
 
-      DEBUG_MSG("\tQuestions:\t\t%u\n",               question_cnt);
-      DEBUG_MSG("\tAnswer RRs:\t\t%u\n",              answer_rr_cnt);
-      DEBUG_MSG("\tAuthority RRs:\t\t%u\n",           authority_rr_cnt);
-      DEBUG_MSG("\tAdditional RRs:\t\t%u\n",          additional_rr_cnt);
+        /********************************************************************
+        *****                   DNS Question section                    *****
+        ********************************************************************/
+        data += sizeof(struct dns_hdr);
+        for (int i = 0; i < question_cnt; i++) {
+            DEBUG_MSG("\nDNS question #%d\n", i + 1);
+            std::string name = get_name(data);
+            DEBUG_MSG("\tName:\t\t\t%s\n", name.c_str());
 
-      /********************************************************************
-      *****                   DNS Question section                    *****
-      ********************************************************************/
-      data += sizeof(struct dns_hdr);
-      for (int i = 0; i < question_cnt; i++) {
-         DEBUG_MSG("\nDNS question #%d\n",            i + 1);
-         std::string name = get_name(data);
-         DEBUG_MSG("\tName:\t\t\t%s\n",               name.c_str());
+            data += get_name_length(data);
+            struct dns_question* question = (struct dns_question*) data;
 
-         data += get_name_length(data);
-         struct dns_question *question = (struct dns_question *) data;
-
-         if ((data - data_begin) + sizeof(struct dns_question) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
-
-         if (i == 0) { // Copy only first question.
-            rec->qtype = ntohs(question->qtype);
-            rec->qclass = ntohs(question->qclass);
-
-            size_t length = name.length();
-            if (length >= sizeof(rec->qname)) {
-               DEBUG_MSG("Truncating qname (length = %lu) to %lu.\n", length, sizeof(rec->qname) - 1);
-               length = sizeof(rec->qname) - 1;
+            if ((data - data_begin) + sizeof(struct dns_question) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
             }
-            memcpy(rec->qname, name.c_str(), length);
-            rec->qname[length] = 0;
-         }
-         DEBUG_MSG("\tType:\t\t\t%u\n",               ntohs(question->qtype));
-         DEBUG_MSG("\tClass:\t\t\t%u\n",              ntohs(question->qclass));
-         data += sizeof(struct dns_question);
-      }
 
-      /********************************************************************
-      *****                    DNS Answers section                    *****
-      ********************************************************************/
-      const char *record_begin;
-      size_t rdlength;
-      std::ostringstream rdata;
-      for (int i = 0; i < answer_rr_cnt; i++) { // Process answers section.
-         record_begin = data;
+            if (i == 0) { // Copy only first question.
+                rec->qtype = ntohs(question->qtype);
+                rec->qclass = ntohs(question->qclass);
 
-         DEBUG_MSG("DNS answer #%d\n", i + 1);
-         DEBUG_MSG("\tAnswer name:\t\t%s\n",          get_name(data).c_str());
-         data += get_name_length(data);
-
-         struct dns_answer *answer = (struct dns_answer *) data;
-
-         uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
-         if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
-
-         DEBUG_MSG("\tType:\t\t\t%u\n",               ntohs(answer->atype));
-         DEBUG_MSG("\tClass:\t\t\t%u\n",              ntohs(answer->aclass));
-         DEBUG_MSG("\tTTL:\t\t\t%u\n",                ntohl(answer->ttl));
-         DEBUG_MSG("\tRD length:\t\t%u\n",            ntohs(answer->rdlength));
-
-         data += sizeof(struct dns_answer);
-         rdlength = ntohs(answer->rdlength);
-
-         if (i == 0) { // Copy only first answer.
-            process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
-            rec->rr_ttl = ntohl(answer->ttl);
-
-            size_t length = rdata.str().length();
-            if (length >= sizeof(rec->data)) {
-               DEBUG_MSG("Truncating rdata (length = %lu) to %lu.\n", length, sizeof(rec->data) - 1);
-               length = sizeof(rec->data) - 1;
+                size_t length = name.length();
+                if (length >= sizeof(rec->qname)) {
+                    DEBUG_MSG(
+                        "Truncating qname (length = %lu) to %lu.\n",
+                        length,
+                        sizeof(rec->qname) - 1);
+                    length = sizeof(rec->qname) - 1;
+                }
+                memcpy(rec->qname, name.c_str(), length);
+                rec->qname[length] = 0;
             }
-            memcpy(rec->data, rdata.str().c_str(), length); // Copy processed rdata.
-            rec->data[length] = 0; // Add terminating '\0' char.
-            rec->rlength = length; // Report length.
-         }
-         data += rdlength;
-      }
+            DEBUG_MSG("\tType:\t\t\t%u\n", ntohs(question->qtype));
+            DEBUG_MSG("\tClass:\t\t\t%u\n", ntohs(question->qclass));
+            data += sizeof(struct dns_question);
+        }
 
-      /********************************************************************
-      *****                 DNS Authority RRs section                 *****
-      ********************************************************************/
+        /********************************************************************
+        *****                    DNS Answers section                    *****
+        ********************************************************************/
+        const char* record_begin;
+        size_t rdlength;
+        std::ostringstream rdata;
+        for (int i = 0; i < answer_rr_cnt; i++) { // Process answers section.
+            record_begin = data;
 
-      for (int i = 0; i < authority_rr_cnt; i++) { // Unused yet.
-         record_begin = data;
+            DEBUG_MSG("DNS answer #%d\n", i + 1);
+            DEBUG_MSG("\tAnswer name:\t\t%s\n", get_name(data).c_str());
+            data += get_name_length(data);
 
-         DEBUG_MSG("DNS authority RR #%d\n", i + 1);
-         DEBUG_MSG("\tAnswer name:\t\t%s\n",          get_name(data).c_str());
-         data += get_name_length(data);
+            struct dns_answer* answer = (struct dns_answer*) data;
 
-         struct dns_answer *answer = (struct dns_answer *) data;
+            uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
+            if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
 
-         uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
-         if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
+            DEBUG_MSG("\tType:\t\t\t%u\n", ntohs(answer->atype));
+            DEBUG_MSG("\tClass:\t\t\t%u\n", ntohs(answer->aclass));
+            DEBUG_MSG("\tTTL:\t\t\t%u\n", ntohl(answer->ttl));
+            DEBUG_MSG("\tRD length:\t\t%u\n", ntohs(answer->rdlength));
 
-         DEBUG_MSG("\tType:\t\t\t%u\n",               ntohs(answer->atype));
-         DEBUG_MSG("\tClass:\t\t\t%u\n",              ntohs(answer->aclass));
-         DEBUG_MSG("\tTTL:\t\t\t%u\n",                ntohl(answer->ttl));
-         DEBUG_MSG("\tRD length:\t\t%u\n",            ntohs(answer->rdlength));
+            data += sizeof(struct dns_answer);
+            rdlength = ntohs(answer->rdlength);
 
-         data += sizeof(struct dns_answer);
-         rdlength = ntohs(answer->rdlength);
-         DEBUG_CODE(process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength));
+            if (i == 0) { // Copy only first answer.
+                process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
+                rec->rr_ttl = ntohl(answer->ttl);
 
-         data += rdlength;
-      }
+                size_t length = rdata.str().length();
+                if (length >= sizeof(rec->data)) {
+                    DEBUG_MSG(
+                        "Truncating rdata (length = %lu) to %lu.\n",
+                        length,
+                        sizeof(rec->data) - 1);
+                    length = sizeof(rec->data) - 1;
+                }
+                memcpy(rec->data, rdata.str().c_str(), length); // Copy processed rdata.
+                rec->data[length] = 0; // Add terminating '\0' char.
+                rec->rlength = length; // Report length.
+            }
+            data += rdlength;
+        }
 
-      /********************************************************************
-      *****                 DNS Additional RRs section                *****
-      ********************************************************************/
-      for (int i = 0; i < additional_rr_cnt; i++) { // Unused yet.
-         record_begin = data;
+        /********************************************************************
+        *****                 DNS Authority RRs section                 *****
+        ********************************************************************/
 
-         DEBUG_MSG("DNS additional RR #%d\n", i + 1);
-         DEBUG_MSG("\tAnswer name:\t\t%s\n",          get_name(data).c_str());
-         data += get_name_length(data);
+        for (int i = 0; i < authority_rr_cnt; i++) { // Unused yet.
+            record_begin = data;
 
-         struct dns_answer *answer = (struct dns_answer *) data;
+            DEBUG_MSG("DNS authority RR #%d\n", i + 1);
+            DEBUG_MSG("\tAnswer name:\t\t%s\n", get_name(data).c_str());
+            data += get_name_length(data);
 
-         uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
-         if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
+            struct dns_answer* answer = (struct dns_answer*) data;
 
-         DEBUG_MSG("\tType:\t\t\t%u\n",               ntohs(answer->atype));
-         if (ntohs(answer->atype) != DNS_TYPE_OPT) {
-            DEBUG_MSG("\tClass:\t\t\t%u\n",           ntohs(answer->aclass));
-            DEBUG_MSG("\tTTL:\t\t\t%u\n",             ntohl(answer->ttl));
-            DEBUG_MSG("\tRD length:\t\t%u\n",         ntohs(answer->rdlength));
+            uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
+            if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
+
+            DEBUG_MSG("\tType:\t\t\t%u\n", ntohs(answer->atype));
+            DEBUG_MSG("\tClass:\t\t\t%u\n", ntohs(answer->aclass));
+            DEBUG_MSG("\tTTL:\t\t\t%u\n", ntohl(answer->ttl));
+            DEBUG_MSG("\tRD length:\t\t%u\n", ntohs(answer->rdlength));
 
             data += sizeof(struct dns_answer);
             rdlength = ntohs(answer->rdlength);
             DEBUG_CODE(process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength));
-         } else { // Process OPT record.
-            DEBUG_MSG("\tReq UDP payload:\t%u\n",     ntohs(answer->aclass));
-            DEBUG_CODE(uint32_t ttl = ntohl(answer->ttl));
-            DEBUG_MSG("\tExtended RCODE:\t\t%#x\n",   (ttl & 0xFF000000) >> 24);
-            DEBUG_MSG("\tVersion:\t\t%#x\n",          (ttl & 0x00FF0000) >> 16);
-            DEBUG_MSG("\tDO bit:\t\t\t%u\n",          ((ttl & 0x8000) >> 15));
-            DEBUG_MSG("\tReserved:\t\t%u\n",          (ttl & 0x7FFF));
-            DEBUG_MSG("\tRD length:\t\t%u\n",         ntohs(answer->rdlength));
 
-            data += sizeof(struct dns_answer);
-            rdlength = ntohs(answer->rdlength);
-            rec->psize = ntohs(answer->aclass); // Copy requested UDP payload size. RFC 6891
-            rec->dns_do = ((ntohl(answer->ttl) & 0x8000) >> 15); // Copy DO bit.
-         }
+            data += rdlength;
+        }
 
-         data += rdlength;
-      }
+        /********************************************************************
+        *****                 DNS Additional RRs section                *****
+        ********************************************************************/
+        for (int i = 0; i < additional_rr_cnt; i++) { // Unused yet.
+            record_begin = data;
 
-      if (DNS_HDR_GET_QR(flags)) {
-         responses++;
-      } else {
-         queries++;
-      }
+            DEBUG_MSG("DNS additional RR #%d\n", i + 1);
+            DEBUG_MSG("\tAnswer name:\t\t%s\n", get_name(data).c_str());
+            data += get_name_length(data);
 
-      DEBUG_MSG("DNS parser quits: parsing done\n\n");
-   } catch (const char *err) {
-      DEBUG_MSG("%s\n", err);
-      return false;
-   }
+            struct dns_answer* answer = (struct dns_answer*) data;
 
-   return true;
+            uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
+            if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
+
+            DEBUG_MSG("\tType:\t\t\t%u\n", ntohs(answer->atype));
+            if (ntohs(answer->atype) != DNS_TYPE_OPT) {
+                DEBUG_MSG("\tClass:\t\t\t%u\n", ntohs(answer->aclass));
+                DEBUG_MSG("\tTTL:\t\t\t%u\n", ntohl(answer->ttl));
+                DEBUG_MSG("\tRD length:\t\t%u\n", ntohs(answer->rdlength));
+
+                data += sizeof(struct dns_answer);
+                rdlength = ntohs(answer->rdlength);
+                DEBUG_CODE(
+                    process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength));
+            } else { // Process OPT record.
+                DEBUG_MSG("\tReq UDP payload:\t%u\n", ntohs(answer->aclass));
+                DEBUG_CODE(uint32_t ttl = ntohl(answer->ttl));
+                DEBUG_MSG("\tExtended RCODE:\t\t%#x\n", (ttl & 0xFF000000) >> 24);
+                DEBUG_MSG("\tVersion:\t\t%#x\n", (ttl & 0x00FF0000) >> 16);
+                DEBUG_MSG("\tDO bit:\t\t\t%u\n", ((ttl & 0x8000) >> 15));
+                DEBUG_MSG("\tReserved:\t\t%u\n", (ttl & 0x7FFF));
+                DEBUG_MSG("\tRD length:\t\t%u\n", ntohs(answer->rdlength));
+
+                data += sizeof(struct dns_answer);
+                rdlength = ntohs(answer->rdlength);
+                rec->psize = ntohs(answer->aclass); // Copy requested UDP payload size. RFC 6891
+                rec->dns_do = ((ntohl(answer->ttl) & 0x8000) >> 15); // Copy DO bit.
+            }
+
+            data += rdlength;
+        }
+
+        if (DNS_HDR_GET_QR(flags)) {
+            responses++;
+        } else {
+            queries++;
+        }
+
+        DEBUG_MSG("DNS parser quits: parsing done\n\n");
+    } catch (const char* err) {
+        DEBUG_MSG("%s\n", err);
+        return false;
+    }
+
+    return true;
 }
 
 /**
@@ -663,16 +677,16 @@ bool DNSPlugin::parse_dns(const char *data, unsigned int payload_len, bool tcp, 
  * \param [in] tcp DNS over tcp.
  * \param [out] rec Destination Flow.
  */
-int DNSPlugin::add_ext_dns(const char *data, unsigned int payload_len, bool tcp, Flow &rec)
+int DNSPlugin::add_ext_dns(const char* data, unsigned int payload_len, bool tcp, Flow& rec)
 {
-   RecordExtDNS *ext = new RecordExtDNS();
-   if (!parse_dns(data, payload_len, tcp, ext)) {
-      delete ext;
-      return 0;
-   } else {
-      rec.add_extension(ext);
-   }
-   return FLOW_FLUSH;
+    RecordExtDNS* ext = new RecordExtDNS();
+    if (!parse_dns(data, payload_len, tcp, ext)) {
+        delete ext;
+        return 0;
+    } else {
+        rec.add_extension(ext);
+    }
+    return FLOW_FLUSH;
 }
 
-}
+} // namespace ipxp

--- a/process/dns.hpp
+++ b/process/dns.hpp
@@ -30,184 +30,178 @@
 #ifndef IPXP_PROCESS_DNS_HPP
 #define IPXP_PROCESS_DNS_HPP
 
-#include <string>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
 #include "dns-utils.hpp"
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
-#define DNS_UNIREC_TEMPLATE "DNS_ID,DNS_ANSWERS,DNS_RCODE,DNS_NAME,DNS_QTYPE,DNS_CLASS,DNS_RR_TTL,DNS_RLENGTH,DNS_RDATA,DNS_PSIZE,DNS_DO"
+#define DNS_UNIREC_TEMPLATE                                                                        \
+    "DNS_ID,DNS_ANSWERS,DNS_RCODE,DNS_NAME,DNS_QTYPE,DNS_CLASS,DNS_RR_TTL,DNS_RLENGTH,DNS_RDATA,"  \
+    "DNS_PSIZE,DNS_DO"
 
-UR_FIELDS (
-   uint16 DNS_ID,
-   uint16 DNS_ANSWERS,
-   uint8  DNS_RCODE,
-   string DNS_NAME,
-   uint16 DNS_QTYPE,
-   uint16 DNS_CLASS,
-   uint32 DNS_RR_TTL,
-   uint16 DNS_RLENGTH,
-   bytes DNS_RDATA,
+UR_FIELDS(
+    uint16 DNS_ID,
+    uint16 DNS_ANSWERS,
+    uint8 DNS_RCODE,
+    string DNS_NAME,
+    uint16 DNS_QTYPE,
+    uint16 DNS_CLASS,
+    uint32 DNS_RR_TTL,
+    uint16 DNS_RLENGTH,
+    bytes DNS_RDATA,
 
-   uint16 DNS_PSIZE,
-   uint8  DNS_DO
-)
+    uint16 DNS_PSIZE,
+    uint8 DNS_DO)
 
 /**
  * \brief Flow record extension header for storing parsed DNS packets.
  */
 struct RecordExtDNS : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t id;
-   uint16_t answers;
-   uint8_t rcode;
-   char qname[128];
-   uint16_t qtype;
-   uint16_t qclass;
-   uint32_t rr_ttl;
-   uint16_t rlength;
-   char data[160];
-   uint16_t psize;
-   uint8_t dns_do;
+    uint16_t id;
+    uint16_t answers;
+    uint8_t rcode;
+    char qname[128];
+    uint16_t qtype;
+    uint16_t qclass;
+    uint32_t rr_ttl;
+    uint16_t rlength;
+    char data[160];
+    uint16_t psize;
+    uint8_t dns_do;
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtDNS() : RecordExt(REGISTERED_ID)
-   {
-      id = 0;
-      answers = 0;
-      rcode = 0;
-      qname[0] = 0;
-      qtype = 0;
-      qclass = 0;
-      rr_ttl = 0;
-      rlength = 0;
-      data[0] = 0;
-      psize = 0;
-      dns_do = 0;
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtDNS()
+        : RecordExt(REGISTERED_ID)
+    {
+        id = 0;
+        answers = 0;
+        rcode = 0;
+        qname[0] = 0;
+        qtype = 0;
+        qclass = 0;
+        rr_ttl = 0;
+        rlength = 0;
+        data[0] = 0;
+        psize = 0;
+        dns_do = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-         ur_set(tmplt, record, F_DNS_ID, id);
-         ur_set(tmplt, record, F_DNS_ANSWERS, answers);
-         ur_set(tmplt, record, F_DNS_RCODE, rcode);
-         ur_set_string(tmplt, record, F_DNS_NAME, qname);
-         ur_set(tmplt, record, F_DNS_QTYPE, qtype);
-         ur_set(tmplt, record, F_DNS_CLASS, qclass);
-         ur_set(tmplt, record, F_DNS_RR_TTL, rr_ttl);
-         ur_set(tmplt, record, F_DNS_RLENGTH, rlength);
-         ur_set_var(tmplt, record, F_DNS_RDATA, data, rlength);
-         ur_set(tmplt, record, F_DNS_PSIZE, psize);
-         ur_set(tmplt, record, F_DNS_DO, dns_do);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_DNS_ID, id);
+        ur_set(tmplt, record, F_DNS_ANSWERS, answers);
+        ur_set(tmplt, record, F_DNS_RCODE, rcode);
+        ur_set_string(tmplt, record, F_DNS_NAME, qname);
+        ur_set(tmplt, record, F_DNS_QTYPE, qtype);
+        ur_set(tmplt, record, F_DNS_CLASS, qclass);
+        ur_set(tmplt, record, F_DNS_RR_TTL, rr_ttl);
+        ur_set(tmplt, record, F_DNS_RLENGTH, rlength);
+        ur_set_var(tmplt, record, F_DNS_RDATA, data, rlength);
+        ur_set(tmplt, record, F_DNS_PSIZE, psize);
+        ur_set(tmplt, record, F_DNS_DO, dns_do);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return DNS_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return DNS_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length;
 
-      length = strlen(qname);
-      if (length + rlength + 20 > size) {
-         return -1;
-      }
-      *(uint16_t *) (buffer) = ntohs(answers);
-      *(uint8_t *) (buffer + 2) = rcode;
-      *(uint16_t *) (buffer + 3) = ntohs(qtype);
-      *(uint16_t *) (buffer + 5) = ntohs(qclass);
-      *(uint32_t *) (buffer + 7) = ntohl(rr_ttl);
-      *(uint16_t *) (buffer + 11) = ntohs(rlength);
-      *(uint16_t *) (buffer + 13) = ntohs(psize);
-      *(uint8_t *) (buffer + 15) = dns_do;
-      *(uint16_t *) (buffer + 16) = ntohs(id);
-      buffer[18] = length;
-      memcpy(buffer + 19, qname, length);
-      buffer[length + 19] = rlength;
-      memcpy(buffer + 20 + length, data, rlength);
+        length = strlen(qname);
+        if (length + rlength + 20 > size) {
+            return -1;
+        }
+        *(uint16_t*) (buffer) = ntohs(answers);
+        *(uint8_t*) (buffer + 2) = rcode;
+        *(uint16_t*) (buffer + 3) = ntohs(qtype);
+        *(uint16_t*) (buffer + 5) = ntohs(qclass);
+        *(uint32_t*) (buffer + 7) = ntohl(rr_ttl);
+        *(uint16_t*) (buffer + 11) = ntohs(rlength);
+        *(uint16_t*) (buffer + 13) = ntohs(psize);
+        *(uint8_t*) (buffer + 15) = dns_do;
+        *(uint16_t*) (buffer + 16) = ntohs(id);
+        buffer[18] = length;
+        memcpy(buffer + 19, qname, length);
+        buffer[length + 19] = rlength;
+        memcpy(buffer + 20 + length, data, rlength);
 
-      return 20 + rlength + length;
-   }
+        return 20 + rlength + length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_DNS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_tmplt;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_DNS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "dnsid=" << id
-         << ",answers=" << answers
-         << ",rcode=" << rcode
-         << ",qname=\"" << qname << "\""
-         << ",qtype=" << qtype
-         << ",qclass=" << qclass
-         << ",rrttl=" << rr_ttl
-         << ",rlength=" << rlength
-         << ",data=\"" << data << "\""
-         << ",psize=" << psize
-         << ",dnsdo=" << dns_do;
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "dnsid=" << id << ",answers=" << answers << ",rcode=" << rcode << ",qname=\""
+            << qname << "\""
+            << ",qtype=" << qtype << ",qclass=" << qclass << ",rrttl=" << rr_ttl
+            << ",rlength=" << rlength << ",data=\"" << data << "\""
+            << ",psize=" << psize << ",dnsdo=" << dns_do;
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing DNS packets.
  */
-class DNSPlugin : public ProcessPlugin
-{
+class DNSPlugin : public ProcessPlugin {
 public:
-   DNSPlugin();
-   ~DNSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("dns", "Parse DNS packets"); }
-   std::string get_name() const { return "dns"; }
-   RecordExt *get_ext() const { return new RecordExtDNS(); }
-   ProcessPlugin *copy();
+    DNSPlugin();
+    ~DNSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("dns", "Parse DNS packets"); }
+    std::string get_name() const { return "dns"; }
+    RecordExt* get_ext() const { return new RecordExtDNS(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   uint32_t queries;       /**< Total number of parsed DNS queries. */
-   uint32_t responses;     /**< Total number of parsed DNS responses. */
-   uint32_t total;         /**< Total number of parsed DNS packets. */
+    uint32_t queries; /**< Total number of parsed DNS queries. */
+    uint32_t responses; /**< Total number of parsed DNS responses. */
+    uint32_t total; /**< Total number of parsed DNS packets. */
 
-   const char *data_begin; /**< Pointer to begin of payload. */
-   uint32_t data_len;      /**< Length of packet payload. */
+    const char* data_begin; /**< Pointer to begin of payload. */
+    uint32_t data_len; /**< Length of packet payload. */
 
-   bool parse_dns(const char *data, unsigned int payload_len, bool tcp, RecordExtDNS *rec);
-   int  add_ext_dns(const char *data, unsigned int payload_len, bool tcp, Flow &rec);
-   void process_srv(std::string &str) const;
-   void process_rdata(const char *record_begin, const char *data, std::ostringstream &rdata, uint16_t type, size_t length) const;
+    bool parse_dns(const char* data, unsigned int payload_len, bool tcp, RecordExtDNS* rec);
+    int add_ext_dns(const char* data, unsigned int payload_len, bool tcp, Flow& rec);
+    void process_srv(std::string& str) const;
+    void process_rdata(
+        const char* record_begin,
+        const char* data,
+        std::ostringstream& rdata,
+        uint16_t type,
+        size_t length) const;
 
-   std::string get_name(const char *data) const;
-   size_t get_name_length(const char *data) const;
+    std::string get_name(const char* data) const;
+    size_t get_name_length(const char* data) const;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_DNS_HPP */

--- a/process/dnssd.cpp
+++ b/process/dnssd.cpp
@@ -27,11 +27,11 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <arpa/inet.h>
 #include <iostream>
 #include <sstream>
-#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #ifdef WITH_NEMEA
 #include <unirec/unirec.h>
@@ -47,9 +47,9 @@ int RecordExtDNSSD::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("dnssd", [](){return new DNSSDPlugin();});
-   register_plugin(&rec);
-   RecordExtDNSSD::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("dnssd", []() { return new DNSSDPlugin(); });
+    register_plugin(&rec);
+    RecordExtDNSSD::REGISTERED_ID = register_extension();
 }
 
 // #define DEBUG_DNSSD
@@ -78,75 +78,90 @@ __attribute__((constructor)) static void register_this_plugin()
 /**
  * \brief Get offset from 2 byte pointer.
  */
-#define GET_OFFSET(half1, half2) ((((uint8_t)(half1) & 0x3F) << 8) | (uint8_t)(half2))
+#define GET_OFFSET(half1, half2) ((((uint8_t) (half1) &0x3F) << 8) | (uint8_t) (half2))
 
-DNSSDPlugin::DNSSDPlugin() : txt_all_records(false), queries(0), responses(0), total(0), data_begin(nullptr), data_len(0)
+DNSSDPlugin::DNSSDPlugin()
+    : txt_all_records(false)
+    , queries(0)
+    , responses(0)
+    , total(0)
+    , data_begin(nullptr)
+    , data_len(0)
 {
 }
 
 DNSSDPlugin::~DNSSDPlugin()
 {
-   close();
+    close();
 }
 
-void DNSSDPlugin::init(const char *params)
+void DNSSDPlugin::init(const char* params)
 {
-   DNSSDOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    DNSSDOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   txt_all_records = parser.m_txt_all;
-   if (!parser.m_config_file.empty()) {
-      load_txtconfig(parser.m_config_file.c_str());
-   }
+    txt_all_records = parser.m_txt_all;
+    if (!parser.m_config_file.empty()) {
+        load_txtconfig(parser.m_config_file.c_str());
+    }
 }
 
-void DNSSDPlugin::close()
+void DNSSDPlugin::close() {}
+
+ProcessPlugin* DNSSDPlugin::copy()
 {
+    return new DNSSDPlugin(*this);
 }
 
-ProcessPlugin *DNSSDPlugin::copy()
+int DNSSDPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   return new DNSSDPlugin(*this);
+    if (pkt.dst_port == 5353 || pkt.src_port == 5353) {
+        return add_ext_dnssd(
+            reinterpret_cast<const char*>(pkt.payload),
+            pkt.payload_len,
+            pkt.ip_proto == IPPROTO_TCP,
+            rec);
+    }
+
+    return 0;
 }
 
-int DNSSDPlugin::post_create(Flow &rec, const Packet &pkt)
+int DNSSDPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   if (pkt.dst_port == 5353 || pkt.src_port == 5353) {
-      return add_ext_dnssd(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.ip_proto == IPPROTO_TCP, rec);
-   }
+    if (pkt.dst_port == 5353 || pkt.src_port == 5353) {
+        RecordExt* ext = rec.get_extension(RecordExtDNSSD::REGISTERED_ID);
 
-   return 0;
-}
+        if (ext == nullptr) {
+            return add_ext_dnssd(
+                reinterpret_cast<const char*>(pkt.payload),
+                pkt.payload_len,
+                pkt.ip_proto == IPPROTO_TCP,
+                rec);
+        } else {
+            parse_dns(
+                reinterpret_cast<const char*>(pkt.payload),
+                pkt.payload_len,
+                pkt.ip_proto == IPPROTO_TCP,
+                static_cast<RecordExtDNSSD*>(ext));
+        }
+        return 0;
+    }
 
-int DNSSDPlugin::post_update(Flow &rec, const Packet &pkt)
-{
-   if (pkt.dst_port == 5353 || pkt.src_port == 5353) {
-      RecordExt *ext = rec.get_extension(RecordExtDNSSD::REGISTERED_ID);
-
-      if (ext == nullptr) {
-         return add_ext_dnssd(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.ip_proto == IPPROTO_TCP, rec);
-      } else {
-         parse_dns(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.ip_proto == IPPROTO_TCP,
-                   static_cast<RecordExtDNSSD *>(ext));
-      }
-      return 0;
-   }
-
-   return 0;
+    return 0;
 }
 
 void DNSSDPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "DNSSD plugin stats:" << std::endl;
-      std::cout << "   Parsed dns queries: " << queries << std::endl;
-      std::cout << "   Parsed dns responses: " << responses << std::endl;
-      std::cout << "   Total dns packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "DNSSD plugin stats:" << std::endl;
+        std::cout << "   Parsed dns queries: " << queries << std::endl;
+        std::cout << "   Parsed dns responses: " << responses << std::endl;
+        std::cout << "   Total dns packets processed: " << total << std::endl;
+    }
 }
 
 /**
@@ -154,44 +169,46 @@ void DNSSDPlugin::finish(bool print_stats)
  *
  * Takes path to file from enviroment variable DNSSD_TXTCONFIG_PATH.
  */
-void DNSSDPlugin::load_txtconfig(const char *config_file)
+void DNSSDPlugin::load_txtconfig(const char* config_file)
 {
-   if (!config_file) {
-      return;
-   }
-   std::ifstream in_file;
+    if (!config_file) {
+        return;
+    }
+    std::ifstream in_file;
 
-   in_file.open(config_file);
-   if (!in_file) {
-      std::ostringstream oss;
-      oss <<  strerror(errno) << " '" << config_file << "'";
-      throw PluginError(oss.str());
-   }
-   std::string line, part;
-   size_t begin = 0, end = 0;
+    in_file.open(config_file);
+    if (!in_file) {
+        std::ostringstream oss;
+        oss << strerror(errno) << " '" << config_file << "'";
+        throw PluginError(oss.str());
+    }
+    std::string line, part;
+    size_t begin = 0, end = 0;
 
-   while (getline(in_file, line)) {
-      begin = end = 0;
-      std::pair<std::string, std::list<std::string> > conf;
-      end = line.find(",", begin);
-      conf.first = line.substr(begin, (end == std::string::npos ? (line.length() - begin)
-                                                           : (end - begin)));
-      DEBUG_MSG("TXT filter service loaded: %s\n", conf.first.c_str());
+    while (getline(in_file, line)) {
+        begin = end = 0;
+        std::pair<std::string, std::list<std::string>> conf;
+        end = line.find(",", begin);
+        conf.first = line.substr(
+            begin,
+            (end == std::string::npos ? (line.length() - begin) : (end - begin)));
+        DEBUG_MSG("TXT filter service loaded: %s\n", conf.first.c_str());
 
-      begin = end + 1;
-      DEBUG_MSG("TXT filter keys loaded: ");
-      while (end != std::string::npos) {
-         end = line.find(",", begin);
-         part = line.substr(begin, (end == std::string::npos ? (line.length() - begin)
-                                                        : (end - begin)));
-         conf.second.push_back(part);
-         DEBUG_MSG("%s ", part.c_str());
-         begin = end + 1;
-      }
-      DEBUG_MSG("\n");
-      txt_config.push_back(conf);
-   }
-   in_file.close();
+        begin = end + 1;
+        DEBUG_MSG("TXT filter keys loaded: ");
+        while (end != std::string::npos) {
+            end = line.find(",", begin);
+            part = line.substr(
+                begin,
+                (end == std::string::npos ? (line.length() - begin) : (end - begin)));
+            conf.second.push_back(part);
+            DEBUG_MSG("%s ", part.c_str());
+            begin = end + 1;
+        }
+        DEBUG_MSG("\n");
+        txt_config.push_back(conf);
+    }
+    in_file.close();
 }
 
 /**
@@ -199,26 +216,26 @@ void DNSSDPlugin::load_txtconfig(const char *config_file)
  * \param [in] data Pointer to string.
  * \return Number of characters in string.
  */
-size_t DNSSDPlugin::get_name_length(const char *data) const
+size_t DNSSDPlugin::get_name_length(const char* data) const
 {
-   size_t len = 0;
+    size_t len = 0;
 
-   while (1) {
-      if ((uint32_t) (data - data_begin) + 1 > data_len) {
-         throw "Error: overflow";
-      }
-      if (!data[0]) {
-         break;
-      }
-      if (IS_POINTER(data[0])) {
-         return len + 2;
-      }
+    while (1) {
+        if ((uint32_t) (data - data_begin) + 1 > data_len) {
+            throw "Error: overflow";
+        }
+        if (!data[0]) {
+            break;
+        }
+        if (IS_POINTER(data[0])) {
+            return len + 2;
+        }
 
-      len += (uint8_t) data[0] + 1;
-      data += (uint8_t) data[0] + 1;
-   }
+        len += (uint8_t) data[0] + 1;
+        data += (uint8_t) data[0] + 1;
+    }
 
-   return len + 1;
+    return len + 1;
 }
 
 /**
@@ -226,42 +243,42 @@ size_t DNSSDPlugin::get_name_length(const char *data) const
  * \param [in] data Pointer to compressed data.
  * \return String with decompressed dns name.
  */
-std::string DNSSDPlugin::get_name(const char *data) const
+std::string DNSSDPlugin::get_name(const char* data) const
 {
-   std::string name = "";
-   int label_cnt = 0;
+    std::string name = "";
+    int label_cnt = 0;
 
-   if ((uint32_t) (data - data_begin) > data_len) {
-      throw "Error: overflow";
-   }
+    if ((uint32_t) (data - data_begin) > data_len) {
+        throw "Error: overflow";
+    }
 
-   while (data[0]) {            /* Check for terminating character. */
-      if (IS_POINTER(data[0])) {        /* Check for label pointer (11xxxxxx byte) */
-         data = data_begin + GET_OFFSET(data[0], data[1]);
+    while (data[0]) { /* Check for terminating character. */
+        if (IS_POINTER(data[0])) { /* Check for label pointer (11xxxxxx byte) */
+            data = data_begin + GET_OFFSET(data[0], data[1]);
 
-         /* Check for possible errors. */
-         if (label_cnt++ > MAX_LABEL_CNT || (uint32_t) (data - data_begin) > data_len) {
+            /* Check for possible errors. */
+            if (label_cnt++ > MAX_LABEL_CNT || (uint32_t) (data - data_begin) > data_len) {
+                throw "Error: label count exceed or overflow";
+            }
+
+            continue;
+        }
+
+        /* Check for possible errors. */
+        if (label_cnt++ > MAX_LABEL_CNT || (uint8_t) data[0] > 63
+            || (uint32_t) ((data - data_begin) + (uint8_t) data[0] + 2) > data_len) {
             throw "Error: label count exceed or overflow";
-         }
+        }
 
-         continue;
-      }
+        name += '.' + std::string(data + 1, (uint8_t) data[0]);
+        data += ((uint8_t) data[0] + 1);
+    }
 
-      /* Check for possible errors. */
-      if (label_cnt++ > MAX_LABEL_CNT || (uint8_t) data[0] > 63 ||
-          (uint32_t) ((data - data_begin) + (uint8_t) data[0] + 2) > data_len) {
-         throw "Error: label count exceed or overflow";
-      }
+    if (name[0] == '.') {
+        name.erase(0, 1);
+    }
 
-      name += '.' + std::string(data + 1, (uint8_t) data[0]);
-      data += ((uint8_t) data[0] + 1);
-   }
-
-   if (name[0] == '.') {
-      name.erase(0, 1);
-   }
-
-   return name;
+    return name;
 }
 
 /**
@@ -272,34 +289,36 @@ std::string DNSSDPlugin::get_name(const char *data) const
  * As an example, given input "My MacBook Air._device-info._tcp.local"
  * returns "_device-info._tcp.local".
  */
-const std::string DNSSDPlugin::get_service_str(std::string &name) const
+const std::string DNSSDPlugin::get_service_str(std::string& name) const
 {
-   size_t begin = name.length();
-   int8_t underscore_counter = 0;
+    size_t begin = name.length();
+    int8_t underscore_counter = 0;
 
-   while (underscore_counter < 2 && begin != std::string::npos) {
-      begin = name.rfind("_", begin - 1);
-      if (begin != std::string::npos) {
-         underscore_counter++;
-      }
-   }
-   return name.substr((begin == std::string::npos ? 0 : begin), name.length());
+    while (underscore_counter < 2 && begin != std::string::npos) {
+        begin = name.rfind("_", begin - 1);
+        if (begin != std::string::npos) {
+            underscore_counter++;
+        }
+    }
+    return name.substr((begin == std::string::npos ? 0 : begin), name.length());
 }
 
 /**
  * \brief Checks if Service Instance Name is allowed for TXT processing by checking txt_config.
  * \return True if allowed, otherwise false.
  */
-bool DNSSDPlugin::matches_service(std::list<std::pair<std::string, std::list<std::string> > >::const_iterator &it, std::string &name) const
+bool DNSSDPlugin::matches_service(
+    std::list<std::pair<std::string, std::list<std::string>>>::const_iterator& it,
+    std::string& name) const
 {
-   std::string service = get_service_str(name);
+    std::string service = get_service_str(name);
 
-   for (it = txt_config.begin(); it != txt_config.end(); it++) {
-      if (it->first == service) {
-         return true;
-      }
-   }
-   return false;
+    for (it = txt_config.begin(); it != txt_config.end(); it++) {
+        if (it->first == service) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**
@@ -310,72 +329,71 @@ bool DNSSDPlugin::matches_service(std::list<std::pair<std::string, std::list<std
  * \param [in] type Type of RDATA section.
  * \param [in] length Length of RDATA section.
  */
-void DNSSDPlugin::process_rdata(const char *record_begin, const char *data, DnsSdRr &rdata, uint16_t type, size_t length) const
+void DNSSDPlugin::process_rdata(
+    const char* record_begin,
+    const char* data,
+    DnsSdRr& rdata,
+    uint16_t type,
+    size_t length) const
 {
-   std::string name = rdata.name;
-   rdata = DnsSdRr();
+    std::string name = rdata.name;
+    rdata = DnsSdRr();
 
-   switch (type) {
-   case DNS_TYPE_PTR:
-      DEBUG_MSG("%16s\t\t    %s\n", "PTR", get_name(data).c_str());
-      break;
-   case DNS_TYPE_SRV:
-      {
-         struct dns_srv *srv = (struct dns_srv *) data;
+    switch (type) {
+    case DNS_TYPE_PTR:
+        DEBUG_MSG("%16s\t\t    %s\n", "PTR", get_name(data).c_str());
+        break;
+    case DNS_TYPE_SRV: {
+        struct dns_srv* srv = (struct dns_srv*) data;
 
-         std::string tmp = get_name(data + 6);
+        std::string tmp = get_name(data + 6);
 
-         DEBUG_MSG("%16s\t%8u    %s\n", "SRV", ntohs(srv->port), tmp.c_str());
+        DEBUG_MSG("%16s\t%8u    %s\n", "SRV", ntohs(srv->port), tmp.c_str());
 
-         rdata.srv_port = ntohs(srv->port);
-         rdata.srv_target = tmp;
-      }
-      break;
-   case DNS_TYPE_HINFO:
-      {
-         rdata.hinfo[0] = std::string(data + 1, (uint8_t) data[0]);
-         data += ((uint8_t) data[0] + 1);
-         rdata.hinfo[1] = std::string(data + 1, (uint8_t) data[0]);
-         data += ((uint8_t) data[0] + 1);
-         DEBUG_MSG("%16s\t\t    %s, %s\n", "HINFO", rdata.hinfo[0].c_str(), rdata.hinfo[1].c_str());
-      }
-      break;
-   case DNS_TYPE_TXT:
-      {
-         std::list<std::pair<std::string, std::list<std::string> > >::const_iterator it;
-         if (!(txt_all_records || matches_service(it, name))) {  // all_records overrides filter
+        rdata.srv_port = ntohs(srv->port);
+        rdata.srv_target = tmp;
+    } break;
+    case DNS_TYPE_HINFO: {
+        rdata.hinfo[0] = std::string(data + 1, (uint8_t) data[0]);
+        data += ((uint8_t) data[0] + 1);
+        rdata.hinfo[1] = std::string(data + 1, (uint8_t) data[0]);
+        data += ((uint8_t) data[0] + 1);
+        DEBUG_MSG("%16s\t\t    %s, %s\n", "HINFO", rdata.hinfo[0].c_str(), rdata.hinfo[1].c_str());
+    } break;
+    case DNS_TYPE_TXT: {
+        std::list<std::pair<std::string, std::list<std::string>>>::const_iterator it;
+        if (!(txt_all_records || matches_service(it, name))) { // all_records overrides filter
             break;
-         }
-         size_t len = (uint8_t) *(data++);
-         size_t total_len = len + 1;
-         std::list<std::string>::const_iterator sit;
-         std::string txt;
+        }
+        size_t len = (uint8_t) * (data++);
+        size_t total_len = len + 1;
+        std::list<std::string>::const_iterator sit;
+        std::string txt;
 
-         while (length != 0 && total_len <= length) {
+        while (length != 0 && total_len <= length) {
             txt = std::string(data, len);
 
             if (txt_all_records) {
-               DEBUG_MSG("%16s\t\t    %s\n", "TXT", txt.c_str());
-               rdata.txt += txt + ":";
+                DEBUG_MSG("%16s\t\t    %s\n", "TXT", txt.c_str());
+                rdata.txt += txt + ":";
             } else {
-                  for (sit = it->second.begin(); sit != it->second.end(); sit++) {
-                  if (*sit == txt.substr(0, txt.find("="))) {
-                     DEBUG_MSG("%16s\t\t    %s\n", "TXT", txt.c_str());
-                     rdata.txt += txt + ":";
-                     break;
-                  }
-               }
+                for (sit = it->second.begin(); sit != it->second.end(); sit++) {
+                    if (*sit == txt.substr(0, txt.find("="))) {
+                        DEBUG_MSG("%16s\t\t    %s\n", "TXT", txt.c_str());
+                        rdata.txt += txt + ":";
+                        break;
+                    }
+                }
             }
 
             data += len;
-            len = (uint8_t) *(data++);
+            len = (uint8_t) * (data++);
             total_len += len + 1;
-         }
-      }
-      break;
-   default:
-      break;
-   }
+        }
+    } break;
+    default:
+        break;
+    }
 }
 
 #ifdef DEBUG_DNSSD
@@ -391,212 +409,232 @@ uint32_t s_responses = 0;
  * \param [out] rec Output Flow extension header.
  * \return True if DNS was parsed.
  */
-bool DNSSDPlugin::parse_dns(const char *data, unsigned int payload_len, bool tcp, RecordExtDNSSD *rec)
+bool DNSSDPlugin::parse_dns(
+    const char* data,
+    unsigned int payload_len,
+    bool tcp,
+    RecordExtDNSSD* rec)
 {
-   try {
-      total++;
+    try {
+        total++;
 
-      DEBUG_MSG("---------- dns parser #%u ----------\n", total);
-      DEBUG_MSG("Payload length: %u\n", payload_len);
+        DEBUG_MSG("---------- dns parser #%u ----------\n", total);
+        DEBUG_MSG("Payload length: %u\n", payload_len);
 
-      if (tcp) {
-         payload_len -= 2;
-         if (ntohs(*(uint16_t *) data) != payload_len) {
-            DEBUG_MSG("parser quits: fragmented tcp pkt");
+        if (tcp) {
+            payload_len -= 2;
+            if (ntohs(*(uint16_t*) data) != payload_len) {
+                DEBUG_MSG("parser quits: fragmented tcp pkt");
+                return false;
+            }
+            data += 2;
+        }
+
+        if (payload_len < sizeof(struct dns_hdr)) {
+            DEBUG_MSG("parser quits: payload length < %ld\n", sizeof(struct dns_hdr));
             return false;
-         }
-         data += 2;
-      }
+        }
 
-      if (payload_len < sizeof(struct dns_hdr)) {
-         DEBUG_MSG("parser quits: payload length < %ld\n", sizeof(struct dns_hdr));
-         return false;
-      }
+        data_begin = data;
+        data_len = payload_len;
 
-      data_begin = data;
-      data_len = payload_len;
+        struct dns_hdr* dns = (struct dns_hdr*) data;
+        uint16_t flags = ntohs(dns->flags);
+        uint16_t question_cnt = ntohs(dns->question_rec_cnt);
+        uint16_t answer_rr_cnt = ntohs(dns->answer_rec_cnt);
+        uint16_t authority_rr_cnt = ntohs(dns->name_server_rec_cnt);
+        uint16_t additional_rr_cnt = ntohs(dns->additional_rec_cnt);
 
-      struct dns_hdr *dns = (struct dns_hdr *) data;
-      uint16_t flags = ntohs(dns->flags);
-      uint16_t question_cnt = ntohs(dns->question_rec_cnt);
-      uint16_t answer_rr_cnt = ntohs(dns->answer_rec_cnt);
-      uint16_t authority_rr_cnt = ntohs(dns->name_server_rec_cnt);
-      uint16_t additional_rr_cnt = ntohs(dns->additional_rec_cnt);
+        DEBUG_MSG(
+            "%s number: %u\n",
+            DNS_HDR_GET_QR(flags) ? "Response" : "Query",
+            DNS_HDR_GET_QR(flags) ? s_queries++ : s_responses++);
+        DEBUG_MSG("DNS message header\n");
+        DEBUG_MSG("\tFlags:\t\t\t%#06x\n", ntohs(dns->flags));
 
-      DEBUG_MSG("%s number: %u\n",                    DNS_HDR_GET_QR(flags) ? "Response" : "Query",
-                                                      DNS_HDR_GET_QR(flags) ? s_queries++ : s_responses++);
-      DEBUG_MSG("DNS message header\n");
-      DEBUG_MSG("\tFlags:\t\t\t%#06x\n",              ntohs(dns->flags));
+        DEBUG_MSG(
+            "\t\tQuestion/reply:\t\t%u (%s)\n",
+            DNS_HDR_GET_QR(flags),
+            DNS_HDR_GET_QR(flags) ? "Response" : "Query");
+        DEBUG_MSG("\t\tAuthoritative answer:\t%u\n", DNS_HDR_GET_AA(flags));
 
-      DEBUG_MSG("\t\tQuestion/reply:\t\t%u (%s)\n",   DNS_HDR_GET_QR(flags),
-                                                      DNS_HDR_GET_QR(flags) ? "Response" : "Query");
-      DEBUG_MSG("\t\tAuthoritative answer:\t%u\n",    DNS_HDR_GET_AA(flags));
+        DEBUG_MSG("\tQuestions:\t\t%u\n", question_cnt);
+        DEBUG_MSG("\tAnswer RRs:\t\t%u\n", answer_rr_cnt);
+        DEBUG_MSG("\tAuthority RRs:\t\t%u\n", authority_rr_cnt);
+        DEBUG_MSG("\tAdditional RRs:\t\t%u\n", additional_rr_cnt);
 
-      DEBUG_MSG("\tQuestions:\t\t%u\n",               question_cnt);
-      DEBUG_MSG("\tAnswer RRs:\t\t%u\n",              answer_rr_cnt);
-      DEBUG_MSG("\tAuthority RRs:\t\t%u\n",           authority_rr_cnt);
-      DEBUG_MSG("\tAdditional RRs:\t\t%u\n",          additional_rr_cnt);
+        /********************************************************************
+        *****                   DNS Question section                    *****
+        ********************************************************************/
+        data += sizeof(struct dns_hdr);
+        for (int i = 0; i < question_cnt; i++) {
+            DEBUG_CODE(if (i == 0) {
+                DEBUG_MSG("\nDNS questions section\n");
+                DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
+            });
+            std::string name = get_name(data);
 
-      /********************************************************************
-      *****                   DNS Question section                    *****
-      ********************************************************************/
-      data += sizeof(struct dns_hdr);
-      for (int i = 0; i < question_cnt; i++) {
-         DEBUG_CODE(if (i == 0) {
-            DEBUG_MSG("\nDNS questions section\n");
-            DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
-         });
-         std::string name = get_name(data);
+            data += get_name_length(data);
+            DEBUG_CODE(struct dns_question* question = (struct dns_question*) data);
 
-         data += get_name_length(data);
-         DEBUG_CODE(struct dns_question *question = (struct dns_question *) data);
+            if ((data - data_begin) + sizeof(struct dns_question) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
 
-         if ((data - data_begin) + sizeof(struct dns_question) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
+            filtered_append(rec, name);
 
-         filtered_append(rec, name);
+            DEBUG_MSG("#%7d%8u%20s%s\n", i + 1, ntohs(question->qtype), "", name.c_str());
+            data += sizeof(struct dns_question);
+        }
 
-         DEBUG_MSG("#%7d%8u%20s%s\n", i + 1, ntohs(question->qtype), "", name.c_str());
-         data += sizeof(struct dns_question);
-      }
+        /********************************************************************
+        *****                    DNS Answers section                    *****
+        ********************************************************************/
+        const char* record_begin;
+        size_t rdlength;
+        DnsSdRr rdata;
 
-      /********************************************************************
-      *****                    DNS Answers section                    *****
-      ********************************************************************/
-      const char *record_begin;
-      size_t rdlength;
-      DnsSdRr rdata;
+        for (int i = 0; i < answer_rr_cnt; i++) { // Process answers section.
+            if (i == 0) {
+                DEBUG_MSG("DNS answers section\n");
+                DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
+            }
 
-      for (int i = 0; i < answer_rr_cnt; i++) { // Process answers section.
-         if (i == 0) {
-            DEBUG_MSG("DNS answers section\n");
-            DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
-         }
+            record_begin = data;
+            std::string name = get_name(data);
 
-         record_begin = data;
-         std::string name = get_name(data);
+            data += get_name_length(data);
 
-         data += get_name_length(data);
+            struct dns_answer* answer = (struct dns_answer*) data;
 
-         struct dns_answer *answer = (struct dns_answer *) data;
+            uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
 
-         uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
-
-         if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
-         DEBUG_MSG("#%7d%8u%8u%12s%s\n", i + 1, ntohs(answer->atype), ntohl(answer->ttl), "",
-                   name.c_str());
-
-         data += sizeof(struct dns_answer);
-         rdlength = ntohs(answer->rdlength);
-         rdata.name = name;
-
-         process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
-         if (DNS_HDR_GET_QR(flags)) {   // Ignore the known answers in a query.
-            filtered_append(rec, name, ntohs(answer->atype), rdata);
-         }
-         data += rdlength;
-      }
-
-      /********************************************************************
-      *****                 DNS Authority RRs section                 *****
-      ********************************************************************/
-
-      for (int i = 0; i < authority_rr_cnt; i++) {
-         DEBUG_CODE(if (i == 0) {
-            DEBUG_MSG("DNS authority RRs section\n");
-            DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
-         });
-
-         record_begin = data;
-         std::string name = get_name(data);
-
-         data += get_name_length(data);
-
-         struct dns_answer *answer = (struct dns_answer *) data;
-
-         uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
-
-         if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
-
-         DEBUG_MSG("#%7d%8u%8u%12s%s\n", i + 1, ntohs(answer->atype), ntohl(answer->ttl), "",
-                   name.c_str());
-
-
-         data += sizeof(struct dns_answer);
-         rdlength = ntohs(answer->rdlength);
-         rdata.name = name;
-
-         process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
-         filtered_append(rec, name, ntohs(answer->atype), rdata);
-
-         data += rdlength;
-      }
-
-      /********************************************************************
-      *****                 DNS Additional RRs section                *****
-      ********************************************************************/
-      for (int i = 0; i < additional_rr_cnt; i++) {
-         DEBUG_CODE(if (i == 0) {
-            DEBUG_MSG("DNS additional RRs section\n");
-            DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
-         });
-
-         record_begin = data;
-
-         std::string name = get_name(data);
-
-         data += get_name_length(data);
-
-         struct dns_answer *answer = (struct dns_answer *) data;
-
-         uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
-
-         if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
-            DEBUG_MSG("DNS parser quits: overflow\n\n");
-            return 1;
-         }
-
-         DEBUG_MSG("#%7d%8u%8u%12s%s\n", i + 1, ntohs(answer->atype), ntohl(answer->ttl), "",
-                   name.c_str());
-
-         rdlength = ntohs(answer->rdlength);
-
-         if (ntohs(answer->atype) != DNS_TYPE_OPT) {
+            if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
+            DEBUG_MSG(
+                "#%7d%8u%8u%12s%s\n",
+                i + 1,
+                ntohs(answer->atype),
+                ntohl(answer->ttl),
+                "",
+                name.c_str());
 
             data += sizeof(struct dns_answer);
+            rdlength = ntohs(answer->rdlength);
             rdata.name = name;
 
             process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
-            if (DNS_HDR_GET_QR(flags)) {
-               filtered_append(rec, name, ntohs(answer->atype), rdata);
+            if (DNS_HDR_GET_QR(flags)) { // Ignore the known answers in a query.
+                filtered_append(rec, name, ntohs(answer->atype), rdata);
             }
-         }
+            data += rdlength;
+        }
 
-         data += rdlength;
-      }
+        /********************************************************************
+        *****                 DNS Authority RRs section                 *****
+        ********************************************************************/
 
-      if (DNS_HDR_GET_QR(flags)) {
-         responses++;
-      } else {
-         queries++;
-      }
+        for (int i = 0; i < authority_rr_cnt; i++) {
+            DEBUG_CODE(if (i == 0) {
+                DEBUG_MSG("DNS authority RRs section\n");
+                DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
+            });
 
-      DEBUG_MSG("DNS parser quits: parsing done\n\n");
-   }
-   catch(const char *err) {
-      DEBUG_MSG("%s\n", err);
-      return false;
-   }
+            record_begin = data;
+            std::string name = get_name(data);
 
-   return true;
+            data += get_name_length(data);
+
+            struct dns_answer* answer = (struct dns_answer*) data;
+
+            uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
+
+            if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
+
+            DEBUG_MSG(
+                "#%7d%8u%8u%12s%s\n",
+                i + 1,
+                ntohs(answer->atype),
+                ntohl(answer->ttl),
+                "",
+                name.c_str());
+
+            data += sizeof(struct dns_answer);
+            rdlength = ntohs(answer->rdlength);
+            rdata.name = name;
+
+            process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
+            filtered_append(rec, name, ntohs(answer->atype), rdata);
+
+            data += rdlength;
+        }
+
+        /********************************************************************
+        *****                 DNS Additional RRs section                *****
+        ********************************************************************/
+        for (int i = 0; i < additional_rr_cnt; i++) {
+            DEBUG_CODE(if (i == 0) {
+                DEBUG_MSG("DNS additional RRs section\n");
+                DEBUG_MSG("%8s%8s%8s%8s%8s\n", "num", "type", "ttl", "port", "name");
+            });
+
+            record_begin = data;
+
+            std::string name = get_name(data);
+
+            data += get_name_length(data);
+
+            struct dns_answer* answer = (struct dns_answer*) data;
+
+            uint32_t tmp = (data - data_begin) + sizeof(dns_answer);
+
+            if (tmp > payload_len || tmp + ntohs(answer->rdlength) > payload_len) {
+                DEBUG_MSG("DNS parser quits: overflow\n\n");
+                return 1;
+            }
+
+            DEBUG_MSG(
+                "#%7d%8u%8u%12s%s\n",
+                i + 1,
+                ntohs(answer->atype),
+                ntohl(answer->ttl),
+                "",
+                name.c_str());
+
+            rdlength = ntohs(answer->rdlength);
+
+            if (ntohs(answer->atype) != DNS_TYPE_OPT) {
+                data += sizeof(struct dns_answer);
+                rdata.name = name;
+
+                process_rdata(record_begin, data, rdata, ntohs(answer->atype), rdlength);
+                if (DNS_HDR_GET_QR(flags)) {
+                    filtered_append(rec, name, ntohs(answer->atype), rdata);
+                }
+            }
+
+            data += rdlength;
+        }
+
+        if (DNS_HDR_GET_QR(flags)) {
+            responses++;
+        } else {
+            queries++;
+        }
+
+        DEBUG_MSG("DNS parser quits: parsing done\n\n");
+    } catch (const char* err) {
+        DEBUG_MSG("%s\n", err);
+        return false;
+    }
+
+    return true;
 }
 
 /**
@@ -604,12 +642,12 @@ bool DNSSDPlugin::parse_dns(const char *data, unsigned int payload_len, bool tcp
  * \param [in,out] rec Pointer to DNSSD extension record
  * \param [in] name Domain name of the DNS record.
  */
-void DNSSDPlugin::filtered_append(RecordExtDNSSD *rec, std::string name)
+void DNSSDPlugin::filtered_append(RecordExtDNSSD* rec, std::string name)
 {
-   if (name.rfind("arpa") == std::string::npos
-       && std::find(rec->queries.begin(), rec->queries.end(), name) == rec->queries.end()) {
-      rec->queries.push_back(name);
-   }
+    if (name.rfind("arpa") == std::string::npos
+        && std::find(rec->queries.begin(), rec->queries.end(), name) == rec->queries.end()) {
+        rec->queries.push_back(name);
+    }
 }
 
 /**
@@ -619,55 +657,59 @@ void DNSSDPlugin::filtered_append(RecordExtDNSSD *rec, std::string name)
  * \param [in] type DNS type id of the DNS record.
  * \param [in] rdata RDATA of the DNS record.
  */
-void DNSSDPlugin::filtered_append(RecordExtDNSSD *rec, std::string name, uint16_t type, DnsSdRr &rdata)
+void DNSSDPlugin::filtered_append(
+    RecordExtDNSSD* rec,
+    std::string name,
+    uint16_t type,
+    DnsSdRr& rdata)
 {
-   if ((type != DNS_TYPE_SRV && type != DNS_TYPE_HINFO && type != DNS_TYPE_TXT)
-       || name.rfind("arpa") != std::string::npos) {
-      return;
-   }
-   std::list<DnsSdRr>::iterator it;
+    if ((type != DNS_TYPE_SRV && type != DNS_TYPE_HINFO && type != DNS_TYPE_TXT)
+        || name.rfind("arpa") != std::string::npos) {
+        return;
+    }
+    std::list<DnsSdRr>::iterator it;
 
-   for (it = rec->responses.begin(); it != rec->responses.end(); it++) {
-      if (it->name == name) {
-         switch (type) {
-         case DNS_TYPE_SRV:
-            it->srv_port = rdata.srv_port;
-            it->srv_target = rdata.srv_target;
-            return;
-         case DNS_TYPE_HINFO:
-            it->hinfo[0] = rdata.hinfo[0];
-            it->hinfo[1] = rdata.hinfo[1];
-            return;
-         case DNS_TYPE_TXT:
-            if (!rdata.txt.empty() && it->txt.find(rdata.txt) == std::string::npos) {
-               it->txt += rdata.txt + ":";
+    for (it = rec->responses.begin(); it != rec->responses.end(); it++) {
+        if (it->name == name) {
+            switch (type) {
+            case DNS_TYPE_SRV:
+                it->srv_port = rdata.srv_port;
+                it->srv_target = rdata.srv_target;
+                return;
+            case DNS_TYPE_HINFO:
+                it->hinfo[0] = rdata.hinfo[0];
+                it->hinfo[1] = rdata.hinfo[1];
+                return;
+            case DNS_TYPE_TXT:
+                if (!rdata.txt.empty() && it->txt.find(rdata.txt) == std::string::npos) {
+                    it->txt += rdata.txt + ":";
+                }
+                return;
+            default:
+                return;
             }
-            return;
-         default:
-            return;
-         }
-      }
-   }
+        }
+    }
 
-   DnsSdRr rr;
+    DnsSdRr rr;
 
-   rr.name = name;
-   switch (type) {
-   case DNS_TYPE_SRV:
-      rr.srv_port = rdata.srv_port;
-      rr.srv_target = rdata.srv_target;
-      break;
-   case DNS_TYPE_HINFO:
-      rr.hinfo[0] = rdata.hinfo[0];
-      rr.hinfo[1] = rdata.hinfo[1];
-      break;
-   case DNS_TYPE_TXT:
-      rr.txt = rdata.txt;
-      break;
-   default:
-      return;
-   }
-   rec->responses.push_back(rr);
+    rr.name = name;
+    switch (type) {
+    case DNS_TYPE_SRV:
+        rr.srv_port = rdata.srv_port;
+        rr.srv_target = rdata.srv_target;
+        break;
+    case DNS_TYPE_HINFO:
+        rr.hinfo[0] = rdata.hinfo[0];
+        rr.hinfo[1] = rdata.hinfo[1];
+        break;
+    case DNS_TYPE_TXT:
+        rr.txt = rdata.txt;
+        break;
+    default:
+        return;
+    }
+    rec->responses.push_back(rr);
 }
 
 /**
@@ -677,18 +719,18 @@ void DNSSDPlugin::filtered_append(RecordExtDNSSD *rec, std::string name, uint16_
  * \param [in] tcp DNS over tcp.
  * \param [out] rec Destination Flow.
  */
-int DNSSDPlugin::add_ext_dnssd(const char *data, unsigned int payload_len, bool tcp, Flow &rec)
+int DNSSDPlugin::add_ext_dnssd(const char* data, unsigned int payload_len, bool tcp, Flow& rec)
 {
-   RecordExtDNSSD *ext = new RecordExtDNSSD();
+    RecordExtDNSSD* ext = new RecordExtDNSSD();
 
-   if (!parse_dns(data, payload_len, tcp, ext)) {
-      delete ext;
+    if (!parse_dns(data, payload_len, tcp, ext)) {
+        delete ext;
 
-      return 0;
-   } else {
-      rec.add_extension(ext);
-   }
-   return 0;
+        return 0;
+    } else {
+        rec.add_extension(ext);
+    }
+    return 0;
 }
 
-}
+} // namespace ipxp

--- a/process/dnssd.hpp
+++ b/process/dnssd.hpp
@@ -29,265 +29,282 @@
 #ifndef IPXP_PROCESS_DNSSD_HPP
 #define IPXP_PROCESS_DNSSD_HPP
 
-#include <string>
+#include <algorithm>
 #include <cstring>
-#include <sstream>
 #include <fstream>
 #include <list>
-#include <algorithm>
+#include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/options.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
 #include "dns-utils.hpp"
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #define DNSSD_UNIREC_TEMPLATE "DNSSD_QUERIES,DNSSD_RESPONSES"
 
-UR_FIELDS (
-   string DNSSD_QUERIES
-   string DNSSD_RESPONSES
-)
+UR_FIELDS(string DNSSD_QUERIES, string DNSSD_RESPONSES)
 
-class DNSSDOptParser : public OptionsParser
-{
+class DNSSDOptParser : public OptionsParser {
 public:
-   bool m_txt_all;
-   std::string m_config_file;
+    bool m_txt_all;
+    std::string m_config_file;
 
-   DNSSDOptParser() : OptionsParser("dnssd", "Processing plugin for parsing DNS service discovery packets"), m_txt_all(false), m_config_file("")
-   {
-      register_option("t", "txt", "FILE", "Activates processing of all txt records. Allow to specify whitelist txt records file (file line format: service.domain,txt_key1,txt_key2,...)",
-         [this](const char *arg){
-            m_txt_all = true;
-            if (arg != nullptr) {m_config_file = arg;}
-            return true;
-         }, OptionFlags::OptionalArgument);
-   }
+    DNSSDOptParser()
+        : OptionsParser("dnssd", "Processing plugin for parsing DNS service discovery packets")
+        , m_txt_all(false)
+        , m_config_file("")
+    {
+        register_option(
+            "t",
+            "txt",
+            "FILE",
+            "Activates processing of all txt records. Allow to specify whitelist txt records file "
+            "(file line format: service.domain,txt_key1,txt_key2,...)",
+            [this](const char* arg) {
+                m_txt_all = true;
+                if (arg != nullptr) {
+                    m_config_file = arg;
+                }
+                return true;
+            },
+            OptionFlags::OptionalArgument);
+    }
 };
 
 struct DnsSdRr {
-   std::string name;
-   int32_t srv_port;
-   std::string srv_target;
-   std::string hinfo[2];
-   std::string txt;
+    std::string name;
+    int32_t srv_port;
+    std::string srv_target;
+    std::string hinfo[2];
+    std::string txt;
 
-   /**
-    * \brief Constructor.
-    */
-   DnsSdRr() {
-      name = std::string();
-      srv_port = -1;
-      srv_target = std::string();
-      hinfo[0] = std::string();
-      txt = std::string();
-   }
+    /**
+     * \brief Constructor.
+     */
+    DnsSdRr()
+    {
+        name = std::string();
+        srv_port = -1;
+        srv_target = std::string();
+        hinfo[0] = std::string();
+        txt = std::string();
+    }
 };
 
 /**
  * \brief Flow record extension header for storing parsed DNSSD packets.
  */
 struct RecordExtDNSSD : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   std::list<std::string> queries;
-   std::list<DnsSdRr> responses;
+    std::list<std::string> queries;
+    std::list<DnsSdRr> responses;
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtDNSSD() : RecordExt(REGISTERED_ID)
-   {
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtDNSSD()
+        : RecordExt(REGISTERED_ID)
+    {
+    }
 
-   /**
-    * \brief Concatenates all collected queries to a single string.
-    * \param [in] max_length Size limit for the output string.
-    * \return String of semicolon separated queries.
-    *
-    * The string will allways contain complete entries.
-    */
-   std::string queries_to_string(size_t max_length) const {
-      std::string ret;
+    /**
+     * \brief Concatenates all collected queries to a single string.
+     * \param [in] max_length Size limit for the output string.
+     * \return String of semicolon separated queries.
+     *
+     * The string will allways contain complete entries.
+     */
+    std::string queries_to_string(size_t max_length) const
+    {
+        std::string ret;
 
-      for (auto it = queries.cbegin(); it != queries.cend(); it++) {
-         if (max_length == std::string::npos) {
-            ret += *it + ";";
-         } else {
-            if (ret.length() + (*it).length() + 1 <= max_length) {
-               ret += *it + ";";
+        for (auto it = queries.cbegin(); it != queries.cend(); it++) {
+            if (max_length == std::string::npos) {
+                ret += *it + ";";
             } else {
-               break;
+                if (ret.length() + (*it).length() + 1 <= max_length) {
+                    ret += *it + ";";
+                } else {
+                    break;
+                }
             }
-         }
-      }
-      return ret;
-   }
+        }
+        return ret;
+    }
 
-   /**
-    * \brief Converts a response to semicolon separated string.
-    * \param [in] response Iterator pointing at the response.
-    */
-   std::string response_to_string(std::list<DnsSdRr>::const_iterator response) const {
-      std::stringstream ret;
+    /**
+     * \brief Converts a response to semicolon separated string.
+     * \param [in] response Iterator pointing at the response.
+     */
+    std::string response_to_string(std::list<DnsSdRr>::const_iterator response) const
+    {
+        std::stringstream ret;
 
-      ret << response->name + ";";
-      ret << response->srv_port << ";";
-      ret << response->srv_target + ";";
-      if (!(response->hinfo[0].empty() && response->hinfo[1].empty())) {
-         ret << response->hinfo[0] << ":" << response->hinfo[1] + ";";
-      } else {
-         ret << ";";
-      }
-      ret << response->txt + ";";
-      return ret.str();
-   }
+        ret << response->name + ";";
+        ret << response->srv_port << ";";
+        ret << response->srv_target + ";";
+        if (!(response->hinfo[0].empty() && response->hinfo[1].empty())) {
+            ret << response->hinfo[0] << ":" << response->hinfo[1] + ";";
+        } else {
+            ret << ";";
+        }
+        ret << response->txt + ";";
+        return ret.str();
+    }
 
-   /**
-    * \brief Concatenates all collected responses to single string.
-    * \param [in] max_length Size limit for the output string.
-    * \return String of semicolon separated responses.
-    *
-    * The string will allways contain complete entries.
-    */
-   std::string responses_to_string(size_t max_length) const {
-      std::string ret, part;
+    /**
+     * \brief Concatenates all collected responses to single string.
+     * \param [in] max_length Size limit for the output string.
+     * \return String of semicolon separated responses.
+     *
+     * The string will allways contain complete entries.
+     */
+    std::string responses_to_string(size_t max_length) const
+    {
+        std::string ret, part;
 
-      for (auto it = responses.cbegin(); it != responses.cend(); it++) {
-         if (max_length == std::string::npos) {
-            ret += response_to_string(it);
-         } else {
-            part = response_to_string(it);
-            if (ret.length() + part.length() + 1 <= max_length) {
-               ret += part;
+        for (auto it = responses.cbegin(); it != responses.cend(); it++) {
+            if (max_length == std::string::npos) {
+                ret += response_to_string(it);
             } else {
-               break;
+                part = response_to_string(it);
+                if (ret.length() + part.length() + 1 <= max_length) {
+                    ret += part;
+                } else {
+                    break;
+                }
             }
-         }
-      }
-      return ret;
-   }
+        }
+        return ret;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set_string(tmplt, record, F_DNSSD_QUERIES, queries_to_string(std::string::npos).c_str());
-      ur_set_string(tmplt, record, F_DNSSD_RESPONSES, responses_to_string(std::string::npos).c_str());
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set_string(tmplt, record, F_DNSSD_QUERIES, queries_to_string(std::string::npos).c_str());
+        ur_set_string(
+            tmplt,
+            record,
+            F_DNSSD_RESPONSES,
+            responses_to_string(std::string::npos).c_str());
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return DNSSD_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return DNSSD_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      std::string queries = queries_to_string(510);
-      std::string responses = responses_to_string(510);
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        std::string queries = queries_to_string(510);
+        std::string responses = responses_to_string(510);
 
-      int length = 0;
-      int qry_len = queries.length();
-      int resp_len = responses.length();
+        int length = 0;
+        int qry_len = queries.length();
+        int resp_len = responses.length();
 
-      if (qry_len + resp_len + 6 > size) {
-         return -1;
-      }
+        if (qry_len + resp_len + 6 > size) {
+            return -1;
+        }
 
-      if (qry_len >= 255) {
-         buffer[length++] = 255;
-         *(uint16_t *)(buffer + length) = ntohs(qry_len);
-         length += sizeof(uint16_t);
-      } else {
-         buffer[length++] = qry_len;
-      }
-      memcpy(buffer + length, queries.c_str(), qry_len);
-      length += qry_len;
+        if (qry_len >= 255) {
+            buffer[length++] = 255;
+            *(uint16_t*) (buffer + length) = ntohs(qry_len);
+            length += sizeof(uint16_t);
+        } else {
+            buffer[length++] = qry_len;
+        }
+        memcpy(buffer + length, queries.c_str(), qry_len);
+        length += qry_len;
 
-      if (resp_len >= 255) {
-         buffer[length++] = 255;
-         *(uint16_t *)(buffer + length) = ntohs(resp_len);
-         length += sizeof(uint16_t);
-      } else {
-         buffer[length++] = resp_len;
-      }
-      memcpy(buffer + length, responses.c_str(), resp_len);
-      length += resp_len;
+        if (resp_len >= 255) {
+            buffer[length++] = 255;
+            *(uint16_t*) (buffer + length) = ntohs(resp_len);
+            length += sizeof(uint16_t);
+        } else {
+            buffer[length++] = resp_len;
+        }
+        memcpy(buffer + length, responses.c_str(), resp_len);
+        length += resp_len;
 
-      return length;
-   }
+        return length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_DNSSD_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_DNSSD_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "dnssdqueries=\"" << queries_to_string(std::string::npos) << "\""
-         << ",dnssdresponses=\"" << responses_to_string(std::string::npos) << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "dnssdqueries=\"" << queries_to_string(std::string::npos) << "\""
+            << ",dnssdresponses=\"" << responses_to_string(std::string::npos) << "\"";
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing DNSSD packets.
  */
-class DNSSDPlugin : public ProcessPlugin
-{
+class DNSSDPlugin : public ProcessPlugin {
 public:
-   DNSSDPlugin();
-   ~DNSSDPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new DNSSDOptParser(); }
-   std::string get_name() const { return "dnssd"; }
-   RecordExt *get_ext() const { return new RecordExtDNSSD(); }
-   ProcessPlugin *copy();
+    DNSSDPlugin();
+    ~DNSSDPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new DNSSDOptParser(); }
+    std::string get_name() const { return "dnssd"; }
+    RecordExt* get_ext() const { return new RecordExtDNSSD(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   bool txt_all_records;   /**< Indicator whether to process all TXT recods. */
-   uint32_t queries;       /**< Total number of parsed DNS queries. */
-   uint32_t responses;     /**< Total number of parsed DNS responses. */
-   uint32_t total;         /**< Total number of parsed DNS packets. */
+    bool txt_all_records; /**< Indicator whether to process all TXT recods. */
+    uint32_t queries; /**< Total number of parsed DNS queries. */
+    uint32_t responses; /**< Total number of parsed DNS responses. */
+    uint32_t total; /**< Total number of parsed DNS packets. */
 
-   const char *data_begin; /**< Pointer to begin of payload. */
-   uint32_t data_len;      /**< Length of packet payload. */
+    const char* data_begin; /**< Pointer to begin of payload. */
+    uint32_t data_len; /**< Length of packet payload. */
 
-   bool parse_dns(const char *data, unsigned int payload_len, bool tcp, RecordExtDNSSD *rec);
-   int  add_ext_dnssd(const char *data, unsigned int payload_len, bool tcp, Flow &rec);
-   void process_rdata(const char *record_begin, const char *data, DnsSdRr &rdata, uint16_t type, size_t length) const;
-   void filtered_append(RecordExtDNSSD *rec, std::string name);
-   void filtered_append(RecordExtDNSSD *rec, std::string name, uint16_t type, DnsSdRr &rdata);
+    bool parse_dns(const char* data, unsigned int payload_len, bool tcp, RecordExtDNSSD* rec);
+    int add_ext_dnssd(const char* data, unsigned int payload_len, bool tcp, Flow& rec);
+    void process_rdata(
+        const char* record_begin,
+        const char* data,
+        DnsSdRr& rdata,
+        uint16_t type,
+        size_t length) const;
+    void filtered_append(RecordExtDNSSD* rec, std::string name);
+    void filtered_append(RecordExtDNSSD* rec, std::string name, uint16_t type, DnsSdRr& rdata);
 
-   std::string get_name(const char *data) const;
-   size_t get_name_length(const char *data) const;
-   const std::string get_service_str(std::string &name) const;
+    std::string get_name(const char* data) const;
+    size_t get_name_length(const char* data) const;
+    const std::string get_service_str(std::string& name) const;
 
-   bool parse_params(const std::string &params, std::string &config_file);
-   void load_txtconfig(const char *config_file);
-   bool matches_service(std::list<std::pair<std::string, std::list<std::string> > >::const_iterator &it, std::string &name) const;
+    bool parse_params(const std::string& params, std::string& config_file);
+    void load_txtconfig(const char* config_file);
+    bool matches_service(
+        std::list<std::pair<std::string, std::list<std::string>>>::const_iterator& it,
+        std::string& name) const;
 
-   std::list<std::pair<std::string, std::list<std::string> > > txt_config;   /**< Configuration for TXT record filter. */
+    std::list<std::pair<std::string, std::list<std::string>>>
+        txt_config; /**< Configuration for TXT record filter. */
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_DNSSD_HPP */

--- a/process/flexprobe-data-processing.cpp
+++ b/process/flexprobe-data-processing.cpp
@@ -34,9 +34,10 @@ int FlexprobeData::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("flexprobe-data", [](){return new FlexprobeDataProcessing();});
-   register_plugin(&rec);
+    static PluginRecord rec
+        = PluginRecord("flexprobe-data", []() { return new FlexprobeDataProcessing(); });
+    register_plugin(&rec);
     FlexprobeData::REGISTERED_ID = register_extension();
 }
 
-}
+} // namespace ipxp

--- a/process/flexprobe-encryption-processing.cpp
+++ b/process/flexprobe-encryption-processing.cpp
@@ -1,8 +1,7 @@
 /**
  * \file flexprobe-encryption-processing.cpp
- * \brief Traffic feature processing for encryption analysis for Flexprobe -- HW accelerated network probe
- * \author Roman Vrana <ivrana@fit.vutbr.cz>
- * \date 2021
+ * \brief Traffic feature processing for encryption analysis for Flexprobe -- HW accelerated network
+ * probe \author Roman Vrana <ivrana@fit.vutbr.cz> \date 2021
  */
 /*
  * Copyright (C) 2021 CESNET
@@ -35,9 +34,10 @@ int FlexprobeEncryptionData::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("flexprobe-encrypt", [](){return new FlexprobeEncryptionProcessing();});
-   register_plugin(&rec);
-   FlexprobeEncryptionData::REGISTERED_ID = register_extension();
+    static PluginRecord rec
+        = PluginRecord("flexprobe-encrypt", []() { return new FlexprobeEncryptionProcessing(); });
+    register_plugin(&rec);
+    FlexprobeEncryptionData::REGISTERED_ID = register_extension();
 }
 
 int FlexprobeEncryptionProcessing::post_create(Flow& rec, const Packet& pkt)
@@ -60,8 +60,11 @@ int FlexprobeEncryptionProcessing::post_update(Flow& rec, const Packet& pkt)
     auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData*>(pkt.custom);
 
     auto arrival = data_view->arrival_time.to_decimal();
-    Flexprobe::Timestamp::DecimalTimestamp flow_end = static_cast<Flexprobe::Timestamp::DecimalTimestamp>(rec.time_last.tv_sec) + static_cast<Flexprobe::Timestamp::DecimalTimestamp>(rec.time_last.tv_usec) * 1e-6f;
-    auto encr_data = dynamic_cast<FlexprobeEncryptionData*>(rec.get_extension(FlexprobeEncryptionData::REGISTERED_ID));
+    Flexprobe::Timestamp::DecimalTimestamp flow_end
+        = static_cast<Flexprobe::Timestamp::DecimalTimestamp>(rec.time_last.tv_sec)
+        + static_cast<Flexprobe::Timestamp::DecimalTimestamp>(rec.time_last.tv_usec) * 1e-6f;
+    auto encr_data = dynamic_cast<FlexprobeEncryptionData*>(
+        rec.get_extension(FlexprobeEncryptionData::REGISTERED_ID));
     auto total_packets = rec.src_packets + rec.dst_packets;
 
     encr_data->time_interpacket.update(arrival - flow_end, total_packets);
@@ -69,17 +72,17 @@ int FlexprobeEncryptionProcessing::post_update(Flow& rec, const Packet& pkt)
 
     if (data_view->payload_size >= 256) {
         encr_data->mpe8_valid_count += 1;
-        //TODO: update value
+        // TODO: update value
         encr_data->mpe_8bit.update(1, encr_data->mpe8_valid_count);
     }
 
     if (data_view->payload_size >= 16) {
         encr_data->mpe4_valid_count += 1;
-        //TODO: update value
+        // TODO: update value
         encr_data->mpe_4bit.update(1, encr_data->mpe4_valid_count);
     }
 
     return 0;
 }
 
-}
+} // namespace ipxp

--- a/process/flexprobe-tcp-tracking.cpp
+++ b/process/flexprobe-tcp-tracking.cpp
@@ -29,124 +29,129 @@
 #include "flexprobe-tcp-tracking.h"
 #include "flexprobe-data.h"
 
-namespace ipxp
+namespace ipxp {
+int TcpTrackingData::REGISTERED_ID = -1;
+
+__attribute__((constructor)) static void register_this_plugin()
 {
-    int TcpTrackingData::REGISTERED_ID = -1;
+    static PluginRecord rec
+        = PluginRecord("flexprobe-tcp", []() { return new FlexprobeTcpTracking(); });
+    register_plugin(&rec);
+    TcpTrackingData::REGISTERED_ID = register_extension();
+}
 
-    __attribute__((constructor)) static void register_this_plugin()
-    {
-        static PluginRecord rec = PluginRecord("flexprobe-tcp", []()
-        { return new FlexprobeTcpTracking(); });
-        register_plugin(&rec);
-        TcpTrackingData::REGISTERED_ID = register_extension();
+std::uint32_t FlexprobeTcpTracking::advance_expected_seq_(
+    std::uint32_t current_seq,
+    std::uint16_t payload_len,
+    bool syn,
+    bool fin)
+{
+    return current_seq + payload_len + (syn ? 1 : 0) + (fin ? 1 : 0);
+}
+
+FlowState
+FlexprobeTcpTracking::check_(TcpTrackingData& td, std::uint32_t tcp_seq, unsigned direction)
+{
+    FlowState fs = FlowState::OK;
+
+    if (td.expected_seq[direction] > tcp_seq) {
+        if (td.tracker_state[direction] != TrackerState::INLINE) {
+            fs = FlowState::PACKET_LOSS;
+        }
+        td.tracker_state[direction] = TrackerState::AHEAD;
+    } else if (td.expected_seq[direction] < tcp_seq) {
+        if (td.tracker_state[direction] != TrackerState::INLINE) {
+            fs = FlowState::PACKET_LOSS;
+        }
+        td.tracker_state[direction] = TrackerState::BEHIND;
+    } else {
+        if (td.tracker_state[direction] == TrackerState::BEHIND) {
+            fs = FlowState::PACKET_LOSS;
+        }
+
+        td.tracker_state[direction] = TrackerState::INLINE;
     }
 
-    std::uint32_t
-    FlexprobeTcpTracking::advance_expected_seq_(std::uint32_t current_seq, std::uint16_t payload_len, bool syn,
-                                                bool fin)
-    {
-        return current_seq + payload_len + (syn ? 1 : 0) + (fin ? 1 : 0);
-    }
+    return direction == 0 ? fs : FlowState::OK;
+}
 
-    FlowState FlexprobeTcpTracking::check_(TcpTrackingData& td, std::uint32_t tcp_seq, unsigned direction)
-    {
-        FlowState fs = FlowState::OK;
-
-        if (td.expected_seq[direction] > tcp_seq) {
-            if (td.tracker_state[direction] != TrackerState::INLINE) {
-                fs = FlowState::PACKET_LOSS;
-            }
-            td.tracker_state[direction] = TrackerState::AHEAD;
-        } else if (td.expected_seq[direction] < tcp_seq) {
-            if (td.tracker_state[direction] != TrackerState::INLINE) {
-                fs = FlowState::PACKET_LOSS;
-            }
-            td.tracker_state[direction] = TrackerState::BEHIND;
-        } else {
-            if (td.tracker_state[direction] == TrackerState::BEHIND) {
-                fs = FlowState::PACKET_LOSS;
-            }
-
-            td.tracker_state[direction] = TrackerState::INLINE;
-        }
-
-        return direction == 0 ? fs : FlowState::OK;
-    }
-
-    int FlexprobeTcpTracking::post_create(Flow& rec, const Packet& pkt)
-    {
-        if (!pkt.custom) {
-            return 0;
-        }
-
-        if (pkt.ip_proto != 0x6) { // track only TCP
-            return 0;
-        }
-
-        auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData *>(pkt.custom);
-
-        if (!rec.get_extension(TcpTrackingData::REGISTERED_ID)) {
-            auto *td = new TcpTrackingData();
-
-            auto direction = pkt.source_pkt ? 0 : 1;
-
-            td->expected_seq[direction] = advance_expected_seq_(pkt.tcp_seq,
-                                                                data_view->payload_size,
-                                                                pkt.tcp_flags & 0x2,
-                                                                pkt.tcp_flags & 0x1);
-            direction = direction == 0 ? 1 : 0;
-            td->expected_seq[direction] = pkt.tcp_ack; // TODO: add to HW
-            rec.add_extension(td);
-        }
-
+int FlexprobeTcpTracking::post_create(Flow& rec, const Packet& pkt)
+{
+    if (!pkt.custom) {
         return 0;
     }
 
-    int FlexprobeTcpTracking::post_update(Flow& rec, const Packet& pkt)
-    {
-        if (!pkt.custom) {
-            return 0;
-        }
+    if (pkt.ip_proto != 0x6) { // track only TCP
+        return 0;
+    }
 
-        if (pkt.ip_proto != 0x6) { // track only TCP
-            return 0;
-        }
+    auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData*>(pkt.custom);
 
-        auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData *>(pkt.custom);
+    if (!rec.get_extension(TcpTrackingData::REGISTERED_ID)) {
+        auto* td = new TcpTrackingData();
 
-        auto tcp_data = dynamic_cast<TcpTrackingData *>(rec.get_extension(TcpTrackingData::REGISTERED_ID));
-        auto next_tcp = pkt.tcp_seq;
         auto direction = pkt.source_pkt ? 0 : 1;
 
-        //skip check if SYN and ACK present and dst -> src at 0)
-        if ((pkt.tcp_flags & 0x12) && tcp_data->expected_seq[direction] == 0) {
-            tcp_data->expected_seq[direction] = advance_expected_seq_(next_tcp,
-                                                                      data_view->payload_size,
-                                                                      pkt.tcp_flags & 0x2,
-                                                                      pkt.tcp_flags & 0x1);
-            return 0;
-        }
-        auto check_result = check_(*tcp_data, next_tcp, direction);
-        if (check_result == FlowState::PACKET_LOSS) {
-            tcp_data->result = TcpResult::INCOMPLETE;
-        }
+        td->expected_seq[direction] = advance_expected_seq_(
+            pkt.tcp_seq,
+            data_view->payload_size,
+            pkt.tcp_flags & 0x2,
+            pkt.tcp_flags & 0x1);
+        direction = direction == 0 ? 1 : 0;
+        td->expected_seq[direction] = pkt.tcp_ack; // TODO: add to HW
+        rec.add_extension(td);
+    }
 
-        switch (tcp_data->tracker_state[direction]) {
-            case TrackerState::INLINE:
-                tcp_data->expected_seq[direction] = advance_expected_seq_(
-                        tcp_data->expected_seq[direction],
-                        data_view->payload_size,
-                        pkt.tcp_flags & 0x2,
-                        pkt.tcp_flags & 0x1);
-                break;
-            case TrackerState::BEHIND:
-                tcp_data->expected_seq[direction] = next_tcp;
-                break;
-            default:
-                break;
-        }
+    return 0;
+}
 
+int FlexprobeTcpTracking::post_update(Flow& rec, const Packet& pkt)
+{
+    if (!pkt.custom) {
         return 0;
     }
 
+    if (pkt.ip_proto != 0x6) { // track only TCP
+        return 0;
+    }
+
+    auto data_view = reinterpret_cast<const Flexprobe::FlexprobeData*>(pkt.custom);
+
+    auto tcp_data
+        = dynamic_cast<TcpTrackingData*>(rec.get_extension(TcpTrackingData::REGISTERED_ID));
+    auto next_tcp = pkt.tcp_seq;
+    auto direction = pkt.source_pkt ? 0 : 1;
+
+    // skip check if SYN and ACK present and dst -> src at 0)
+    if ((pkt.tcp_flags & 0x12) && tcp_data->expected_seq[direction] == 0) {
+        tcp_data->expected_seq[direction] = advance_expected_seq_(
+            next_tcp,
+            data_view->payload_size,
+            pkt.tcp_flags & 0x2,
+            pkt.tcp_flags & 0x1);
+        return 0;
+    }
+    auto check_result = check_(*tcp_data, next_tcp, direction);
+    if (check_result == FlowState::PACKET_LOSS) {
+        tcp_data->result = TcpResult::INCOMPLETE;
+    }
+
+    switch (tcp_data->tracker_state[direction]) {
+    case TrackerState::INLINE:
+        tcp_data->expected_seq[direction] = advance_expected_seq_(
+            tcp_data->expected_seq[direction],
+            data_view->payload_size,
+            pkt.tcp_flags & 0x2,
+            pkt.tcp_flags & 0x1);
+        break;
+    case TrackerState::BEHIND:
+        tcp_data->expected_seq[direction] = next_tcp;
+        break;
+    default:
+        break;
+    }
+
+    return 0;
 }
+
+} // namespace ipxp

--- a/process/flow_hash.cpp
+++ b/process/flow_hash.cpp
@@ -36,33 +36,25 @@ int RecordExtFLOW_HASH::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-    static PluginRecord rec = PluginRecord("flow_hash", [](){return new FLOW_HASHPlugin();});
+    static PluginRecord rec = PluginRecord("flow_hash", []() { return new FLOW_HASHPlugin(); });
     register_plugin(&rec);
     RecordExtFLOW_HASH::REGISTERED_ID = register_extension();
 }
 
-FLOW_HASHPlugin::FLOW_HASHPlugin()
-{
-}
+FLOW_HASHPlugin::FLOW_HASHPlugin() {}
 
-FLOW_HASHPlugin::~FLOW_HASHPlugin()
-{
-}
+FLOW_HASHPlugin::~FLOW_HASHPlugin() {}
 
-void FLOW_HASHPlugin::init(const char *params)
-{
-}
+void FLOW_HASHPlugin::init(const char* params) {}
 
-void FLOW_HASHPlugin::close()
-{
-}
+void FLOW_HASHPlugin::close() {}
 
-ProcessPlugin *FLOW_HASHPlugin::copy()
+ProcessPlugin* FLOW_HASHPlugin::copy()
 {
     return new FLOW_HASHPlugin(*this);
 }
 
-int FLOW_HASHPlugin::post_create(Flow &rec, const Packet &pkt)
+int FLOW_HASHPlugin::post_create(Flow& rec, const Packet& pkt)
 {
     auto ext = new RecordExtFLOW_HASH();
 
@@ -73,5 +65,4 @@ int FLOW_HASHPlugin::post_create(Flow &rec, const Packet &pkt)
     return 0;
 }
 
-}
-
+} // namespace ipxp

--- a/process/flow_hash.hpp
+++ b/process/flow_hash.hpp
@@ -32,25 +32,23 @@
 #include <cstring>
 
 #ifdef WITH_NEMEA
-  #include "fields.h"
+#include "fields.h"
 #endif
 
-#include <string>
 #include <sstream>
+#include <string>
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
 #include <ipfixprobe/byte-utils.hpp>
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #define FLOW_HASH_UNIREC_TEMPLATE "FLOW_ID"
 
-UR_FIELDS (
-    uint64 FLOW_ID
-)
+UR_FIELDS(uint64 FLOW_ID)
 
 /**
  * \brief Flow record extension header for storing parsed FLOW_HASH data.
@@ -61,24 +59,22 @@ struct RecordExtFLOW_HASH : public RecordExt {
     // Value in host byte order
     uint64_t flow_hash;
 
-    RecordExtFLOW_HASH() : RecordExt(REGISTERED_ID)
+    RecordExtFLOW_HASH()
+        : RecordExt(REGISTERED_ID)
     {
         flow_hash = 0;
     }
 
 #ifdef WITH_NEMEA
-   void fill_unirec(ur_template_t *tmplt, void *record) override
+    void fill_unirec(ur_template_t* tmplt, void* record) override
     {
         ur_set(tmplt, record, F_FLOW_ID, flow_hash);
     }
 
-    const char *get_unirec_tmplt() const
-    {
-        return FLOW_HASH_UNIREC_TEMPLATE;
-    }
+    const char* get_unirec_tmplt() const { return FLOW_HASH_UNIREC_TEMPLATE; }
 #endif
 
-    int fill_ipfix(uint8_t *buffer, int size) override
+    int fill_ipfix(uint8_t* buffer, int size) override
     {
         constexpr int LEN = sizeof(flow_hash);
 
@@ -87,17 +83,14 @@ struct RecordExtFLOW_HASH : public RecordExt {
         }
 
         // value is converted from host byte-order to network byte-order
-        *reinterpret_cast<decltype(flow_hash) *>(buffer) = swap_uint64(flow_hash);
+        *reinterpret_cast<decltype(flow_hash)*>(buffer) = swap_uint64(flow_hash);
 
         return LEN;
     }
 
-    const char **get_ipfix_tmplt() const
+    const char** get_ipfix_tmplt() const
     {
-        static const char *ipfix_template[] = {
-            IPFIX_FLOW_HASH_TEMPLATE(IPFIX_FIELD_NAMES)
-            NULL
-        };
+        static const char* ipfix_template[] = {IPFIX_FLOW_HASH_TEMPLATE(IPFIX_FIELD_NAMES) NULL};
         return ipfix_template;
     }
 
@@ -113,21 +106,22 @@ struct RecordExtFLOW_HASH : public RecordExt {
 /**
  * \brief Process plugin for parsing FLOW_HASH packets.
  */
-class FLOW_HASHPlugin : public ProcessPlugin
-{
+class FLOW_HASHPlugin : public ProcessPlugin {
 public:
     FLOW_HASHPlugin();
     ~FLOW_HASHPlugin();
-    void init(const char *params);
+    void init(const char* params);
     void close();
-    OptionsParser *get_parser() const { return new OptionsParser("flow_hash", "Export flow hash as flow id"); }
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser("flow_hash", "Export flow hash as flow id");
+    }
     std::string get_name() const { return "flow_hash"; }
-    RecordExt *get_ext() const { return new RecordExtFLOW_HASH(); }
-    ProcessPlugin *copy();
+    RecordExt* get_ext() const { return new RecordExtFLOW_HASH(); }
+    ProcessPlugin* copy();
 
-    int post_create(Flow &rec, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_FLOW_HASH_HPP */
-

--- a/process/http.cpp
+++ b/process/http.cpp
@@ -44,9 +44,9 @@ int RecordExtHTTP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-	static PluginRecord rec = PluginRecord("http", []() { return new HTTPPlugin(); });
-	register_plugin(&rec);
-	RecordExtHTTP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("http", []() { return new HTTPPlugin(); });
+    register_plugin(&rec);
+    RecordExtHTTP::REGISTERED_ID = register_extension();
 }
 
 // #define DEBUG_HTTP
@@ -71,87 +71,87 @@ __attribute__((constructor)) static void register_this_plugin()
 #define STRING_DELIMITER ";"
 
 HTTPPlugin::HTTPPlugin()
-	: recPrealloc(nullptr)
-	, flow_flush(false)
-	, requests(0)
-	, responses(0)
-	, total(0)
+    : recPrealloc(nullptr)
+    , flow_flush(false)
+    , requests(0)
+    , responses(0)
+    , total(0)
 {
 }
 
 HTTPPlugin::~HTTPPlugin()
 {
-	close();
+    close();
 }
 
 void HTTPPlugin::init(const char* params) {}
 
 void HTTPPlugin::close()
 {
-	if (recPrealloc != nullptr) {
-		delete recPrealloc;
-		recPrealloc = nullptr;
-	}
+    if (recPrealloc != nullptr) {
+        delete recPrealloc;
+        recPrealloc = nullptr;
+    }
 }
 
 ProcessPlugin* HTTPPlugin::copy()
 {
-	return new HTTPPlugin(*this);
+    return new HTTPPlugin(*this);
 }
 
 int HTTPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-	const char* payload = reinterpret_cast<const char*>(pkt.payload);
-	if (is_request(payload, pkt.payload_len)) {
-		add_ext_http_request(payload, pkt.payload_len, rec);
-	} else if (is_response(payload, pkt.payload_len)) {
-		add_ext_http_response(payload, pkt.payload_len, rec);
-	}
+    const char* payload = reinterpret_cast<const char*>(pkt.payload);
+    if (is_request(payload, pkt.payload_len)) {
+        add_ext_http_request(payload, pkt.payload_len, rec);
+    } else if (is_response(payload, pkt.payload_len)) {
+        add_ext_http_response(payload, pkt.payload_len, rec);
+    }
 
-	return 0;
+    return 0;
 }
 
 int HTTPPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-	RecordExt* ext = nullptr;
-	const char* payload = reinterpret_cast<const char*>(pkt.payload);
-	if (is_request(payload, pkt.payload_len)) {
-		ext = rec.get_extension(RecordExtHTTP::REGISTERED_ID);
-		if (ext == nullptr) { /* Check if header is present in flow. */
-			add_ext_http_request(payload, pkt.payload_len, rec);
-			return 0;
-		}
+    RecordExt* ext = nullptr;
+    const char* payload = reinterpret_cast<const char*>(pkt.payload);
+    if (is_request(payload, pkt.payload_len)) {
+        ext = rec.get_extension(RecordExtHTTP::REGISTERED_ID);
+        if (ext == nullptr) { /* Check if header is present in flow. */
+            add_ext_http_request(payload, pkt.payload_len, rec);
+            return 0;
+        }
 
-		parse_http_request(payload, pkt.payload_len, static_cast<RecordExtHTTP*>(ext));
-		if (flow_flush) {
-			flow_flush = false;
-			return FLOW_FLUSH_WITH_REINSERT;
-		}
-	} else if (is_response(payload, pkt.payload_len)) {
-		ext = rec.get_extension(RecordExtHTTP::REGISTERED_ID);
-		if (ext == nullptr) { /* Check if header is present in flow. */
-			add_ext_http_response(payload, pkt.payload_len, rec);
-			return 0;
-		}
+        parse_http_request(payload, pkt.payload_len, static_cast<RecordExtHTTP*>(ext));
+        if (flow_flush) {
+            flow_flush = false;
+            return FLOW_FLUSH_WITH_REINSERT;
+        }
+    } else if (is_response(payload, pkt.payload_len)) {
+        ext = rec.get_extension(RecordExtHTTP::REGISTERED_ID);
+        if (ext == nullptr) { /* Check if header is present in flow. */
+            add_ext_http_response(payload, pkt.payload_len, rec);
+            return 0;
+        }
 
-		parse_http_response(payload, pkt.payload_len, static_cast<RecordExtHTTP*>(ext));
-		if (flow_flush) {
-			flow_flush = false;
-			return FLOW_FLUSH_WITH_REINSERT;
-		}
-	}
+        parse_http_response(payload, pkt.payload_len, static_cast<RecordExtHTTP*>(ext));
+        if (flow_flush) {
+            flow_flush = false;
+            return FLOW_FLUSH_WITH_REINSERT;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 void HTTPPlugin::finish(bool print_stats)
 {
-	if (print_stats) {
-		std::cout << "HTTP plugin stats:" << std::endl;
-		std::cout << "   Parsed http requests: " << requests << std::endl;
-		std::cout << "   Parsed http responses: " << responses << std::endl;
-		std::cout << "   Total http packets processed: " << total << std::endl;
-	}
+    if (print_stats) {
+        std::cout << "HTTP plugin stats:" << std::endl;
+        std::cout << "   Parsed http requests: " << requests << std::endl;
+        std::cout << "   Parsed http responses: " << responses << std::endl;
+        std::cout << "   Total http packets processed: " << total << std::endl;
+    }
 }
 
 /**
@@ -164,22 +164,22 @@ void HTTPPlugin::finish(bool print_stats)
  */
 void copy_str(char* dst, ssize_t size, const char* begin, const char* end)
 {
-	ssize_t len = end - begin;
-	if (len >= size) {
-		len = size - 1;
-	}
+    ssize_t len = end - begin;
+    if (len >= size) {
+        len = size - 1;
+    }
 
-	memcpy(dst, begin, len);
+    memcpy(dst, begin, len);
 
-	if (len >= 1 && dst[len - 1] == '\n') {
-		len--;
-	}
+    if (len >= 1 && dst[len - 1] == '\n') {
+        len--;
+    }
 
-	if (len >= 1 && dst[len - 1] == '\r') {
-		len--;
-	}
+    if (len >= 1 && dst[len - 1] == '\r') {
+        len--;
+    }
 
-	dst[len] = 0;
+    dst[len] = 0;
 }
 
 /**
@@ -191,65 +191,65 @@ void copy_str(char* dst, ssize_t size, const char* begin, const char* end)
  */
 void add_str(char* dst, ssize_t size, const char* begin, const char* end, const char* delimiter)
 {
-	ssize_t len_of_dst = strlen(dst);
-	ssize_t len_of_delimiter = strlen(delimiter);
-	ssize_t len = end - begin;
-	if (len_of_dst > 0) {
-		if (len_of_dst + len_of_delimiter + 1 >= size) {
-			return;
-		}
-		if (len + len_of_dst + len_of_delimiter >= size) {
-			len = size - len_of_dst - len_of_delimiter - 1;
-		}
-		dst = strcat(dst, delimiter);
+    ssize_t len_of_dst = strlen(dst);
+    ssize_t len_of_delimiter = strlen(delimiter);
+    ssize_t len = end - begin;
+    if (len_of_dst > 0) {
+        if (len_of_dst + len_of_delimiter + 1 >= size) {
+            return;
+        }
+        if (len + len_of_dst + len_of_delimiter >= size) {
+            len = size - len_of_dst - len_of_delimiter - 1;
+        }
+        dst = strcat(dst, delimiter);
 
-		dst[len_of_dst + len_of_delimiter] = 0;
-	} else if (len + len_of_dst > size) {
-		len = size - len_of_dst - 1;
-	}
-	char src[len + 1];
-	memcpy(src, begin, len);
-	src[len] = 0;
-	strcat(dst, src);
-	if (len >= 1 && dst[len - 1] == '\n') {
-		len--;
-	}
+        dst[len_of_dst + len_of_delimiter] = 0;
+    } else if (len + len_of_dst > size) {
+        len = size - len_of_dst - 1;
+    }
+    char src[len + 1];
+    memcpy(src, begin, len);
+    src[len] = 0;
+    strcat(dst, src);
+    if (len >= 1 && dst[len - 1] == '\n') {
+        len--;
+    }
 
-	if (len >= 1 && dst[len - 1] == '\r') {
-		len--;
-	}
-	if (len_of_dst > 0)
-		dst[len + len_of_dst + len_of_delimiter] = 0;
-	else
-		dst[len] = 0;
+    if (len >= 1 && dst[len - 1] == '\r') {
+        len--;
+    }
+    if (len_of_dst > 0)
+        dst[len + len_of_dst + len_of_delimiter] = 0;
+    else
+        dst[len] = 0;
 }
 
 bool HTTPPlugin::is_request(const char* data, int payload_len)
 {
-	char chars[5];
+    char chars[5];
 
-	if (payload_len < 4) {
-		return false;
-	}
-	memcpy(chars, data, 4);
-	chars[4] = 0;
+    if (payload_len < 4) {
+        return false;
+    }
+    memcpy(chars, data, 4);
+    chars[4] = 0;
 
-	// 'valid_http_method' can quicky confirm valid http methods.
-	// 'invalid_http_method' is slower but can check if it is http request even
-	// if the method is invalid.
-	return valid_http_method(chars) || invalid_http_method(data, payload_len);
+    // 'valid_http_method' can quicky confirm valid http methods.
+    // 'invalid_http_method' is slower but can check if it is http request even
+    // if the method is invalid.
+    return valid_http_method(chars) || invalid_http_method(data, payload_len);
 }
 
 bool HTTPPlugin::is_response(const char* data, int payload_len)
 {
-	char chars[5];
+    char chars[5];
 
-	if (payload_len < 4) {
-		return false;
-	}
-	memcpy(chars, data, 4);
-	chars[4] = 0;
-	return !strcmp(chars, "HTTP");
+    if (payload_len < 4) {
+        return false;
+    }
+    memcpy(chars, data, 4);
+    chars[4] = 0;
+    return !strcmp(chars, "HTTP");
 }
 
 #ifdef DEBUG_HTTP
@@ -265,141 +265,141 @@ static uint32_t s_requests = 0, s_responses = 0;
  */
 bool HTTPPlugin::parse_http_request(const char* data, int payload_len, RecordExtHTTP* rec)
 {
-	char buffer[64];
-	size_t remaining;
-	const char *begin, *end, *keyval_delimiter;
+    char buffer[64];
+    size_t remaining;
+    const char *begin, *end, *keyval_delimiter;
 
-	total++;
+    total++;
 
-	DEBUG_MSG("---------- http parser #%u ----------\n", total);
-	DEBUG_MSG("Parsing request number: %u\n", ++s_requests);
-	DEBUG_MSG("Payload length: %u\n\n", payload_len);
+    DEBUG_MSG("---------- http parser #%u ----------\n", total);
+    DEBUG_MSG("Parsing request number: %u\n", ++s_requests);
+    DEBUG_MSG("Payload length: %u\n\n", payload_len);
 
-	if (payload_len == 0) {
-		DEBUG_MSG("Parser quits:\tpayload length = 0\n");
-		return false;
-	}
+    if (payload_len == 0) {
+        DEBUG_MSG("Parser quits:\tpayload length = 0\n");
+        return false;
+    }
 
-	/* Request line:
-	 *
-	 * METHOD URI VERSION
-	 * |     |   |
-	 * |     |   -------- end
-	 * |     ------------ begin
-	 * ----- ------------ data
-	 */
+    /* Request line:
+     *
+     * METHOD URI VERSION
+     * |     |   |
+     * |     |   -------- end
+     * |     ------------ begin
+     * ----- ------------ data
+     */
 
-	/* Find begin of URI. */
-	begin = static_cast<const char*>(memchr(data, ' ', payload_len));
-	if (begin == nullptr) {
-		DEBUG_MSG("Parser quits:\tnot a http request header\n");
-		return false;
-	}
+    /* Find begin of URI. */
+    begin = static_cast<const char*>(memchr(data, ' ', payload_len));
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tnot a http request header\n");
+        return false;
+    }
 
-	/* Find end of URI. */
-	if (check_payload_len(payload_len, (begin + 1) - data)) {
-		DEBUG_MSG("Parser quits:\tpayload end\n");
-		return false;
-	}
+    /* Find end of URI. */
+    if (check_payload_len(payload_len, (begin + 1) - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
 
-	remaining = payload_len - ((begin + 1) - data);
-	end = static_cast<const char*>(memchr(begin + 1, ' ', remaining));
+    remaining = payload_len - ((begin + 1) - data);
+    end = static_cast<const char*>(memchr(begin + 1, ' ', remaining));
 
-	if (end == nullptr) {
-		DEBUG_MSG("Parser quits:\trequest is fragmented\n");
-		return false;
-	}
+    if (end == nullptr) {
+        DEBUG_MSG("Parser quits:\trequest is fragmented\n");
+        return false;
+    }
 
-	if (memcmp(end + 1, "HTTP", 4)) {
-		DEBUG_MSG("Parser quits:\tnot a HTTP request\n");
-		return false;
-	}
+    if (memcmp(end + 1, "HTTP", 4)) {
+        DEBUG_MSG("Parser quits:\tnot a HTTP request\n");
+        return false;
+    }
 
-	/* Copy and check HTTP method */
-	copy_str(buffer, sizeof(buffer), data, begin);
-	if (rec->req) {
-		flow_flush = true;
-		total--;
-		DEBUG_MSG("Parser quits:\tflushing flow\n");
-		return false;
-	}
-	strncpy(rec->method, buffer, sizeof(rec->method));
-	rec->method[sizeof(rec->method) - 1] = 0;
+    /* Copy and check HTTP method */
+    copy_str(buffer, sizeof(buffer), data, begin);
+    if (rec->req) {
+        flow_flush = true;
+        total--;
+        DEBUG_MSG("Parser quits:\tflushing flow\n");
+        return false;
+    }
+    strncpy(rec->method, buffer, sizeof(rec->method));
+    rec->method[sizeof(rec->method) - 1] = 0;
 
-	copy_str(rec->uri, sizeof(rec->uri), begin + 1, end);
-	DEBUG_MSG("\tMethod: %s\n", rec->method);
-	DEBUG_MSG("\tURI: %s\n", rec->uri);
+    copy_str(rec->uri, sizeof(rec->uri), begin + 1, end);
+    DEBUG_MSG("\tMethod: %s\n", rec->method);
+    DEBUG_MSG("\tURI: %s\n", rec->uri);
 
-	/* Find begin of next line after request line. */
-	if (check_payload_len(payload_len, end - data)) {
-		DEBUG_MSG("Parser quits:\tpayload end\n");
-		return false;
-	}
-	remaining = payload_len - (end - data);
-	begin = ipxp::strnstr(end, HTTP_LINE_DELIMITER, remaining);
-	if (begin == nullptr) {
-		DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
-		return false;
-	}
-	begin += 2;
+    /* Find begin of next line after request line. */
+    if (check_payload_len(payload_len, end - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - (end - data);
+    begin = ipxp::strnstr(end, HTTP_LINE_DELIMITER, remaining);
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
+        return false;
+    }
+    begin += 2;
 
-	/* Header:
-	 *
-	 * REQ-FIELD: VALUE
-	 * |        |      |
-	 * |        |      ----- end
-	 * |        ------------ keyval_delimiter
-	 * --------------------- begin
-	 */
+    /* Header:
+     *
+     * REQ-FIELD: VALUE
+     * |        |      |
+     * |        |      ----- end
+     * |        ------------ keyval_delimiter
+     * --------------------- begin
+     */
 
-	rec->host[0] = 0;
-	rec->user_agent[0] = 0;
-	rec->referer[0] = 0;
-	/* Process headers. */
-	while (begin - data < payload_len) {
-		remaining = payload_len - (begin - data);
-		end = ipxp::strnstr(begin, HTTP_LINE_DELIMITER, remaining);
-		keyval_delimiter
-			= static_cast<const char*>(memchr(begin, HTTP_KEYVAL_DELIMITER, remaining));
+    rec->host[0] = 0;
+    rec->user_agent[0] = 0;
+    rec->referer[0] = 0;
+    /* Process headers. */
+    while (begin - data < payload_len) {
+        remaining = payload_len - (begin - data);
+        end = ipxp::strnstr(begin, HTTP_LINE_DELIMITER, remaining);
+        keyval_delimiter
+            = static_cast<const char*>(memchr(begin, HTTP_KEYVAL_DELIMITER, remaining));
 
-		if (end == nullptr) {
-			DEBUG_MSG("Parser quits:\theader is fragmented\n");
-			return false;
-		}
+        if (end == nullptr) {
+            DEBUG_MSG("Parser quits:\theader is fragmented\n");
+            return false;
+        }
 
-		end += 1;
-		int tmp = end - begin;
-		if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
-			break; /* Double LF found - end of header section. */
-		} else if (keyval_delimiter == nullptr) {
-			DEBUG_MSG("Parser quits:\theader is fragmented\n");
-			return false;
-		}
+        end += 1;
+        int tmp = end - begin;
+        if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
+            break; /* Double LF found - end of header section. */
+        } else if (keyval_delimiter == nullptr) {
+            DEBUG_MSG("Parser quits:\theader is fragmented\n");
+            return false;
+        }
 
-		/* Copy field name. */
-		copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
+        /* Copy field name. */
+        copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
 
-		DEBUG_CODE(char debug_buffer[4096]);
-		DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
-		DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
+        DEBUG_CODE(char debug_buffer[4096]);
+        DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
+        DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
 
-		/* Copy interesting field values. */
-		if (!strcmp(buffer, "Host")) {
-			copy_str(rec->host, sizeof(rec->host), keyval_delimiter + 2, end);
-		} else if (!strcmp(buffer, "User-Agent")) {
-			copy_str(rec->user_agent, sizeof(rec->user_agent), keyval_delimiter + 2, end);
-		} else if (!strcmp(buffer, "Referer")) {
-			copy_str(rec->referer, sizeof(rec->referer), keyval_delimiter + 2, end);
-		}
+        /* Copy interesting field values. */
+        if (!strcmp(buffer, "Host")) {
+            copy_str(rec->host, sizeof(rec->host), keyval_delimiter + 2, end);
+        } else if (!strcmp(buffer, "User-Agent")) {
+            copy_str(rec->user_agent, sizeof(rec->user_agent), keyval_delimiter + 2, end);
+        } else if (!strcmp(buffer, "Referer")) {
+            copy_str(rec->referer, sizeof(rec->referer), keyval_delimiter + 2, end);
+        }
 
-		/* Go to next line. */
-		begin = end + 1;
-	}
+        /* Go to next line. */
+        begin = end + 1;
+    }
 
-	DEBUG_MSG("Parser quits:\tend of header section\n");
-	rec->req = true;
-	requests++;
-	return true;
+    DEBUG_MSG("Parser quits:\tend of header section\n");
+    rec->req = true;
+    requests++;
+    return true;
 }
 
 /**
@@ -411,154 +411,154 @@ bool HTTPPlugin::parse_http_request(const char* data, int payload_len, RecordExt
  */
 bool HTTPPlugin::parse_http_response(const char* data, int payload_len, RecordExtHTTP* rec)
 {
-	char buffer[64];
-	const char *begin, *end, *keyval_delimiter, *cookie_name_end;
-	size_t remaining;
-	int code;
+    char buffer[64];
+    const char *begin, *end, *keyval_delimiter, *cookie_name_end;
+    size_t remaining;
+    int code;
 
-	total++;
+    total++;
 
-	DEBUG_MSG("---------- http parser #%u ----------\n", total);
-	DEBUG_MSG("Parsing response number: %u\n", ++s_responses);
-	DEBUG_MSG("Payload length: %u\n\n", payload_len);
+    DEBUG_MSG("---------- http parser #%u ----------\n", total);
+    DEBUG_MSG("Parsing response number: %u\n", ++s_responses);
+    DEBUG_MSG("Payload length: %u\n\n", payload_len);
 
-	if (payload_len == 0) {
-		DEBUG_MSG("Parser quits:\tpayload length = 0\n");
-		return false;
-	}
+    if (payload_len == 0) {
+        DEBUG_MSG("Parser quits:\tpayload length = 0\n");
+        return false;
+    }
 
-	/* Check begin of response header. */
-	if (memcmp(data, "HTTP", 4)) {
-		DEBUG_MSG("Parser quits:\tpacket contains http response data\n");
-		return false;
-	}
+    /* Check begin of response header. */
+    if (memcmp(data, "HTTP", 4)) {
+        DEBUG_MSG("Parser quits:\tpacket contains http response data\n");
+        return false;
+    }
 
-	/* Response line:
-	 *
-	 * VERSION CODE REASON
-	 * |      |    |
-	 * |      |    --------- end
-	 * |      -------------- begin
-	 * --------------------- data
-	 */
+    /* Response line:
+     *
+     * VERSION CODE REASON
+     * |      |    |
+     * |      |    --------- end
+     * |      -------------- begin
+     * --------------------- data
+     */
 
-	/* Find begin of status code. */
-	begin = static_cast<const char*>(memchr(data, ' ', payload_len));
-	if (begin == nullptr) {
-		DEBUG_MSG("Parser quits:\tnot a http response header\n");
-		return false;
-	}
+    /* Find begin of status code. */
+    begin = static_cast<const char*>(memchr(data, ' ', payload_len));
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tnot a http response header\n");
+        return false;
+    }
 
-	/* Find end of status code. */
-	if (check_payload_len(payload_len, (begin + 1) - data)) {
-		DEBUG_MSG("Parser quits:\tpayload end\n");
-		return false;
-	}
-	remaining = payload_len - ((begin + 1) - data);
-	end = static_cast<const char*>(memchr(begin + 1, ' ', remaining));
-	if (end == nullptr) {
-		DEBUG_MSG("Parser quits:\tresponse is fragmented\n");
-		return false;
-	}
+    /* Find end of status code. */
+    if (check_payload_len(payload_len, (begin + 1) - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - ((begin + 1) - data);
+    end = static_cast<const char*>(memchr(begin + 1, ' ', remaining));
+    if (end == nullptr) {
+        DEBUG_MSG("Parser quits:\tresponse is fragmented\n");
+        return false;
+    }
 
-	/* Copy and check HTTP response code. */
-	copy_str(buffer, sizeof(buffer), begin + 1, end);
-	code = atoi(buffer);
-	if (code <= 0) {
-		DEBUG_MSG("Parser quits:\twrong response code: %d\n", code);
-		return false;
-	}
+    /* Copy and check HTTP response code. */
+    copy_str(buffer, sizeof(buffer), begin + 1, end);
+    code = atoi(buffer);
+    if (code <= 0) {
+        DEBUG_MSG("Parser quits:\twrong response code: %d\n", code);
+        return false;
+    }
 
-	DEBUG_MSG("\tCode: %d\n", code);
-	if (rec->resp) {
-		flow_flush = true;
-		total--;
-		DEBUG_MSG("Parser quits:\tflushing flow\n");
-		return false;
-	}
-	rec->code = code;
+    DEBUG_MSG("\tCode: %d\n", code);
+    if (rec->resp) {
+        flow_flush = true;
+        total--;
+        DEBUG_MSG("Parser quits:\tflushing flow\n");
+        return false;
+    }
+    rec->code = code;
 
-	/* Find begin of next line after request line. */
-	if (check_payload_len(payload_len, end - data)) {
-		DEBUG_MSG("Parser quits:\tpayload end\n");
-		return false;
-	}
-	remaining = payload_len - (end - data);
-	begin = ipxp::strnstr(end, HTTP_LINE_DELIMITER, remaining);
-	if (begin == nullptr) {
-		DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
-		return false;
-	}
-	begin += 2;
+    /* Find begin of next line after request line. */
+    if (check_payload_len(payload_len, end - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - (end - data);
+    begin = ipxp::strnstr(end, HTTP_LINE_DELIMITER, remaining);
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
+        return false;
+    }
+    begin += 2;
 
-	/* Header:
-	 *
-	 * REQ-FIELD: VALUE
-	 * |        |      |
-	 * |        |      ----- end
-	 * |        ------------ keyval_delimiter
-	 * --------------------- begin
-	 */
+    /* Header:
+     *
+     * REQ-FIELD: VALUE
+     * |        |      |
+     * |        |      ----- end
+     * |        ------------ keyval_delimiter
+     * --------------------- begin
+     */
 
-	rec->content_type[0] = 0;
-	rec->server[0] = 0;
-	rec->set_cookie[0] = 0;
+    rec->content_type[0] = 0;
+    rec->server[0] = 0;
+    rec->set_cookie[0] = 0;
 
-	/* Process headers. */
-	while (begin - data < payload_len) {
-		remaining = payload_len - (begin - data);
-		end = ipxp::strnstr(begin, HTTP_LINE_DELIMITER, remaining);
-		keyval_delimiter
-			= static_cast<const char*>(memchr(begin, HTTP_KEYVAL_DELIMITER, remaining));
+    /* Process headers. */
+    while (begin - data < payload_len) {
+        remaining = payload_len - (begin - data);
+        end = ipxp::strnstr(begin, HTTP_LINE_DELIMITER, remaining);
+        keyval_delimiter
+            = static_cast<const char*>(memchr(begin, HTTP_KEYVAL_DELIMITER, remaining));
 
-		if (end == nullptr) {
-			DEBUG_MSG("Parser quits:\theader is fragmented\n");
-			return false;
-		}
+        if (end == nullptr) {
+            DEBUG_MSG("Parser quits:\theader is fragmented\n");
+            return false;
+        }
 
-		end += 1;
-		int tmp = end - begin;
-		if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
-			break; /* Double LF found - end of header section. */
-		} else if (keyval_delimiter == nullptr) {
-			DEBUG_MSG("Parser quits:\theader is fragmented\n");
-			return false;
-		}
+        end += 1;
+        int tmp = end - begin;
+        if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
+            break; /* Double LF found - end of header section. */
+        } else if (keyval_delimiter == nullptr) {
+            DEBUG_MSG("Parser quits:\theader is fragmented\n");
+            return false;
+        }
 
-		/* Copy field name. */
-		copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
+        /* Copy field name. */
+        copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
 
-		DEBUG_CODE(char debug_buffer[4096]);
-		DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
-		DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
+        DEBUG_CODE(char debug_buffer[4096]);
+        DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
+        DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
 
-		/* Copy interesting field values. */
-		if (!strcmp(buffer, "Content-Type")) {
-			copy_str(rec->content_type, sizeof(rec->content_type), keyval_delimiter + 2, end);
-		} else if (!strcmp(buffer, "Server")) {
-			copy_str(rec->server, sizeof(rec->server), keyval_delimiter + 2, end);
-		} else if (!strcmp(buffer, "Set-Cookie")) {
-			cookie_name_end
-				= ipxp::strnstr(begin, HTTP_SETCOOKIE_NAME_DELIMITER, size_t(end - begin));
-			if (cookie_name_end == nullptr) {
-				break;
-			}
-			add_str(
-				rec->set_cookie,
-				sizeof(rec->set_cookie),
-				keyval_delimiter + 2,
-				cookie_name_end,
-				STRING_DELIMITER);
-		}
+        /* Copy interesting field values. */
+        if (!strcmp(buffer, "Content-Type")) {
+            copy_str(rec->content_type, sizeof(rec->content_type), keyval_delimiter + 2, end);
+        } else if (!strcmp(buffer, "Server")) {
+            copy_str(rec->server, sizeof(rec->server), keyval_delimiter + 2, end);
+        } else if (!strcmp(buffer, "Set-Cookie")) {
+            cookie_name_end
+                = ipxp::strnstr(begin, HTTP_SETCOOKIE_NAME_DELIMITER, size_t(end - begin));
+            if (cookie_name_end == nullptr) {
+                break;
+            }
+            add_str(
+                rec->set_cookie,
+                sizeof(rec->set_cookie),
+                keyval_delimiter + 2,
+                cookie_name_end,
+                STRING_DELIMITER);
+        }
 
-		/* Go to next line. */
-		begin = end + 1;
-	}
+        /* Go to next line. */
+        begin = end + 1;
+    }
 
-	DEBUG_MSG("Parser quits:\tend of header section\n");
-	rec->resp = true;
-	responses++;
-	return true;
+    DEBUG_MSG("Parser quits:\tend of header section\n");
+    rec->resp = true;
+    responses++;
+    return true;
 }
 
 /**
@@ -568,10 +568,10 @@ bool HTTPPlugin::parse_http_response(const char* data, int payload_len, RecordEx
  */
 bool HTTPPlugin::valid_http_method(const char* method) const
 {
-	return (
-		!strcmp(method, "GET ") || !strcmp(method, "POST") || !strcmp(method, "PUT ")
-		|| !strcmp(method, "HEAD") || !strcmp(method, "DELE") || !strcmp(method, "TRAC")
-		|| !strcmp(method, "OPTI") || !strcmp(method, "CONN") || !strcmp(method, "PATC"));
+    return (
+        !strcmp(method, "GET ") || !strcmp(method, "POST") || !strcmp(method, "PUT ")
+        || !strcmp(method, "HEAD") || !strcmp(method, "DELE") || !strcmp(method, "TRAC")
+        || !strcmp(method, "OPTI") || !strcmp(method, "CONN") || !strcmp(method, "PATC"));
 }
 
 /**
@@ -583,35 +583,35 @@ bool HTTPPlugin::valid_http_method(const char* method) const
  */
 bool HTTPPlugin::invalid_http_method(const char* data, int payload_len) const
 {
-	// arbitrary value, if the method is longer it propably isnt http request
-	// so don't look further
-	const int MAX_METHOD_LENGTH = 32;
+    // arbitrary value, if the method is longer it propably isnt http request
+    // so don't look further
+    const int MAX_METHOD_LENGTH = 32;
 
-	// METHOD URI HTTP/VERSION
-	// |     |   |
-	// |     |   +---- uri_end
-	// |     +---- method_end
-	// +---- data
+    // METHOD URI HTTP/VERSION
+    // |     |   |
+    // |     |   +---- uri_end
+    // |     +---- method_end
+    // +---- data
 
-	// check if there is space in the first HTTP_MAX_METHOD_LENGTH chars
-	int len = std::min(payload_len, MAX_METHOD_LENGTH);
-	auto method_end = static_cast<const char*>(memchr(data, ' ', len));
-	if (method_end == nullptr)
-		return false;
+    // check if there is space in the first HTTP_MAX_METHOD_LENGTH chars
+    int len = std::min(payload_len, MAX_METHOD_LENGTH);
+    auto method_end = static_cast<const char*>(memchr(data, ' ', len));
+    if (method_end == nullptr)
+        return false;
 
-	payload_len -= method_end - data - 1;
-	if (payload_len <= 0)
-		return false;
+    payload_len -= method_end - data - 1;
+    if (payload_len <= 0)
+        return false;
 
-	auto uri_end = static_cast<const char*>(memchr(method_end + 1, ' ', payload_len));
-	if (uri_end == nullptr)
-		return false;
+    auto uri_end = static_cast<const char*>(memchr(method_end + 1, ' ', payload_len));
+    if (uri_end == nullptr)
+        return false;
 
-	payload_len -= uri_end - method_end;
-	if (payload_len <= 4)
-		return false;
+    payload_len -= uri_end - method_end;
+    if (payload_len <= 4)
+        return false;
 
-	return memcmp(uri_end + 1, "HTTP", 4) == 0;
+    return memcmp(uri_end + 1, "HTTP", 4) == 0;
 }
 
 /**
@@ -622,14 +622,14 @@ bool HTTPPlugin::invalid_http_method(const char* data, int payload_len) const
  */
 void HTTPPlugin::add_ext_http_request(const char* data, int payload_len, Flow& flow)
 {
-	if (recPrealloc == nullptr) {
-		recPrealloc = new RecordExtHTTP();
-	}
+    if (recPrealloc == nullptr) {
+        recPrealloc = new RecordExtHTTP();
+    }
 
-	if (parse_http_request(data, payload_len, recPrealloc)) {
-		flow.add_extension(recPrealloc);
-		recPrealloc = nullptr;
-	}
+    if (parse_http_request(data, payload_len, recPrealloc)) {
+        flow.add_extension(recPrealloc);
+        recPrealloc = nullptr;
+    }
 }
 
 /**
@@ -640,14 +640,14 @@ void HTTPPlugin::add_ext_http_request(const char* data, int payload_len, Flow& f
  */
 void HTTPPlugin::add_ext_http_response(const char* data, int payload_len, Flow& flow)
 {
-	if (recPrealloc == nullptr) {
-		recPrealloc = new RecordExtHTTP();
-	}
+    if (recPrealloc == nullptr) {
+        recPrealloc = new RecordExtHTTP();
+    }
 
-	if (parse_http_response(data, payload_len, recPrealloc)) {
-		flow.add_extension(recPrealloc);
-		recPrealloc = nullptr;
-	}
+    if (parse_http_response(data, payload_len, recPrealloc)) {
+        flow.add_extension(recPrealloc);
+        recPrealloc = nullptr;
+    }
 }
 
 } // namespace ipxp

--- a/process/http.hpp
+++ b/process/http.hpp
@@ -31,219 +31,215 @@
 #define IPXP_PROCESS_HTTP_HPP
 
 #include <config.h>
-#include <cstring>
 #include <cstdlib>
-#include <sstream>
+#include <cstring>
 #include <iostream>
+#include <sstream>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
-#define HTTP_UNIREC_TEMPLATE  "HTTP_REQUEST_METHOD,HTTP_REQUEST_HOST,HTTP_REQUEST_URL,HTTP_REQUEST_AGENT,HTTP_REQUEST_REFERER,HTTP_RESPONSE_STATUS_CODE,HTTP_RESPONSE_CONTENT_TYPE,HTTP_RESPONSE_SERVER,HTTP_RESPONSE_SET_COOKIE_NAMES"
+#define HTTP_UNIREC_TEMPLATE                                                                       \
+    "HTTP_REQUEST_METHOD,HTTP_REQUEST_HOST,HTTP_REQUEST_URL,HTTP_REQUEST_AGENT,HTTP_REQUEST_"      \
+    "REFERER,HTTP_RESPONSE_STATUS_CODE,HTTP_RESPONSE_CONTENT_TYPE,HTTP_RESPONSE_SERVER,HTTP_"      \
+    "RESPONSE_SET_COOKIE_NAMES"
 
-UR_FIELDS (
-   string HTTP_REQUEST_METHOD,
-   string HTTP_REQUEST_HOST,
-   string HTTP_REQUEST_URL,
-   string HTTP_REQUEST_AGENT,
-   string HTTP_REQUEST_REFERER,
+UR_FIELDS(
+    string HTTP_REQUEST_METHOD,
+    string HTTP_REQUEST_HOST,
+    string HTTP_REQUEST_URL,
+    string HTTP_REQUEST_AGENT,
+    string HTTP_REQUEST_REFERER,
 
-   uint16 HTTP_RESPONSE_STATUS_CODE,
-   string HTTP_RESPONSE_CONTENT_TYPE,
-   string HTTP_RESPONSE_SERVER,
-   string HTTP_RESPONSE_SET_COOKIE_NAMES
-)
+    uint16 HTTP_RESPONSE_STATUS_CODE,
+    string HTTP_RESPONSE_CONTENT_TYPE,
+    string HTTP_RESPONSE_SERVER,
+    string HTTP_RESPONSE_SET_COOKIE_NAMES)
 
-void copy_str(char *dst, ssize_t size, const char *begin, const char *end);
-void add_str(char *dst, ssize_t size, const char *begin, const char *end, const char* delimiter);
+void copy_str(char* dst, ssize_t size, const char* begin, const char* end);
+void add_str(char* dst, ssize_t size, const char* begin, const char* end, const char* delimiter);
 
 /**
  * \brief Flow record extension header for storing HTTP requests.
  */
 struct RecordExtHTTP : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   bool req;
-   bool resp;
+    bool req;
+    bool resp;
 
-   char method[16];
-   char host[64];
-   char uri[128];
-   char user_agent[128];
-   char referer[128];
+    char method[16];
+    char host[64];
+    char uri[128];
+    char user_agent[128];
+    char referer[128];
 
-   uint16_t code;
-   char content_type[32];
+    uint16_t code;
+    char content_type[32];
 
-   char server[128];
-   char set_cookie[512];
+    char server[128];
+    char set_cookie[512];
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtHTTP() : RecordExt(REGISTERED_ID)
-   {
-      req = false;
-      resp = false;
-      method[0] = 0;
-      host[0] = 0;
-      uri[0] = 0;
-      user_agent[0] = 0;
-      referer[0] = 0;
-      code = 0;
-      content_type[0] = 0;
-      server[0] = 0;
-      set_cookie[0] = 0;
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtHTTP()
+        : RecordExt(REGISTERED_ID)
+    {
+        req = false;
+        resp = false;
+        method[0] = 0;
+        host[0] = 0;
+        uri[0] = 0;
+        user_agent[0] = 0;
+        referer[0] = 0;
+        code = 0;
+        content_type[0] = 0;
+        server[0] = 0;
+        set_cookie[0] = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set_string(tmplt, record, F_HTTP_REQUEST_METHOD, method);
-      ur_set_string(tmplt, record, F_HTTP_REQUEST_HOST, host);
-      ur_set_string(tmplt, record, F_HTTP_REQUEST_URL, uri);
-      ur_set_string(tmplt, record, F_HTTP_REQUEST_AGENT, user_agent);
-      ur_set_string(tmplt, record, F_HTTP_REQUEST_REFERER, referer);
-      ur_set_string(tmplt, record, F_HTTP_RESPONSE_CONTENT_TYPE, content_type);
-      ur_set(tmplt, record, F_HTTP_RESPONSE_STATUS_CODE, code);
-      ur_set_string(tmplt, record, F_HTTP_RESPONSE_SERVER, server);
-      ur_set_string(tmplt, record, F_HTTP_RESPONSE_SET_COOKIE_NAMES, set_cookie);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set_string(tmplt, record, F_HTTP_REQUEST_METHOD, method);
+        ur_set_string(tmplt, record, F_HTTP_REQUEST_HOST, host);
+        ur_set_string(tmplt, record, F_HTTP_REQUEST_URL, uri);
+        ur_set_string(tmplt, record, F_HTTP_REQUEST_AGENT, user_agent);
+        ur_set_string(tmplt, record, F_HTTP_REQUEST_REFERER, referer);
+        ur_set_string(tmplt, record, F_HTTP_RESPONSE_CONTENT_TYPE, content_type);
+        ur_set(tmplt, record, F_HTTP_RESPONSE_STATUS_CODE, code);
+        ur_set_string(tmplt, record, F_HTTP_RESPONSE_SERVER, server);
+        ur_set_string(tmplt, record, F_HTTP_RESPONSE_SET_COOKIE_NAMES, set_cookie);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return HTTP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return HTTP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      uint16_t length = 0;
-      uint32_t total_length = 0;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        uint16_t length = 0;
+        uint32_t total_length = 0;
 
-      length = strlen(user_agent);
-      if ((uint32_t) (length + 3) > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) user_agent, length);
+        length = strlen(user_agent);
+        if ((uint32_t) (length + 3) > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) user_agent, length);
 
-      length = strlen(method);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) method, length);
+        length = strlen(method);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) method, length);
 
-      length = strlen(host);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) host, length);
+        length = strlen(host);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) host, length);
 
-      length = strlen(referer);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) referer, length);
+        length = strlen(referer);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) referer, length);
 
-      length = strlen(uri);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) uri, length);
+        length = strlen(uri);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) uri, length);
 
-      length = strlen(content_type);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) content_type, length);
+        length = strlen(content_type);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length
+            += variable2ipfix_buffer(buffer + total_length, (uint8_t*) content_type, length);
 
-      length = strlen(server);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) server, length);
+        length = strlen(server);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) server, length);
 
-      length = strlen(set_cookie);
-      if (total_length + length + 3 > (uint32_t) size) {
-         return -1;
-      }
-      total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) set_cookie, length);
+        length = strlen(set_cookie);
+        if (total_length + length + 3 > (uint32_t) size) {
+            return -1;
+        }
+        total_length += variable2ipfix_buffer(buffer + total_length, (uint8_t*) set_cookie, length);
 
-      *(uint16_t *) (buffer + total_length) = ntohs(code);
-      total_length += 2;
+        *(uint16_t*) (buffer + total_length) = ntohs(code);
+        total_length += 2;
 
-      return total_length;
-   }
+        return total_length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_HTTP_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_HTTP_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "method=\"" << method << "\""
-         << ",host=\"" << host << "\""
-         << ",uri=\"" << uri << "\""
-         << ",agent=\"" << user_agent << "\""
-         << ",referer=\"" << referer << "\""
-         << ",content=\"" << content_type << "\""
-         << ",status=" << code
-         << ",server=\"" << server << "\""
-         << ",set-cookie=\"" << set_cookie << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "method=\"" << method << "\""
+            << ",host=\"" << host << "\""
+            << ",uri=\"" << uri << "\""
+            << ",agent=\"" << user_agent << "\""
+            << ",referer=\"" << referer << "\""
+            << ",content=\"" << content_type << "\""
+            << ",status=" << code << ",server=\"" << server << "\""
+            << ",set-cookie=\"" << set_cookie << "\"";
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin used to parse HTTP requests / responses.
  */
-class HTTPPlugin : public ProcessPlugin
-{
+class HTTPPlugin : public ProcessPlugin {
 public:
-   HTTPPlugin();
-   ~HTTPPlugin();
-   void init(const char *params);
-   void close();
-   RecordExt *get_ext() const { return new RecordExtHTTP(); }
-   OptionsParser *get_parser() const { return new OptionsParser("http", "Parse HTTP traffic"); }
-   std::string get_name() const { return "http"; }
-   ProcessPlugin *copy();
+    HTTPPlugin();
+    ~HTTPPlugin();
+    void init(const char* params);
+    void close();
+    RecordExt* get_ext() const { return new RecordExtHTTP(); }
+    OptionsParser* get_parser() const { return new OptionsParser("http", "Parse HTTP traffic"); }
+    std::string get_name() const { return "http"; }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   bool is_response(const char *data, int payload_len);
-   bool is_request(const char *data, int payload_len);
-   bool parse_http_request(const char *data, int payload_len, RecordExtHTTP *rec);
-   bool parse_http_response(const char *data, int payload_len, RecordExtHTTP *rec);
-   void add_ext_http_request(const char *data, int payload_len, Flow &flow);
-   void add_ext_http_response(const char *data, int payload_len, Flow &flow);
-   bool valid_http_method(const char *method) const;
-   bool invalid_http_method(const char *payload, int payload_len) const;
+    bool is_response(const char* data, int payload_len);
+    bool is_request(const char* data, int payload_len);
+    bool parse_http_request(const char* data, int payload_len, RecordExtHTTP* rec);
+    bool parse_http_response(const char* data, int payload_len, RecordExtHTTP* rec);
+    void add_ext_http_request(const char* data, int payload_len, Flow& flow);
+    void add_ext_http_response(const char* data, int payload_len, Flow& flow);
+    bool valid_http_method(const char* method) const;
+    bool invalid_http_method(const char* payload, int payload_len) const;
 
-   RecordExtHTTP *recPrealloc;/**< Preallocated extension. */
-   bool flow_flush;           /**< Tell storage plugin to flush current Flow. */
-   uint32_t requests;         /**< Total number of parsed HTTP requests. */
-   uint32_t responses;        /**< Total number of parsed HTTP responses. */
-   uint32_t total;            /**< Total number of parsed HTTP packets. */
+    RecordExtHTTP* recPrealloc; /**< Preallocated extension. */
+    bool flow_flush; /**< Tell storage plugin to flush current Flow. */
+    uint32_t requests; /**< Total number of parsed HTTP requests. */
+    uint32_t responses; /**< Total number of parsed HTTP responses. */
+    uint32_t total; /**< Total number of parsed HTTP packets. */
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_HTTP_HPP */

--- a/process/icmp.cpp
+++ b/process/icmp.cpp
@@ -53,33 +53,31 @@ int RecordExtICMP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("icmp", [](){return new ICMPPlugin();});
-   register_plugin(&rec);
-   RecordExtICMP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("icmp", []() { return new ICMPPlugin(); });
+    register_plugin(&rec);
+    RecordExtICMP::REGISTERED_ID = register_extension();
 }
 
-ProcessPlugin *ICMPPlugin::copy()
+ProcessPlugin* ICMPPlugin::copy()
 {
-   return new ICMPPlugin(*this);
+    return new ICMPPlugin(*this);
 }
 
-int ICMPPlugin::post_create(Flow &rec, const Packet &pkt)
+int ICMPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   if (pkt.ip_proto == IPPROTO_ICMP ||
-       pkt.ip_proto == IPPROTO_ICMPV6) {
-      if (pkt.payload_len < sizeof(RecordExtICMP::type_code))
-         return 0;
+    if (pkt.ip_proto == IPPROTO_ICMP || pkt.ip_proto == IPPROTO_ICMPV6) {
+        if (pkt.payload_len < sizeof(RecordExtICMP::type_code))
+            return 0;
 
-      auto ext = new RecordExtICMP();
+        auto ext = new RecordExtICMP();
 
-      // the type and code are the first two bytes, type on MSB and code on LSB
-      // in the network byte order
-      ext->type_code = *reinterpret_cast<const uint16_t *>(pkt.payload);
+        // the type and code are the first two bytes, type on MSB and code on LSB
+        // in the network byte order
+        ext->type_code = *reinterpret_cast<const uint16_t*>(pkt.payload);
 
-      rec.add_extension(ext);
-   }
-   return 0;
+        rec.add_extension(ext);
+    }
+    return 0;
 }
 
-}
-
+} // namespace ipxp

--- a/process/icmp.hpp
+++ b/process/icmp.hpp
@@ -47,100 +47,91 @@
 #include <cstring>
 
 #ifdef WITH_NEMEA
-  #include "fields.h"
+#include "fields.h"
 #endif
 
 #include <sstream>
 
 #include <ipfixprobe/utils.hpp>
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #define ICMP_UNIREC_TEMPLATE "L4_ICMP_TYPE_CODE"
 
-UR_FIELDS (
-   uint16 L4_ICMP_TYPE_CODE
-)
+UR_FIELDS(uint16 L4_ICMP_TYPE_CODE)
 
 /**
  * \brief Flow record extension header for storing parsed ICMP data.
  */
 struct RecordExtICMP : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t type_code;
+    uint16_t type_code;
 
-   RecordExtICMP() : RecordExt(REGISTERED_ID)
-   {
-      type_code = 0;
-   }
+    RecordExtICMP()
+        : RecordExt(REGISTERED_ID)
+    {
+        type_code = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_L4_ICMP_TYPE_CODE, ntohs(type_code));
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_L4_ICMP_TYPE_CODE, ntohs(type_code));
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return ICMP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return ICMP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      const int LEN = 2;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        const int LEN = 2;
 
-      if (size < LEN) {
-         return -1;
-      }
+        if (size < LEN) {
+            return -1;
+        }
 
-      *reinterpret_cast<uint16_t *>(buffer) = type_code;
+        *reinterpret_cast<uint16_t*>(buffer) = type_code;
 
-      return LEN;
-   }
+        return LEN;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_ICMP_TEMPLATE(IPFIX_FIELD_NAMES)
-         NULL
-      };
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_ICMP_TEMPLATE(IPFIX_FIELD_NAMES) NULL};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      // type is on the first byte, code is on the second byte
-      auto *type_code = reinterpret_cast<const uint8_t *>(&this->type_code);
+    std::string get_text() const
+    {
+        // type is on the first byte, code is on the second byte
+        auto* type_code = reinterpret_cast<const uint8_t*>(&this->type_code);
 
-      std::ostringstream out;
-      out << "type=\"" << static_cast<int>(type_code[0]) << '"'
-         << ",code=\"" << static_cast<int>(type_code[1]) << '"';
+        std::ostringstream out;
+        out << "type=\"" << static_cast<int>(type_code[0]) << '"' << ",code=\""
+            << static_cast<int>(type_code[1]) << '"';
 
-      return out.str();
-   }
+        return out.str();
+    }
 };
 
 /**
  * \brief Process plugin for parsing ICMP packets.
  */
-class ICMPPlugin : public ProcessPlugin
-{
+class ICMPPlugin : public ProcessPlugin {
 public:
-   OptionsParser *get_parser() const { return new OptionsParser("icmp", "Parse ICMP traffic"); }
-   std::string get_name() const { return "icmp"; }
-   RecordExt *get_ext() const { return new RecordExtICMP(); }
-   ProcessPlugin *copy();
+    OptionsParser* get_parser() const { return new OptionsParser("icmp", "Parse ICMP traffic"); }
+    std::string get_name() const { return "icmp"; }
+    RecordExt* get_ext() const { return new RecordExtICMP(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_ICMP_HPP */
-

--- a/process/idpcontent.cpp
+++ b/process/idpcontent.cpp
@@ -36,64 +36,61 @@ int RecordExtIDPCONTENT::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("idpcontent", [](){return new IDPCONTENTPlugin();});
-   register_plugin(&rec);
-   RecordExtIDPCONTENT::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("idpcontent", []() { return new IDPCONTENTPlugin(); });
+    register_plugin(&rec);
+    RecordExtIDPCONTENT::REGISTERED_ID = register_extension();
 }
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
-IDPCONTENTPlugin::IDPCONTENTPlugin()
-{
-}
+IDPCONTENTPlugin::IDPCONTENTPlugin() {}
 
 IDPCONTENTPlugin::~IDPCONTENTPlugin()
 {
-   close();
+    close();
 }
 
-void IDPCONTENTPlugin::init(const char *params)
+void IDPCONTENTPlugin::init(const char* params) {}
+
+void IDPCONTENTPlugin::close() {}
+
+ProcessPlugin* IDPCONTENTPlugin::copy()
 {
+    return new IDPCONTENTPlugin(*this);
 }
 
-void IDPCONTENTPlugin::close()
+void IDPCONTENTPlugin::update_record(RecordExtIDPCONTENT* idpcontent_data, const Packet& pkt)
 {
+    // create ptr into buffers from packet directions
+    uint8_t paket_direction = (uint8_t) (!pkt.source_pkt);
+
+    // Check zero-packets and be sure, that the exported content is from both directions
+    if (idpcontent_data->pkt_export_flg[paket_direction] != 1 && pkt.payload_len > 0) {
+        idpcontent_data->idps[paket_direction].size = MIN(IDPCONTENT_SIZE, pkt.payload_len);
+        memcpy(
+            idpcontent_data->idps[paket_direction].data,
+            pkt.payload,
+            idpcontent_data->idps[paket_direction].size);
+        idpcontent_data->pkt_export_flg[paket_direction] = 1;
+    }
 }
 
-ProcessPlugin *IDPCONTENTPlugin::copy()
+int IDPCONTENTPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   return new IDPCONTENTPlugin(*this);
+    RecordExtIDPCONTENT* idpcontent_data = new RecordExtIDPCONTENT();
+    memset(idpcontent_data->pkt_export_flg, 0, 2 * sizeof(uint8_t));
+    rec.add_extension(idpcontent_data);
+
+    update_record(idpcontent_data, pkt);
+    return 0;
 }
 
-void IDPCONTENTPlugin::update_record(RecordExtIDPCONTENT *idpcontent_data, const Packet &pkt)
+int IDPCONTENTPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   // create ptr into buffers from packet directions
-   uint8_t paket_direction = (uint8_t) (!pkt.source_pkt);
-
-   // Check zero-packets and be sure, that the exported content is from both directions
-   if (idpcontent_data->pkt_export_flg[paket_direction] != 1 && pkt.payload_len > 0) {
-      idpcontent_data->idps[paket_direction].size = MIN(IDPCONTENT_SIZE, pkt.payload_len);
-      memcpy(idpcontent_data->idps[paket_direction].data, pkt.payload,
-        idpcontent_data->idps[paket_direction].size);
-      idpcontent_data->pkt_export_flg[paket_direction] = 1;
-   }
+    RecordExtIDPCONTENT* idpcontent_data
+        = static_cast<RecordExtIDPCONTENT*>(rec.get_extension(RecordExtIDPCONTENT::REGISTERED_ID));
+    update_record(idpcontent_data, pkt);
+    return 0;
 }
 
-int IDPCONTENTPlugin::post_create(Flow &rec, const Packet &pkt)
-{
-   RecordExtIDPCONTENT *idpcontent_data = new RecordExtIDPCONTENT();
-   memset(idpcontent_data->pkt_export_flg, 0, 2 * sizeof(uint8_t));
-   rec.add_extension(idpcontent_data);
-
-   update_record(idpcontent_data, pkt);
-   return 0;
-}
-
-int IDPCONTENTPlugin::post_update(Flow &rec, const Packet &pkt)
-{
-   RecordExtIDPCONTENT *idpcontent_data = static_cast<RecordExtIDPCONTENT *>(rec.get_extension(RecordExtIDPCONTENT::REGISTERED_ID));
-   update_record(idpcontent_data, pkt);
-   return 0;
-}
-
-}
+} // namespace ipxp

--- a/process/idpcontent.hpp
+++ b/process/idpcontent.hpp
@@ -29,128 +29,133 @@
 #ifndef IPXP_PROCESS_IDPCONTENT_HPP
 #define IPXP_PROCESS_IDPCONTENT_HPP
 
-#include <string>
 #include <cstring>
-#include <sstream>
 #include <iomanip>
+#include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
-#define IDPCONTENT_SIZE       100
-#define EXPORTED_PACKETS      2
-#define IDP_CONTENT_INDEX     0
+#define IDPCONTENT_SIZE 100
+#define EXPORTED_PACKETS 2
+#define IDP_CONTENT_INDEX 0
 #define IDP_CONTENT_REV_INDEX 1
 
 #define IDPCONTENT_UNIREC_TEMPLATE "IDP_CONTENT,IDP_CONTENT_REV"
 
-UR_FIELDS(
-   bytes IDP_CONTENT,
-   bytes IDP_CONTENT_REV
-)
+UR_FIELDS(bytes IDP_CONTENT, bytes IDP_CONTENT_REV)
 
 /**
  * \brief Flow record extension header for storing parsed IDPCONTENT packets.
  */
 
 struct idpcontentArray {
-   idpcontentArray() : size(0){ };
-   uint8_t size;
-   uint8_t data[IDPCONTENT_SIZE];
+    idpcontentArray()
+        : size(0) {};
+    uint8_t size;
+    uint8_t data[IDPCONTENT_SIZE];
 };
 
 struct RecordExtIDPCONTENT : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint8_t         pkt_export_flg[EXPORTED_PACKETS];
-   idpcontentArray idps[EXPORTED_PACKETS];
+    uint8_t pkt_export_flg[EXPORTED_PACKETS];
+    idpcontentArray idps[EXPORTED_PACKETS];
 
+    RecordExtIDPCONTENT()
+        : RecordExt(REGISTERED_ID)
+    {
+    }
 
-   RecordExtIDPCONTENT() : RecordExt(REGISTERED_ID)
-   { }
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set_var(
+            tmplt,
+            record,
+            F_IDP_CONTENT,
+            idps[IDP_CONTENT_INDEX].data,
+            idps[IDP_CONTENT_INDEX].size);
+        ur_set_var(
+            tmplt,
+            record,
+            F_IDP_CONTENT_REV,
+            idps[IDP_CONTENT_REV_INDEX].data,
+            idps[IDP_CONTENT_REV_INDEX].size);
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set_var(tmplt, record, F_IDP_CONTENT, idps[IDP_CONTENT_INDEX].data, idps[IDP_CONTENT_INDEX].size);
-      ur_set_var(tmplt, record, F_IDP_CONTENT_REV, idps[IDP_CONTENT_REV_INDEX].data, idps[IDP_CONTENT_REV_INDEX].size);
-   }
+    const char* get_unirec_tmplt() const { return IDPCONTENT_UNIREC_TEMPLATE; }
+#endif
 
-   const char *get_unirec_tmplt() const
-   {
-      return IDPCONTENT_UNIREC_TEMPLATE;
-   }
-   #endif
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        uint32_t pos = 0;
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      uint32_t pos = 0;
+        if (idps[IDP_CONTENT_INDEX].size + idps[IDP_CONTENT_REV_INDEX].size + 2 > size) {
+            return -1;
+        }
+        for (int i = 0; i < EXPORTED_PACKETS; i++) {
+            buffer[pos++] = idps[i].size;
+            memcpy(buffer + pos, idps[i].data, idps[i].size);
+            pos += idps[i].size;
+        }
 
-      if (idps[IDP_CONTENT_INDEX].size + idps[IDP_CONTENT_REV_INDEX].size + 2 > size) {
-         return -1;
-      }
-      for (int i = 0; i < EXPORTED_PACKETS; i++) {
-         buffer[pos++] = idps[i].size;
-         memcpy(buffer + pos, idps[i].data, idps[i].size);
-         pos += idps[i].size;
-      }
+        return pos;
+    }
 
-      return pos;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_IDPCONTENT_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_IDPCONTENT_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+        return ipfix_tmplt;
+    }
 
-      return ipfix_tmplt;
-   }
-
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "idpsrc=";
-      for (size_t i = 0; i < idps[IDP_CONTENT_INDEX].size; i++) {
-         out << std::hex << std::setw(2) << std::setfill('0') << idps[IDP_CONTENT_INDEX].data[i];
-      }
-      out << ",idpdst=";
-      for (size_t i = 0; i < idps[IDP_CONTENT_REV_INDEX].size; i++) {
-         out << std::hex << std::setw(2) << std::setfill('0') << idps[IDP_CONTENT_REV_INDEX].data[i];
-      }
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "idpsrc=";
+        for (size_t i = 0; i < idps[IDP_CONTENT_INDEX].size; i++) {
+            out << std::hex << std::setw(2) << std::setfill('0') << idps[IDP_CONTENT_INDEX].data[i];
+        }
+        out << ",idpdst=";
+        for (size_t i = 0; i < idps[IDP_CONTENT_REV_INDEX].size; i++) {
+            out << std::hex << std::setw(2) << std::setfill('0')
+                << idps[IDP_CONTENT_REV_INDEX].data[i];
+        }
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing IDPCONTENT packets.
  */
-class IDPCONTENTPlugin : public ProcessPlugin
-{
+class IDPCONTENTPlugin : public ProcessPlugin {
 public:
-   IDPCONTENTPlugin();
-   ~IDPCONTENTPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("idpcontent", "Parse first bytes of flow payload"); }
-   std::string get_name() const { return "idpcontent"; }
-   RecordExt *get_ext() const { return new RecordExtIDPCONTENT(); }
-   ProcessPlugin *copy();
+    IDPCONTENTPlugin();
+    ~IDPCONTENTPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser("idpcontent", "Parse first bytes of flow payload");
+    }
+    std::string get_name() const { return "idpcontent"; }
+    RecordExt* get_ext() const { return new RecordExtIDPCONTENT(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void update_record(RecordExtIDPCONTENT *pstats_data, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void update_record(RecordExtIDPCONTENT* pstats_data, const Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_IDPCONTENT_HPP */

--- a/process/md5.cpp
+++ b/process/md5.cpp
@@ -59,43 +59,52 @@ namespace ipxp {
 ///////////////////////////////////////////////
 
 // F, G, H and I are basic MD5 functions.
-inline MD5::uint4 MD5::F(uint4 x, uint4 y, uint4 z) {
-  return (x&y) | (~x&z);
+inline MD5::uint4 MD5::F(uint4 x, uint4 y, uint4 z)
+{
+    return (x & y) | (~x & z);
 }
 
-inline MD5::uint4 MD5::G(uint4 x, uint4 y, uint4 z) {
-  return (x&z) | (y&~z);
+inline MD5::uint4 MD5::G(uint4 x, uint4 y, uint4 z)
+{
+    return (x & z) | (y & ~z);
 }
 
-inline MD5::uint4 MD5::H(uint4 x, uint4 y, uint4 z) {
-  return x^y^z;
+inline MD5::uint4 MD5::H(uint4 x, uint4 y, uint4 z)
+{
+    return x ^ y ^ z;
 }
 
-inline MD5::uint4 MD5::I(uint4 x, uint4 y, uint4 z) {
-  return y ^ (x | ~z);
+inline MD5::uint4 MD5::I(uint4 x, uint4 y, uint4 z)
+{
+    return y ^ (x | ~z);
 }
 
 // rotate_left rotates x left n bits.
-inline MD5::uint4 MD5::rotate_left(uint4 x, int n) {
-  return (x << n) | (x >> (32-n));
+inline MD5::uint4 MD5::rotate_left(uint4 x, int n)
+{
+    return (x << n) | (x >> (32 - n));
 }
 
 // FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
 // Rotation is separate from addition to prevent recomputation.
-inline void MD5::FF(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
-  a = rotate_left(a+ F(b,c,d) + x + ac, s) + b;
+inline void MD5::FF(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac)
+{
+    a = rotate_left(a + F(b, c, d) + x + ac, s) + b;
 }
 
-inline void MD5::GG(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
-  a = rotate_left(a + G(b,c,d) + x + ac, s) + b;
+inline void MD5::GG(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac)
+{
+    a = rotate_left(a + G(b, c, d) + x + ac, s) + b;
 }
 
-inline void MD5::HH(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
-  a = rotate_left(a + H(b,c,d) + x + ac, s) + b;
+inline void MD5::HH(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac)
+{
+    a = rotate_left(a + H(b, c, d) + x + ac, s) + b;
 }
 
-inline void MD5::II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
-  a = rotate_left(a + I(b,c,d) + x + ac, s) + b;
+inline void MD5::II(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac)
+{
+    a = rotate_left(a + I(b, c, d) + x + ac, s) + b;
 }
 
 //////////////////////////////////////////////
@@ -103,33 +112,33 @@ inline void MD5::II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4
 // default ctor, just initailize
 MD5::MD5()
 {
-  init();
+    init();
 }
 
 //////////////////////////////////////////////
 
 // nifty shortcut ctor, compute MD5 for string and finalize it right away
-MD5::MD5(const std::string &text)
+MD5::MD5(const std::string& text)
 {
-  init();
-  update(text.c_str(), text.length());
-  finalize();
+    init();
+    update(text.c_str(), text.length());
+    finalize();
 }
 
 //////////////////////////////
 
 void MD5::init()
 {
-  finalized=false;
+    finalized = false;
 
-  count[0] = 0;
-  count[1] = 0;
+    count[0] = 0;
+    count[1] = 0;
 
-  // load magic initialization constants.
-  state[0] = 0x67452301;
-  state[1] = 0xefcdab89;
-  state[2] = 0x98badcfe;
-  state[3] = 0x10325476;
+    // load magic initialization constants.
+    state[0] = 0x67452301;
+    state[1] = 0xefcdab89;
+    state[2] = 0x98badcfe;
+    state[3] = 0x10325476;
 }
 
 //////////////////////////////
@@ -137,9 +146,9 @@ void MD5::init()
 // decodes input (unsigned char) into output (uint4). Assumes len is a multiple of 4.
 void MD5::decode(uint4 output[], const uint1 input[], size_type len)
 {
-  for (unsigned int i = 0, j = 0; j < len; i++, j += 4)
-    output[i] = ((uint4)input[j]) | (((uint4)input[j+1]) << 8) |
-      (((uint4)input[j+2]) << 16) | (((uint4)input[j+3]) << 24);
+    for (unsigned int i = 0, j = 0; j < len; i++, j += 4)
+        output[i] = ((uint4) input[j]) | (((uint4) input[j + 1]) << 8)
+            | (((uint4) input[j + 2]) << 16) | (((uint4) input[j + 3]) << 24);
 }
 
 //////////////////////////////
@@ -148,12 +157,12 @@ void MD5::decode(uint4 output[], const uint1 input[], size_type len)
 // a multiple of 4.
 void MD5::encode(uint1 output[], const uint4 input[], size_type len)
 {
-  for (size_type i = 0, j = 0; j < len; i++, j += 4) {
-    output[j] = input[i] & 0xff;
-    output[j+1] = (input[i] >> 8) & 0xff;
-    output[j+2] = (input[i] >> 16) & 0xff;
-    output[j+3] = (input[i] >> 24) & 0xff;
-  }
+    for (size_type i = 0, j = 0; j < len; i++, j += 4) {
+        output[j] = input[i] & 0xff;
+        output[j + 1] = (input[i] >> 8) & 0xff;
+        output[j + 2] = (input[i] >> 16) & 0xff;
+        output[j + 3] = (input[i] >> 24) & 0xff;
+    }
 }
 
 //////////////////////////////
@@ -161,88 +170,88 @@ void MD5::encode(uint1 output[], const uint4 input[], size_type len)
 // apply MD5 algo on a block
 void MD5::transform(const uint1 block[blocksize])
 {
-  uint4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
-  decode (x, block, blocksize);
+    uint4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+    decode(x, block, blocksize);
 
-  /* Round 1 */
-  FF (a, b, c, d, x[ 0], S11, 0xd76aa478); /* 1 */
-  FF (d, a, b, c, x[ 1], S12, 0xe8c7b756); /* 2 */
-  FF (c, d, a, b, x[ 2], S13, 0x242070db); /* 3 */
-  FF (b, c, d, a, x[ 3], S14, 0xc1bdceee); /* 4 */
-  FF (a, b, c, d, x[ 4], S11, 0xf57c0faf); /* 5 */
-  FF (d, a, b, c, x[ 5], S12, 0x4787c62a); /* 6 */
-  FF (c, d, a, b, x[ 6], S13, 0xa8304613); /* 7 */
-  FF (b, c, d, a, x[ 7], S14, 0xfd469501); /* 8 */
-  FF (a, b, c, d, x[ 8], S11, 0x698098d8); /* 9 */
-  FF (d, a, b, c, x[ 9], S12, 0x8b44f7af); /* 10 */
-  FF (c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
-  FF (b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
-  FF (a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
-  FF (d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
-  FF (c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
-  FF (b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
+    /* Round 1 */
+    FF(a, b, c, d, x[0], S11, 0xd76aa478); /* 1 */
+    FF(d, a, b, c, x[1], S12, 0xe8c7b756); /* 2 */
+    FF(c, d, a, b, x[2], S13, 0x242070db); /* 3 */
+    FF(b, c, d, a, x[3], S14, 0xc1bdceee); /* 4 */
+    FF(a, b, c, d, x[4], S11, 0xf57c0faf); /* 5 */
+    FF(d, a, b, c, x[5], S12, 0x4787c62a); /* 6 */
+    FF(c, d, a, b, x[6], S13, 0xa8304613); /* 7 */
+    FF(b, c, d, a, x[7], S14, 0xfd469501); /* 8 */
+    FF(a, b, c, d, x[8], S11, 0x698098d8); /* 9 */
+    FF(d, a, b, c, x[9], S12, 0x8b44f7af); /* 10 */
+    FF(c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
+    FF(b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
+    FF(a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
+    FF(d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
+    FF(c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
+    FF(b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
 
-  /* Round 2 */
-  GG (a, b, c, d, x[ 1], S21, 0xf61e2562); /* 17 */
-  GG (d, a, b, c, x[ 6], S22, 0xc040b340); /* 18 */
-  GG (c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
-  GG (b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
-  GG (a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
-  GG (d, a, b, c, x[10], S22,  0x2441453); /* 22 */
-  GG (c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
-  GG (b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
-  GG (a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
-  GG (d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
-  GG (c, d, a, b, x[ 3], S23, 0xf4d50d87); /* 27 */
-  GG (b, c, d, a, x[ 8], S24, 0x455a14ed); /* 28 */
-  GG (a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
-  GG (d, a, b, c, x[ 2], S22, 0xfcefa3f8); /* 30 */
-  GG (c, d, a, b, x[ 7], S23, 0x676f02d9); /* 31 */
-  GG (b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
+    /* Round 2 */
+    GG(a, b, c, d, x[1], S21, 0xf61e2562); /* 17 */
+    GG(d, a, b, c, x[6], S22, 0xc040b340); /* 18 */
+    GG(c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
+    GG(b, c, d, a, x[0], S24, 0xe9b6c7aa); /* 20 */
+    GG(a, b, c, d, x[5], S21, 0xd62f105d); /* 21 */
+    GG(d, a, b, c, x[10], S22, 0x2441453); /* 22 */
+    GG(c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
+    GG(b, c, d, a, x[4], S24, 0xe7d3fbc8); /* 24 */
+    GG(a, b, c, d, x[9], S21, 0x21e1cde6); /* 25 */
+    GG(d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
+    GG(c, d, a, b, x[3], S23, 0xf4d50d87); /* 27 */
+    GG(b, c, d, a, x[8], S24, 0x455a14ed); /* 28 */
+    GG(a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
+    GG(d, a, b, c, x[2], S22, 0xfcefa3f8); /* 30 */
+    GG(c, d, a, b, x[7], S23, 0x676f02d9); /* 31 */
+    GG(b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
 
-  /* Round 3 */
-  HH (a, b, c, d, x[ 5], S31, 0xfffa3942); /* 33 */
-  HH (d, a, b, c, x[ 8], S32, 0x8771f681); /* 34 */
-  HH (c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
-  HH (b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
-  HH (a, b, c, d, x[ 1], S31, 0xa4beea44); /* 37 */
-  HH (d, a, b, c, x[ 4], S32, 0x4bdecfa9); /* 38 */
-  HH (c, d, a, b, x[ 7], S33, 0xf6bb4b60); /* 39 */
-  HH (b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
-  HH (a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
-  HH (d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
-  HH (c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
-  HH (b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
-  HH (a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
-  HH (d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
-  HH (c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
-  HH (b, c, d, a, x[ 2], S34, 0xc4ac5665); /* 48 */
+    /* Round 3 */
+    HH(a, b, c, d, x[5], S31, 0xfffa3942); /* 33 */
+    HH(d, a, b, c, x[8], S32, 0x8771f681); /* 34 */
+    HH(c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
+    HH(b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
+    HH(a, b, c, d, x[1], S31, 0xa4beea44); /* 37 */
+    HH(d, a, b, c, x[4], S32, 0x4bdecfa9); /* 38 */
+    HH(c, d, a, b, x[7], S33, 0xf6bb4b60); /* 39 */
+    HH(b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
+    HH(a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
+    HH(d, a, b, c, x[0], S32, 0xeaa127fa); /* 42 */
+    HH(c, d, a, b, x[3], S33, 0xd4ef3085); /* 43 */
+    HH(b, c, d, a, x[6], S34, 0x4881d05); /* 44 */
+    HH(a, b, c, d, x[9], S31, 0xd9d4d039); /* 45 */
+    HH(d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
+    HH(c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
+    HH(b, c, d, a, x[2], S34, 0xc4ac5665); /* 48 */
 
-  /* Round 4 */
-  II (a, b, c, d, x[ 0], S41, 0xf4292244); /* 49 */
-  II (d, a, b, c, x[ 7], S42, 0x432aff97); /* 50 */
-  II (c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
-  II (b, c, d, a, x[ 5], S44, 0xfc93a039); /* 52 */
-  II (a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
-  II (d, a, b, c, x[ 3], S42, 0x8f0ccc92); /* 54 */
-  II (c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
-  II (b, c, d, a, x[ 1], S44, 0x85845dd1); /* 56 */
-  II (a, b, c, d, x[ 8], S41, 0x6fa87e4f); /* 57 */
-  II (d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
-  II (c, d, a, b, x[ 6], S43, 0xa3014314); /* 59 */
-  II (b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
-  II (a, b, c, d, x[ 4], S41, 0xf7537e82); /* 61 */
-  II (d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
-  II (c, d, a, b, x[ 2], S43, 0x2ad7d2bb); /* 63 */
-  II (b, c, d, a, x[ 9], S44, 0xeb86d391); /* 64 */
+    /* Round 4 */
+    II(a, b, c, d, x[0], S41, 0xf4292244); /* 49 */
+    II(d, a, b, c, x[7], S42, 0x432aff97); /* 50 */
+    II(c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
+    II(b, c, d, a, x[5], S44, 0xfc93a039); /* 52 */
+    II(a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
+    II(d, a, b, c, x[3], S42, 0x8f0ccc92); /* 54 */
+    II(c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
+    II(b, c, d, a, x[1], S44, 0x85845dd1); /* 56 */
+    II(a, b, c, d, x[8], S41, 0x6fa87e4f); /* 57 */
+    II(d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
+    II(c, d, a, b, x[6], S43, 0xa3014314); /* 59 */
+    II(b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
+    II(a, b, c, d, x[4], S41, 0xf7537e82); /* 61 */
+    II(d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
+    II(c, d, a, b, x[2], S43, 0x2ad7d2bb); /* 63 */
+    II(b, c, d, a, x[9], S44, 0xeb86d391); /* 64 */
 
-  state[0] += a;
-  state[1] += b;
-  state[2] += c;
-  state[3] += d;
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
 
-  // Zeroize sensitive information.
-  memset(x, 0, sizeof x);
+    // Zeroize sensitive information.
+    memset(x, 0, sizeof x);
 }
 
 //////////////////////////////
@@ -251,37 +260,35 @@ void MD5::transform(const uint1 block[blocksize])
 // operation, processing another message block
 void MD5::update(const unsigned char input[], size_type length)
 {
-  // compute number of bytes mod 64
-  size_type index = count[0] / 8 % blocksize;
+    // compute number of bytes mod 64
+    size_type index = count[0] / 8 % blocksize;
 
-  // Update number of bits
-  if ((count[0] += (length << 3)) < (length << 3))
-    count[1]++;
-  count[1] += (length >> 29);
+    // Update number of bits
+    if ((count[0] += (length << 3)) < (length << 3))
+        count[1]++;
+    count[1] += (length >> 29);
 
-  // number of bytes we need to fill in buffer
-  size_type firstpart = 64 - index;
+    // number of bytes we need to fill in buffer
+    size_type firstpart = 64 - index;
 
-  size_type i;
+    size_type i;
 
-  // transform as many times as possible.
-  if (length >= firstpart)
-  {
-    // fill buffer first, transform
-    memcpy(&buffer[index], input, firstpart);
-    transform(buffer);
+    // transform as many times as possible.
+    if (length >= firstpart) {
+        // fill buffer first, transform
+        memcpy(&buffer[index], input, firstpart);
+        transform(buffer);
 
-    // transform chunks of blocksize (64 bytes)
-    for (i = firstpart; i + blocksize <= length; i += blocksize)
-      transform(&input[i]);
+        // transform chunks of blocksize (64 bytes)
+        for (i = firstpart; i + blocksize <= length; i += blocksize)
+            transform(&input[i]);
 
-    index = 0;
-  }
-  else
-    i = 0;
+        index = 0;
+    } else
+        i = 0;
 
-  // buffer remaining input
-  memcpy(&buffer[index], &input[i], length-i);
+    // buffer remaining input
+    memcpy(&buffer[index], &input[i], length - i);
 }
 
 //////////////////////////////
@@ -289,7 +296,7 @@ void MD5::update(const unsigned char input[], size_type length)
 // for convenience provide a verson with signed char
 void MD5::update(const char input[], size_type length)
 {
-  update((const unsigned char*)input, length);
+    update((const unsigned char*) input, length);
 }
 
 //////////////////////////////
@@ -298,36 +305,35 @@ void MD5::update(const char input[], size_type length)
 // the message digest and zeroizing the context.
 MD5& MD5::finalize()
 {
-  static unsigned char padding[64] = {
-    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-  };
+    static unsigned char padding[64]
+        = {0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+           0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+           0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-  if (!finalized) {
-    // Save number of bits
-    unsigned char bits[8];
-    encode(bits, count, 8);
+    if (!finalized) {
+        // Save number of bits
+        unsigned char bits[8];
+        encode(bits, count, 8);
 
-    // pad out to 56 mod 64.
-    size_type index = count[0] / 8 % 64;
-    size_type padLen = (index < 56) ? (56 - index) : (120 - index);
-    update(padding, padLen);
+        // pad out to 56 mod 64.
+        size_type index = count[0] / 8 % 64;
+        size_type padLen = (index < 56) ? (56 - index) : (120 - index);
+        update(padding, padLen);
 
-    // Append length (before padding)
-    update(bits, 8);
+        // Append length (before padding)
+        update(bits, 8);
 
-    // Store state in digest
-    encode(digest, state, 16);
+        // Store state in digest
+        encode(digest, state, 16);
 
-    // Zeroize sensitive information.
-    memset(buffer, 0, sizeof buffer);
-    memset(count, 0, sizeof count);
+        // Zeroize sensitive information.
+        memset(buffer, 0, sizeof buffer);
+        memset(count, 0, sizeof count);
 
-    finalized=true;
-  }
+        finalized = true;
+    }
 
-  return *this;
+    return *this;
 }
 
 //////////////////////////////
@@ -335,15 +341,15 @@ MD5& MD5::finalize()
 // return hex representation of digest as string
 std::string MD5::hexdigest() const
 {
-  if (!finalized)
-    return "";
+    if (!finalized)
+        return "";
 
-  char buf[33];
-  for (int i=0; i<16; i++)
-    sprintf(buf+i*2, "%02x", digest[i]);
-  buf[32]=0;
+    char buf[33];
+    for (int i = 0; i < 16; i++)
+        sprintf(buf + i * 2, "%02x", digest[i]);
+    buf[32] = 0;
 
-  return std::string(buf);
+    return std::string(buf);
 }
 
 //////////////////////////////
@@ -357,7 +363,7 @@ const unsigned char* MD5::binary_digest() const
 
 std::ostream& operator<<(std::ostream& out, MD5 md5)
 {
-  return out << md5.hexdigest();
+    return out << md5.hexdigest();
 }
 
 //////////////////////////////
@@ -377,4 +383,4 @@ void md5_get_bin(const std::string str, void* dest)
     memcpy(dest, md5.binary_digest(), 16);
 }
 
-}
+} // namespace ipxp

--- a/process/md5.hpp
+++ b/process/md5.hpp
@@ -48,50 +48,49 @@ namespace ipxp {
 //      MD5(std::string).hexdigest()
 //
 // assumes that char is 8 bit and int is 32 bit
-class MD5
-{
+class MD5 {
 public:
-  typedef unsigned int size_type; // must be 32bit
+    typedef unsigned int size_type; // must be 32bit
 
-  MD5();
-  MD5(const std::string& text);
-  void update(const unsigned char *buf, size_type length);
-  void update(const char *buf, size_type length);
-  MD5& finalize();
-  std::string hexdigest() const;
-  const unsigned char* binary_digest() const;
-  friend std::ostream& operator<<(std::ostream&, MD5 md5);
+    MD5();
+    MD5(const std::string& text);
+    void update(const unsigned char* buf, size_type length);
+    void update(const char* buf, size_type length);
+    MD5& finalize();
+    std::string hexdigest() const;
+    const unsigned char* binary_digest() const;
+    friend std::ostream& operator<<(std::ostream&, MD5 md5);
 
 private:
-  void init();
-  typedef unsigned char uint1; //  8bit
-  typedef unsigned int uint4;  // 32bit
-  enum {blocksize = 64}; // VC6 won't eat a const static int here
+    void init();
+    typedef unsigned char uint1; //  8bit
+    typedef unsigned int uint4; // 32bit
+    enum { blocksize = 64 }; // VC6 won't eat a const static int here
 
-  void transform(const uint1 block[blocksize]);
-  static void decode(uint4 output[], const uint1 input[], size_type len);
-  static void encode(uint1 output[], const uint4 input[], size_type len);
+    void transform(const uint1 block[blocksize]);
+    static void decode(uint4 output[], const uint1 input[], size_type len);
+    static void encode(uint1 output[], const uint4 input[], size_type len);
 
-  bool finalized;
-  uint1 buffer[blocksize]; // bytes that didn't fit in last 64 byte chunk
-  uint4 count[2];   // 64bit counter for number of bits (lo, hi)
-  uint4 state[4];   // digest so far
-  uint1 digest[16]; // the result
+    bool finalized;
+    uint1 buffer[blocksize]; // bytes that didn't fit in last 64 byte chunk
+    uint4 count[2]; // 64bit counter for number of bits (lo, hi)
+    uint4 state[4]; // digest so far
+    uint1 digest[16]; // the result
 
-  // low level logic operations
-  static inline uint4 F(uint4 x, uint4 y, uint4 z);
-  static inline uint4 G(uint4 x, uint4 y, uint4 z);
-  static inline uint4 H(uint4 x, uint4 y, uint4 z);
-  static inline uint4 I(uint4 x, uint4 y, uint4 z);
-  static inline uint4 rotate_left(uint4 x, int n);
-  static inline void FF(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
-  static inline void GG(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
-  static inline void HH(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
-  static inline void II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+    // low level logic operations
+    static inline uint4 F(uint4 x, uint4 y, uint4 z);
+    static inline uint4 G(uint4 x, uint4 y, uint4 z);
+    static inline uint4 H(uint4 x, uint4 y, uint4 z);
+    static inline uint4 I(uint4 x, uint4 y, uint4 z);
+    static inline uint4 rotate_left(uint4 x, int n);
+    static inline void FF(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+    static inline void GG(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+    static inline void HH(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+    static inline void II(uint4& a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
 };
 
 std::string md5(const std::string str);
 void md5_get_bin(const std::string str, void* dest);
 
-}
+} // namespace ipxp
 #endif

--- a/process/mpls.cpp
+++ b/process/mpls.cpp
@@ -36,28 +36,27 @@ int RecordExtMPLS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("mpls", [](){return new MPLSPlugin();});
-   register_plugin(&rec);
-   RecordExtMPLS::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("mpls", []() { return new MPLSPlugin(); });
+    register_plugin(&rec);
+    RecordExtMPLS::REGISTERED_ID = register_extension();
 }
 
-ProcessPlugin *MPLSPlugin::copy()
+ProcessPlugin* MPLSPlugin::copy()
 {
-   return new MPLSPlugin(*this);
+    return new MPLSPlugin(*this);
 }
 
-int MPLSPlugin::post_create(Flow &rec, const Packet &pkt)
+int MPLSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   if (pkt.mplsTop == 0) {
-      return 0;
-   }
+    if (pkt.mplsTop == 0) {
+        return 0;
+    }
 
-   auto ext = new RecordExtMPLS();
-   ext->mpls = pkt.mplsTop;
+    auto ext = new RecordExtMPLS();
+    ext->mpls = pkt.mplsTop;
 
-   rec.add_extension(ext);
-   return 0;
+    rec.add_extension(ext);
+    return 0;
 }
 
-}
-
+} // namespace ipxp

--- a/process/mpls.hpp
+++ b/process/mpls.hpp
@@ -30,17 +30,17 @@
 #define IPXP_PROCESS_MPLS_HPP
 
 #include <cstring>
-#include <string>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
-  #include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
@@ -48,84 +48,78 @@ namespace ipxp {
 
 #define MPLS_UNIREC_TEMPLATE "MPLS_TOP_LABEL_STACK_SECTION"
 
-UR_FIELDS (
-   bytes MPLS_TOP_LABEL_STACK_SECTION
-)
+UR_FIELDS(bytes MPLS_TOP_LABEL_STACK_SECTION)
 
 /**
  * \brief Flow record extension header for storing parsed MPLS data.
  */
 struct RecordExtMPLS : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   // Contents are (from MSb to LSb):
-   //   20-bit - Label,
-   //   3-bit  - Traffic class / EXP,
-   //   1-bit  - Bottom of stack (true if last),
-   //   8-bit  - TTL (Time To Live)
-   uint32_t mpls;
+    // Contents are (from MSb to LSb):
+    //   20-bit - Label,
+    //   3-bit  - Traffic class / EXP,
+    //   1-bit  - Bottom of stack (true if last),
+    //   8-bit  - TTL (Time To Live)
+    uint32_t mpls;
 
-   RecordExtMPLS() : RecordExt(REGISTERED_ID), mpls(0) { }
+    RecordExtMPLS()
+        : RecordExt(REGISTERED_ID)
+        , mpls(0)
+    {
+    }
 
 #ifdef WITH_NEMEA
-   void fill_unirec(ur_template_t *tmplt, void *record) override
-   {
-      auto v = htonl(mpls);
-      auto arr = reinterpret_cast<uint8_t *>(&v);
-      ur_set_var(tmplt, record, F_MPLS_TOP_LABEL_STACK_SECTION, arr, MPLS_LABEL_SECTION_LENGTH);
-   }
+    void fill_unirec(ur_template_t* tmplt, void* record) override
+    {
+        auto v = htonl(mpls);
+        auto arr = reinterpret_cast<uint8_t*>(&v);
+        ur_set_var(tmplt, record, F_MPLS_TOP_LABEL_STACK_SECTION, arr, MPLS_LABEL_SECTION_LENGTH);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return MPLS_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return MPLS_UNIREC_TEMPLATE; }
 #endif
 
-   int fill_ipfix(uint8_t *buffer, int size) override
-   {
-      if (size < MPLS_LABEL_SECTION_LENGTH + 1) {
-         return -1;
-      }
+    int fill_ipfix(uint8_t* buffer, int size) override
+    {
+        if (size < MPLS_LABEL_SECTION_LENGTH + 1) {
+            return -1;
+        }
 
-      buffer[0] = MPLS_LABEL_SECTION_LENGTH;
-      auto v = htonl(mpls);
-      auto arr = reinterpret_cast<uint8_t *>(&v);
-      memcpy(buffer + 2, arr, MPLS_LABEL_SECTION_LENGTH);
+        buffer[0] = MPLS_LABEL_SECTION_LENGTH;
+        auto v = htonl(mpls);
+        auto arr = reinterpret_cast<uint8_t*>(&v);
+        memcpy(buffer + 2, arr, MPLS_LABEL_SECTION_LENGTH);
 
-      return MPLS_LABEL_SECTION_LENGTH + 1;
-   }
+        return MPLS_LABEL_SECTION_LENGTH + 1;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_MPLS_TEMPLATE(IPFIX_FIELD_NAMES)
-         NULL
-      };
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_MPLS_TEMPLATE(IPFIX_FIELD_NAMES) NULL};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "mpls_label_1=\"" << (mpls >> 8) << '"';
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "mpls_label_1=\"" << (mpls >> 8) << '"';
+        return out.str();
+    }
 };
 
 /**
  * \brief Process plugin for parsing MPLS packets.
  */
-class MPLSPlugin : public ProcessPlugin
-{
+class MPLSPlugin : public ProcessPlugin {
 public:
-   OptionsParser *get_parser() const { return new OptionsParser("mpls", "Parse MPLS traffic"); }
-   std::string get_name() const { return "mpls"; }
-   RecordExt *get_ext() const { return new RecordExtMPLS(); }
-   ProcessPlugin *copy();
+    OptionsParser* get_parser() const { return new OptionsParser("mpls", "Parse MPLS traffic"); }
+    std::string get_name() const { return "mpls"; }
+    RecordExt* get_ext() const { return new RecordExtMPLS(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_MPLS_HPP */
-

--- a/process/netbios.cpp
+++ b/process/netbios.cpp
@@ -40,34 +40,32 @@ int RecordExtNETBIOS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("netbios", [](){return new NETBIOSPlugin();});
-   register_plugin(&rec);
-   RecordExtNETBIOS::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("netbios", []() { return new NETBIOSPlugin(); });
+    register_plugin(&rec);
+    RecordExtNETBIOS::REGISTERED_ID = register_extension();
 }
 
-NETBIOSPlugin::NETBIOSPlugin() : total_netbios_packets(0)
+NETBIOSPlugin::NETBIOSPlugin()
+    : total_netbios_packets(0)
 {
 }
 
 NETBIOSPlugin::~NETBIOSPlugin()
 {
-   close();
+    close();
 }
 
-void NETBIOSPlugin::init(const char *params)
+void NETBIOSPlugin::init(const char* params) {}
+
+void NETBIOSPlugin::close() {}
+
+ProcessPlugin* NETBIOSPlugin::copy()
 {
+    return new NETBIOSPlugin(*this);
 }
 
-void NETBIOSPlugin::close()
+int NETBIOSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-}
-
-ProcessPlugin *NETBIOSPlugin::copy()
-{
-   return new NETBIOSPlugin(*this);
-}
-
-int NETBIOSPlugin::post_create(Flow &rec, const Packet &pkt) {
     if (pkt.dst_port == 137 || pkt.src_port == 137) {
         return add_netbios_ext(rec, pkt);
     }
@@ -75,7 +73,8 @@ int NETBIOSPlugin::post_create(Flow &rec, const Packet &pkt) {
     return 0;
 }
 
-int NETBIOSPlugin::post_update(Flow &rec, const Packet &pkt) {
+int NETBIOSPlugin::post_update(Flow& rec, const Packet& pkt)
+{
     if (pkt.dst_port == 137 || pkt.src_port == 137) {
         return add_netbios_ext(rec, pkt);
     }
@@ -83,8 +82,9 @@ int NETBIOSPlugin::post_update(Flow &rec, const Packet &pkt) {
     return 0;
 }
 
-int NETBIOSPlugin::add_netbios_ext(Flow &rec, const Packet &pkt) {
-    RecordExtNETBIOS *ext = new RecordExtNETBIOS();
+int NETBIOSPlugin::add_netbios_ext(Flow& rec, const Packet& pkt)
+{
+    RecordExtNETBIOS* ext = new RecordExtNETBIOS();
     if (parse_nbns(ext, pkt)) {
         total_netbios_packets++;
         rec.add_extension(ext);
@@ -95,8 +95,9 @@ int NETBIOSPlugin::add_netbios_ext(Flow &rec, const Packet &pkt) {
     return 0;
 }
 
-bool NETBIOSPlugin::parse_nbns(RecordExtNETBIOS *rec, const Packet &pkt) {
-    const char *payload = reinterpret_cast<const char *>(pkt.payload);
+bool NETBIOSPlugin::parse_nbns(RecordExtNETBIOS* rec, const Packet& pkt)
+{
+    const char* payload = reinterpret_cast<const char*>(pkt.payload);
 
     int qry_cnt = get_query_count(payload, pkt.payload_len);
     payload += sizeof(struct dns_hdr);
@@ -107,16 +108,18 @@ bool NETBIOSPlugin::parse_nbns(RecordExtNETBIOS *rec, const Packet &pkt) {
     return store_first_query(payload, rec);
 }
 
-int NETBIOSPlugin::get_query_count(const char *payload, uint16_t payload_length) {
+int NETBIOSPlugin::get_query_count(const char* payload, uint16_t payload_length)
+{
     if (payload_length < sizeof(struct dns_hdr)) {
         return -1;
     }
 
-    struct dns_hdr *hdr = (struct dns_hdr *) payload;
+    struct dns_hdr* hdr = (struct dns_hdr*) payload;
     return ntohs(hdr->question_rec_cnt);
 }
 
-bool NETBIOSPlugin::store_first_query(const char *payload, RecordExtNETBIOS *rec) {
+bool NETBIOSPlugin::store_first_query(const char* payload, RecordExtNETBIOS* rec)
+{
     uint8_t nb_name_length = *payload++;
     if (nb_name_length != 32) {
         return false;
@@ -133,19 +136,22 @@ bool NETBIOSPlugin::store_first_query(const char *payload, RecordExtNETBIOS *rec
     return true;
 }
 
-char NETBIOSPlugin::compress_nbns_name_char(const char *uncompressed) {
+char NETBIOSPlugin::compress_nbns_name_char(const char* uncompressed)
+{
     return (((uncompressed[0] - 'A') << 4) | (uncompressed[1] - 'A'));
 }
 
-uint8_t NETBIOSPlugin::get_nbns_suffix(const char *uncompressed) {
+uint8_t NETBIOSPlugin::get_nbns_suffix(const char* uncompressed)
+{
     return compress_nbns_name_char(uncompressed);
 }
 
-void NETBIOSPlugin::finish(bool print_stats) {
+void NETBIOSPlugin::finish(bool print_stats)
+{
     if (print_stats) {
         std::cout << "NETBIOS plugin stats:" << std::endl;
         std::cout << "   Parsed NBNS packets in total: " << total_netbios_packets << std::endl;
     }
 }
 
-}
+} // namespace ipxp

--- a/process/netbios.hpp
+++ b/process/netbios.hpp
@@ -29,86 +29,79 @@
 #ifndef IPXP_PROCESS_NETBIOS_HPP
 #define IPXP_PROCESS_NETBIOS_HPP
 
-#include <string>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
 #include "dns-utils.hpp"
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #define NETBIOS_UNIREC_TEMPLATE "NB_NAME,NB_SUFFIX"
 
-UR_FIELDS (
-    string NB_NAME,
-    uint8 NB_SUFFIX
-)
+UR_FIELDS(string NB_NAME, uint8 NB_SUFFIX)
 
 /**
  * \brief Flow record extension header for storing parsed NETBIOS packets.
  */
 struct RecordExtNETBIOS : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   std::string netbios_name;
-   char netbios_suffix;
+    std::string netbios_name;
+    char netbios_suffix;
 
-   RecordExtNETBIOS() : RecordExt(REGISTERED_ID), netbios_suffix(0)
-   {
-   }
+    RecordExtNETBIOS()
+        : RecordExt(REGISTERED_ID)
+        , netbios_suffix(0)
+    {
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_NB_SUFFIX, netbios_suffix);
-      ur_set_string(tmplt, record, F_NB_NAME, netbios_name.c_str());
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_NB_SUFFIX, netbios_suffix);
+        ur_set_string(tmplt, record, F_NB_NAME, netbios_name.c_str());
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return NETBIOS_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return NETBIOS_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length = netbios_name.length();
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length = netbios_name.length();
 
-      if (2 + length > size) {
-         return -1;
-      }
+        if (2 + length > size) {
+            return -1;
+        }
 
-      buffer[0] = netbios_suffix;
-      buffer[1] = length;
-      memcpy(buffer + 2, netbios_name.c_str(), length);
+        buffer[0] = netbios_suffix;
+        buffer[1] = length;
+        memcpy(buffer + 2, netbios_name.c_str(), length);
 
-      return length + 2;
-   }
+        return length + 2;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_netbios_template[] = {
-         IPFIX_NETBIOS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_netbios_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_netbios_template[]
+            = {IPFIX_NETBIOS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_netbios_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "netbiossuffix=" << netbios_suffix
-         << ",name=\"" << netbios_name << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "netbiossuffix=" << netbios_suffix << ",name=\"" << netbios_name << "\"";
+        return out.str();
+    }
 };
 
 /**
@@ -118,27 +111,30 @@ class NETBIOSPlugin : public ProcessPlugin {
 public:
     NETBIOSPlugin();
     ~NETBIOSPlugin();
-    void init(const char *params);
+    void init(const char* params);
     void close();
-    OptionsParser *get_parser() const { return new OptionsParser("netbios", "Parse netbios traffic"); }
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser("netbios", "Parse netbios traffic");
+    }
     std::string get_name() const { return "netbios"; }
-    RecordExt *get_ext() const { return new RecordExtNETBIOS(); }
-    ProcessPlugin *copy();
+    RecordExt* get_ext() const { return new RecordExtNETBIOS(); }
+    ProcessPlugin* copy();
 
-    int post_create(Flow &rec, const Packet &pkt);
-    int post_update(Flow &rec, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
     void finish(bool print_stats);
 
 private:
     int total_netbios_packets;
 
-    int add_netbios_ext(Flow &rec, const Packet &pkt);
-    bool parse_nbns(RecordExtNETBIOS *rec, const Packet &pkt);
-    int get_query_count(const char *payload, uint16_t payload_length);
-    bool store_first_query(const char *payload, RecordExtNETBIOS *rec);
-    char compress_nbns_name_char(const char *uncompressed);
-    uint8_t get_nbns_suffix(const char *uncompressed);
+    int add_netbios_ext(Flow& rec, const Packet& pkt);
+    bool parse_nbns(RecordExtNETBIOS* rec, const Packet& pkt);
+    int get_query_count(const char* payload, uint16_t payload_length);
+    bool store_first_query(const char* payload, RecordExtNETBIOS* rec);
+    char compress_nbns_name_char(const char* uncompressed);
+    uint8_t get_nbns_suffix(const char* uncompressed);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_NETBIOS_HPP */

--- a/process/ntp.cpp
+++ b/process/ntp.cpp
@@ -43,12 +43,12 @@ int RecordExtNTP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("ntp", [](){return new NTPPlugin();});
-   register_plugin(&rec);
-   RecordExtNTP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("ntp", []() { return new NTPPlugin(); });
+    register_plugin(&rec);
+    RecordExtNTP::REGISTERED_ID = register_extension();
 }
 
-//#define DEBUG_NTP
+// #define DEBUG_NTP
 
 /*Print debug message if debugging is allowed.*/
 #ifdef DEBUG_NTP
@@ -57,26 +57,25 @@ __attribute__((constructor)) static void register_this_plugin()
 #define DEBUG_MSG(format, ...)
 #endif
 
-NTPPlugin::NTPPlugin() : requests(0), responses(0), total(0)
+NTPPlugin::NTPPlugin()
+    : requests(0)
+    , responses(0)
+    , total(0)
 {
 }
 
 NTPPlugin::~NTPPlugin()
 {
-   close();
+    close();
 }
 
-void NTPPlugin::init(const char *params)
-{
-}
+void NTPPlugin::init(const char* params) {}
 
-void NTPPlugin::close()
-{
-}
+void NTPPlugin::close() {}
 
-ProcessPlugin *NTPPlugin::copy()
+ProcessPlugin* NTPPlugin::copy()
 {
-   return new NTPPlugin(*this);
+    return new NTPPlugin(*this);
 }
 
 /**
@@ -85,14 +84,14 @@ ProcessPlugin *NTPPlugin::copy()
  *\param [in] pkt Parsed packet.
  *\return 0 on success or FLOW_FLUSH option.
  */
-int NTPPlugin::post_create(Flow &rec, const Packet &pkt)
+int NTPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   if (pkt.dst_port == 123 || pkt.src_port == 123) {
-      add_ext_ntp(rec, pkt);
-      return FLOW_FLUSH;
-   }
+    if (pkt.dst_port == 123 || pkt.src_port == 123) {
+        add_ext_ntp(rec, pkt);
+        return FLOW_FLUSH;
+    }
 
-   return 0;
+    return 0;
 }
 
 /**
@@ -100,12 +99,12 @@ int NTPPlugin::post_create(Flow &rec, const Packet &pkt)
  */
 void NTPPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "NTP plugin stats:" << std::endl;
-      std::cout << "   Parsed NTP requests: " << requests << std::endl;
-      std::cout << "   Parsed NTP responses: " << responses << std::endl;
-      std::cout << "   Total NTP packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "NTP plugin stats:" << std::endl;
+        std::cout << "   Parsed NTP requests: " << requests << std::endl;
+        std::cout << "   Parsed NTP responses: " << responses << std::endl;
+        std::cout << "   Total NTP packets processed: " << total << std::endl;
+    }
 }
 
 /**
@@ -113,14 +112,14 @@ void NTPPlugin::finish(bool print_stats)
  *\param [in] packet.
  *\param [out] rec Destination Flow.
  */
-void NTPPlugin::add_ext_ntp(Flow &rec, const Packet &pkt)
+void NTPPlugin::add_ext_ntp(Flow& rec, const Packet& pkt)
 {
-   RecordExtNTP *ntp_data_ext = new RecordExtNTP();
-   if (!parse_ntp(pkt, ntp_data_ext)) {
-      delete ntp_data_ext; /*Don't add new extension packet.*/
-   } else {
-      rec.add_extension(ntp_data_ext); /*Add extension to  packet.*/
-   }
+    RecordExtNTP* ntp_data_ext = new RecordExtNTP();
+    if (!parse_ntp(pkt, ntp_data_ext)) {
+        delete ntp_data_ext; /*Don't add new extension packet.*/
+    } else {
+        rec.add_extension(ntp_data_ext); /*Add extension to  packet.*/
+    }
 }
 
 /**
@@ -129,301 +128,323 @@ void NTPPlugin::add_ext_ntp(Flow &rec, const Packet &pkt)
  *\param [out] rec Output Flow extension header RecordExtNTP.
  *\return True if NTP was parsed.
  */
-bool NTPPlugin::parse_ntp(const Packet &pkt, RecordExtNTP *ntp_data_ext)
+bool NTPPlugin::parse_ntp(const Packet& pkt, RecordExtNTP* ntp_data_ext)
 {
-   size_t i = 0;
-   int number = 0, ch_counter = 0;
-   const unsigned char *payload = nullptr;
-   unsigned char aux = '.';
-   std::string result = "", result2 = "";
-   std::string convert;
-   std::string str;
-   payload = (unsigned char *) pkt.payload;
+    size_t i = 0;
+    int number = 0, ch_counter = 0;
+    const unsigned char* payload = nullptr;
+    unsigned char aux = '.';
+    std::string result = "", result2 = "";
+    std::string convert;
+    std::string str;
+    payload = (unsigned char*) pkt.payload;
 
-   if (pkt.payload_len == 0) {
-      DEBUG_MSG("Parser quits:\tpayload length = 0\n");
-      return false; /*Don't add extension to  paket.*/
-   }
+    if (pkt.payload_len == 0) {
+        DEBUG_MSG("Parser quits:\tpayload length = 0\n");
+        return false; /*Don't add extension to  paket.*/
+    }
 
-   try{
-      DEBUG_MSG("\n---------- NTP PARSER #%u ----------\n", total + 1);
+    try {
+        DEBUG_MSG("\n---------- NTP PARSER #%u ----------\n", total + 1);
 
-      /******************
-                 * PARSE NTP_LEAP.*
-                 * ****************/
-      total++;
-      aux = payload[0];
-      aux = aux >> 6;
-      ntp_data_ext->leap = (uint8_t) aux;
-      DEBUG_MSG("\tntp leap:\t\t%d\n", ntp_data_ext->leap);
+        /******************
+         * PARSE NTP_LEAP.*
+         * ****************/
+        total++;
+        aux = payload[0];
+        aux = aux >> 6;
+        ntp_data_ext->leap = (uint8_t) aux;
+        DEBUG_MSG("\tntp leap:\t\t%d\n", ntp_data_ext->leap);
 
-      /*******************
-                 *PARSE NTP_VERION.*
-                 *******************/
-      aux = payload[0];
-      aux = aux << 2;
-      aux = aux >> 5;
-      ntp_data_ext->version = (uint8_t) aux;
-      if (ntp_data_ext->version != 4) { throw "Error: Bad number of version or NTP exploit detected."; }
-      DEBUG_MSG("\tntp version:\t\t%d\n", ntp_data_ext->version);
+        /*******************
+         *PARSE NTP_VERION.*
+         *******************/
+        aux = payload[0];
+        aux = aux << 2;
+        aux = aux >> 5;
+        ntp_data_ext->version = (uint8_t) aux;
+        if (ntp_data_ext->version != 4) {
+            throw "Error: Bad number of version or NTP exploit detected.";
+        }
+        DEBUG_MSG("\tntp version:\t\t%d\n", ntp_data_ext->version);
 
-      /*****************
-                 *PARSE NTP_MODE.*
-       *****************/
-      aux = payload[0];
-      aux = aux << 5;
-      aux = aux >> 5;
-      ntp_data_ext->mode = (uint8_t) aux;
-      if (ntp_data_ext->mode < 3 || ntp_data_ext->mode > 4) { throw "Error: Bad NTP mode or NTP exploit detected."; }
-      if (ntp_data_ext->mode == 3) { requests++; }
-      if (ntp_data_ext->mode == 4) { responses++; }
-      DEBUG_MSG("\tntp mode:\t\t%d\n", ntp_data_ext->mode);
+        /*****************
+         *PARSE NTP_MODE.*
+         *****************/
+        aux = payload[0];
+        aux = aux << 5;
+        aux = aux >> 5;
+        ntp_data_ext->mode = (uint8_t) aux;
+        if (ntp_data_ext->mode < 3 || ntp_data_ext->mode > 4) {
+            throw "Error: Bad NTP mode or NTP exploit detected.";
+        }
+        if (ntp_data_ext->mode == 3) {
+            requests++;
+        }
+        if (ntp_data_ext->mode == 4) {
+            responses++;
+        }
+        DEBUG_MSG("\tntp mode:\t\t%d\n", ntp_data_ext->mode);
 
-      /*********************
-                 * PARSE NTP_STRATUM.*
-                 * *******************/
-      aux = payload[1];
-      ntp_data_ext->stratum = (uint8_t) aux;
-      if (ntp_data_ext->stratum > 16) { throw "Error: Bad NTP Stratum or NTP exploit detected."; }
-      DEBUG_MSG("\tntp stratum:\t\t%d\n", ntp_data_ext->stratum);
+        /*********************
+         * PARSE NTP_STRATUM.*
+         * *******************/
+        aux = payload[1];
+        ntp_data_ext->stratum = (uint8_t) aux;
+        if (ntp_data_ext->stratum > 16) {
+            throw "Error: Bad NTP Stratum or NTP exploit detected.";
+        }
+        DEBUG_MSG("\tntp stratum:\t\t%d\n", ntp_data_ext->stratum);
 
-      /*****************
-      * PARSE NTP_POLL.*
-      * ****************/
-      aux = payload[2];
-      ntp_data_ext->poll = (uint8_t) aux;
-      if (ntp_data_ext->poll > 17) { throw "Error: Bad NTP Poll or NTP exploit detected."; }
-      DEBUG_MSG("\tntp poll:\t\t%d\n", ntp_data_ext->poll);
+        /*****************
+         * PARSE NTP_POLL.*
+         * ****************/
+        aux = payload[2];
+        ntp_data_ext->poll = (uint8_t) aux;
+        if (ntp_data_ext->poll > 17) {
+            throw "Error: Bad NTP Poll or NTP exploit detected.";
+        }
+        DEBUG_MSG("\tntp poll:\t\t%d\n", ntp_data_ext->poll);
 
-      /*****************************************
-      * PARSE NTP_PRECISION         not used   *
-      ******************************************/
-      aux = payload[3];
-      ntp_data_ext->precision = (uint8_t) aux;
-      DEBUG_MSG("\tntp precision:\t\t%d\n", ntp_data_ext->precision);
+        /*****************************************
+         * PARSE NTP_PRECISION         not used   *
+         ******************************************/
+        aux = payload[3];
+        ntp_data_ext->precision = (uint8_t) aux;
+        DEBUG_MSG("\tntp precision:\t\t%d\n", ntp_data_ext->precision);
 
-      /******************************************
-      * PARSE NTP_DELAY-                        *
-      *payload [4][5][6][7]. not implemented yet*
-      *******************************************/
+        /******************************************
+         * PARSE NTP_DELAY-                        *
+         *payload [4][5][6][7]. not implemented yet*
+         *******************************************/
 
-      /********************************************
-      * PARSE NTP_DISPERSION-                     *
-      *payload [8][9][10][11]. not implemented yet*
-      *********************************************/
+        /********************************************
+         * PARSE NTP_DISPERSION-                     *
+         *payload [8][9][10][11]. not implemented yet*
+         *********************************************/
 
-      /**************************
-      * PARSE NTP_REF_ID -      *
-      *payload [12][13][14][15].*
-      ***************************/
+        /**************************
+         * PARSE NTP_REF_ID -      *
+         *payload [12][13][14][15].*
+         ***************************/
 
-      /********************************
-      * First octect NTP reference ID.*
-      * *******************************/
-      ch_counter = 0;
-      number = (int) payload[12];
-      convert = std::to_string(number);
-      for (i = 0; i < convert.length(); i++) {
-         ntp_data_ext->reference_id[ch_counter] = convert[i];
-         ch_counter++;
-      }
-      ntp_data_ext->reference_id[ch_counter] = '.';
-      ch_counter++;
+        /********************************
+         * First octect NTP reference ID.*
+         * *******************************/
+        ch_counter = 0;
+        number = (int) payload[12];
+        convert = std::to_string(number);
+        for (i = 0; i < convert.length(); i++) {
+            ntp_data_ext->reference_id[ch_counter] = convert[i];
+            ch_counter++;
+        }
+        ntp_data_ext->reference_id[ch_counter] = '.';
+        ch_counter++;
 
-      /*********************************
-      * Second octect NTP reference ID.*
-      * ********************************/
-      number = (int) payload[13];
-      convert = std::to_string(number);
-      for (i = 0; i < convert.length(); i++) {
-         ntp_data_ext->reference_id[ch_counter] = convert[i];
-         ch_counter++;
-      }
-      ntp_data_ext->reference_id[ch_counter] = '.';
-      ch_counter++;
+        /*********************************
+         * Second octect NTP reference ID.*
+         * ********************************/
+        number = (int) payload[13];
+        convert = std::to_string(number);
+        for (i = 0; i < convert.length(); i++) {
+            ntp_data_ext->reference_id[ch_counter] = convert[i];
+            ch_counter++;
+        }
+        ntp_data_ext->reference_id[ch_counter] = '.';
+        ch_counter++;
 
-      /********************************
-      * Third octect NTP reference ID.*
-      * *******************************/
-      number = (int) payload[14];
-      convert = std::to_string(number);
-      for (i = 0; i < convert.length(); i++) {
-         ntp_data_ext->reference_id[ch_counter] = convert[i];
-         ch_counter++;
-      }
-      ntp_data_ext->reference_id[ch_counter] = '.';
-      ch_counter++;
+        /********************************
+         * Third octect NTP reference ID.*
+         * *******************************/
+        number = (int) payload[14];
+        convert = std::to_string(number);
+        for (i = 0; i < convert.length(); i++) {
+            ntp_data_ext->reference_id[ch_counter] = convert[i];
+            ch_counter++;
+        }
+        ntp_data_ext->reference_id[ch_counter] = '.';
+        ch_counter++;
 
-      /*********************************
-      * Fourth octect NTP reference ID.*
-      * ********************************/
-      number = (int) payload[15];
-      convert = std::to_string(number);
-      for (i = 0; i < convert.length(); i++) {
-         ntp_data_ext->reference_id[ch_counter] = convert[i];
-         ch_counter++;
-      }
-      ntp_data_ext->reference_id[ch_counter] = '\0';
-      if (ntp_data_ext->stratum == 0) {
-         if (strcmp (ntp_data_ext->reference_id, NTP_RefID_INIT) == 0) { strcpy (ntp_data_ext->reference_id, INIT); }
-         if (strcmp (ntp_data_ext->reference_id, NTP_RefID_STEP) == 0) { strcpy (ntp_data_ext->reference_id, STEP); }
-         if (strcmp (ntp_data_ext->reference_id, NTP_RefID_DENY) == 0) { strcpy (ntp_data_ext->reference_id, DENY); }
-         if (strcmp (ntp_data_ext->reference_id, NTP_RefID_RATE) == 0) { strcpy (ntp_data_ext->reference_id, RATE); }
-      }
-      DEBUG_MSG("\tntp reference id:\t\t%s\n", ntp_data_ext->reference_id);
+        /*********************************
+         * Fourth octect NTP reference ID.*
+         * ********************************/
+        number = (int) payload[15];
+        convert = std::to_string(number);
+        for (i = 0; i < convert.length(); i++) {
+            ntp_data_ext->reference_id[ch_counter] = convert[i];
+            ch_counter++;
+        }
+        ntp_data_ext->reference_id[ch_counter] = '\0';
+        if (ntp_data_ext->stratum == 0) {
+            if (strcmp(ntp_data_ext->reference_id, NTP_RefID_INIT) == 0) {
+                strcpy(ntp_data_ext->reference_id, INIT);
+            }
+            if (strcmp(ntp_data_ext->reference_id, NTP_RefID_STEP) == 0) {
+                strcpy(ntp_data_ext->reference_id, STEP);
+            }
+            if (strcmp(ntp_data_ext->reference_id, NTP_RefID_DENY) == 0) {
+                strcpy(ntp_data_ext->reference_id, DENY);
+            }
+            if (strcmp(ntp_data_ext->reference_id, NTP_RefID_RATE) == 0) {
+                strcpy(ntp_data_ext->reference_id, RATE);
+            }
+        }
+        DEBUG_MSG("\tntp reference id:\t\t%s\n", ntp_data_ext->reference_id);
 
-      /*****************************
-      * PARSE NTP_REF -            *
-      * payload:                   *
-      * SECONDS   [16][17][18][19] *
-      * FRACTIONS [20][21][22][23].*
-      * ****************************/
-      DEBUG_MSG("\tntp Reference Timestamp\n");
-      ch_counter = 0;
-      result = parse_timestamp(pkt, 16, 19, 20, 23);
-      for (i = 0; i < result.length(); i++) {
-         ntp_data_ext->reference[ch_counter] = result[i];
-         ch_counter++;
-      }
-      ntp_data_ext->reference[ch_counter] = '\0';
-      DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->reference);
+        /*****************************
+         * PARSE NTP_REF -            *
+         * payload:                   *
+         * SECONDS   [16][17][18][19] *
+         * FRACTIONS [20][21][22][23].*
+         * ****************************/
+        DEBUG_MSG("\tntp Reference Timestamp\n");
+        ch_counter = 0;
+        result = parse_timestamp(pkt, 16, 19, 20, 23);
+        for (i = 0; i < result.length(); i++) {
+            ntp_data_ext->reference[ch_counter] = result[i];
+            ch_counter++;
+        }
+        ntp_data_ext->reference[ch_counter] = '\0';
+        DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->reference);
 
-      /****************************
-      * PARSE NTP_ORIG -          *
-      *payload:                   *
-      *SECONDS   [24][25][26][27] *
-      *FRACTIONS [28][29][30][31].*
-      *****************************/
-      DEBUG_MSG("\tntp Origin Timestamp\n");
-      ch_counter = 0;
-      result = parse_timestamp(pkt, 24, 27, 28, 31);
-      for (i = 0; i < result.length(); i++){
-         ntp_data_ext->origin[ch_counter] = result[i];
-         ch_counter++;
-      }
-      ntp_data_ext->origin[ch_counter] = '\0';
-      DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->origin);
+        /****************************
+         * PARSE NTP_ORIG -          *
+         *payload:                   *
+         *SECONDS   [24][25][26][27] *
+         *FRACTIONS [28][29][30][31].*
+         *****************************/
+        DEBUG_MSG("\tntp Origin Timestamp\n");
+        ch_counter = 0;
+        result = parse_timestamp(pkt, 24, 27, 28, 31);
+        for (i = 0; i < result.length(); i++) {
+            ntp_data_ext->origin[ch_counter] = result[i];
+            ch_counter++;
+        }
+        ntp_data_ext->origin[ch_counter] = '\0';
+        DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->origin);
 
-      /****************************
-      * PARSE NTP_RECV -          *
-      *payload:                   *
-      *SECONDS   [32][33][34][35] *
-      *FRACTIONS [36][37][38][39].*
-      *****************************/
-      DEBUG_MSG("\tntp Receive Timestamp\n");
-      ch_counter = 0;
-      result = parse_timestamp(pkt, 32, 35, 36, 39);
-      for(i = 0; i < result.length(); i++) {
-         ntp_data_ext->receive[ch_counter] = result[i];
-         ch_counter++;
-      }
-      ntp_data_ext->receive[ch_counter] = '\0';
-      DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->receive);
+        /****************************
+         * PARSE NTP_RECV -          *
+         *payload:                   *
+         *SECONDS   [32][33][34][35] *
+         *FRACTIONS [36][37][38][39].*
+         *****************************/
+        DEBUG_MSG("\tntp Receive Timestamp\n");
+        ch_counter = 0;
+        result = parse_timestamp(pkt, 32, 35, 36, 39);
+        for (i = 0; i < result.length(); i++) {
+            ntp_data_ext->receive[ch_counter] = result[i];
+            ch_counter++;
+        }
+        ntp_data_ext->receive[ch_counter] = '\0';
+        DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->receive);
 
-      /****************************
-      * PARSE NTP_SENT -          *
-      *payload:                   *
-      *SECONDS   [40][41][42][43] *
-      *FRACTIONS [44][45][46][47].*
-      *****************************/
-      DEBUG_MSG("\tntp Transmit Timestamp\n");
-      ch_counter = 0;
-      result = parse_timestamp(pkt, 40, 43, 44, 47);
-      for (i = 0; i < result.length(); i++) {
-         ntp_data_ext->sent[ch_counter] = result[i];
-         ch_counter++;
-      }
-      ntp_data_ext->sent[ch_counter] = '\0';
-      DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->sent);
+        /****************************
+         * PARSE NTP_SENT -          *
+         *payload:                   *
+         *SECONDS   [40][41][42][43] *
+         *FRACTIONS [44][45][46][47].*
+         *****************************/
+        DEBUG_MSG("\tntp Transmit Timestamp\n");
+        ch_counter = 0;
+        result = parse_timestamp(pkt, 40, 43, 44, 47);
+        for (i = 0; i < result.length(); i++) {
+            ntp_data_ext->sent[ch_counter] = result[i];
+            ch_counter++;
+        }
+        ntp_data_ext->sent[ch_counter] = '\0';
+        DEBUG_MSG("\t\ttimestamp:\t\t%s\n", ntp_data_ext->sent);
 
-   } catch (const char *err) {
-      DEBUG_MSG("%s\n", err);
-      return false; /*Don't add extension to  paket.*/
-   }
+    } catch (const char* err) {
+        DEBUG_MSG("%s\n", err);
+        return false; /*Don't add extension to  paket.*/
+    }
 
-   return true; /*Add extension to  NTP packet*/
+    return true; /*Add extension to  NTP packet*/
 }
 
 /**
-*\brief Parse of Timestamp NTP packet.
-*\param [in] Packet.
-*\param [in] P1: Index of Payload where the First octect of the Seconds timestamp.
-*\param [in] P4: Index of Payload where the Fourth octect of the Seconds timestamp.
-*\param [in] P5: Index of Payload where the First octect of the Fraction timestamp starts.
-*\param [in] P8: Index of Payload where the Fourth octect of the Fraction timestamp starts.
-*\return String of timestamp.
-*/
-std::string NTPPlugin::parse_timestamp(const Packet &pkt, uint16_t p1, uint16_t p4, uint16_t p5, uint16_t p8)
+ *\brief Parse of Timestamp NTP packet.
+ *\param [in] Packet.
+ *\param [in] P1: Index of Payload where the First octect of the Seconds timestamp.
+ *\param [in] P4: Index of Payload where the Fourth octect of the Seconds timestamp.
+ *\param [in] P5: Index of Payload where the First octect of the Fraction timestamp starts.
+ *\param [in] P8: Index of Payload where the Fourth octect of the Fraction timestamp starts.
+ *\return String of timestamp.
+ */
+std::string
+NTPPlugin::parse_timestamp(const Packet& pkt, uint16_t p1, uint16_t p4, uint16_t p5, uint16_t p8)
 {
-   size_t i = 0, k = 0;
-   int number = 0;
-   const unsigned char *payload = nullptr;
-   std::string result = "", result2 = "";
-   std::string str;
-   std::string convert2;
-   std::string convert;
-   char hex_buf[3];
-   uint32_t time = 0;
-   uint32_t highestbit = 0x80000000;
-   double fract = 0.0f;
-   uint32_t tmp = 0;
-   double curfract = 0.5;
-   payload = (unsigned char *) pkt.payload;
+    size_t i = 0, k = 0;
+    int number = 0;
+    const unsigned char* payload = nullptr;
+    std::string result = "", result2 = "";
+    std::string str;
+    std::string convert2;
+    std::string convert;
+    char hex_buf[3];
+    uint32_t time = 0;
+    uint32_t highestbit = 0x80000000;
+    double fract = 0.0f;
+    uint32_t tmp = 0;
+    double curfract = 0.5;
+    payload = (unsigned char*) pkt.payload;
 
-      /* ********************
-      * SECONDS CALCULATION.*
-      * *********************/
-   result = "";
-   number = 0;
-   convert = "0";
-   for (i = p1; i <= p4; i++) {
-      number =  payload[i];
-      std::sprintf(hex_buf, "%x", number);
-      convert += hex_buf;
-   }
-   result = convert;
-   str = result;
-   const char *c = str.c_str();
-   time = strtoul(c, 0, 16);
-   convert2 = std::to_string(time);
-   DEBUG_MSG("\t\ttimestamp seconds:\t\t\t%u\n", time);
+    /* ********************
+     * SECONDS CALCULATION.*
+     * *********************/
+    result = "";
+    number = 0;
+    convert = "0";
+    for (i = p1; i <= p4; i++) {
+        number = payload[i];
+        std::sprintf(hex_buf, "%x", number);
+        convert += hex_buf;
+    }
+    result = convert;
+    str = result;
+    const char* c = str.c_str();
+    time = strtoul(c, 0, 16);
+    convert2 = std::to_string(time);
+    DEBUG_MSG("\t\ttimestamp seconds:\t\t\t%u\n", time);
 
-      /* *********************
-      * FRACTION CALCULATION.*
-      * **********************/
-   result = "";
-   convert2 += ".";
-   convert = "";
-   for (i = p5; i <= p8; i++) {
-      number = payload[i];
-      std::sprintf(hex_buf, "%x", number);
-      convert += hex_buf;
+    /* *********************
+     * FRACTION CALCULATION.*
+     * **********************/
+    result = "";
+    convert2 += ".";
+    convert = "";
+    for (i = p5; i <= p8; i++) {
+        number = payload[i];
+        std::sprintf(hex_buf, "%x", number);
+        convert += hex_buf;
+    }
+    result = convert;
+    str = result;
+    const char* c2 = str.c_str();
+    time = strtoul(c2, 0, 16);
+    tmp = time;
+    for (i = 1; i <= 32; i++) {
+        if ((highestbit & tmp) != 0) {
+            fract = fract + curfract;
+        }
+        curfract = curfract / 2;
+        tmp = tmp << 1;
+    }
+    DEBUG_MSG("\t\ttimestamp fraction:\t\t\t%f\n", fract);
+    convert2 += std::to_string(fract);
+    result2 = convert2;
 
-   }
-   result = convert;
-   str = result;
-   const char *c2 = str.c_str();
-   time = strtoul(c2, 0, 16);
-   tmp = time;
-   for (i = 1; i <= 32; i++) {
-      if ((highestbit & tmp) != 0) {
-         fract = fract + curfract;
-      }
-      curfract = curfract / 2;
-      tmp = tmp << 1;
-   }
-   DEBUG_MSG("\t\ttimestamp fraction:\t\t\t%f\n", fract);
-   convert2 += std::to_string(fract);
-   result2 = convert2;
-
-   for (i = 0; ; i++) {
-      if (result2[i] == '.') {
-         for (k = i + 2; k <= result2.length(); k++) { result2[k - 2] = result2[k]; }
-         break;
-      }
-   }
-   result2.resize(result2.length() - 1);
-   return result2;
+    for (i = 0;; i++) {
+        if (result2[i] == '.') {
+            for (k = i + 2; k <= result2.length(); k++) {
+                result2[k - 2] = result2[k];
+            }
+            break;
+        }
+    }
+    result2.resize(result2.length() - 1);
+    return result2;
 }
 
-}
+} // namespace ipxp

--- a/process/ntp.hpp
+++ b/process/ntp.hpp
@@ -33,36 +33,35 @@
 #include <iostream>
 #include <sstream>
 
-#ifdef WITH_NEMEA
 #include <fields.h>
-#endif
 
 #include <stdio.h>
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
-#define NTP_UNIREC_TEMPLATE  "NTP_LEAP,NTP_VERSION,NTP_MODE,NTP_STRATUM,NTP_POLL,NTP_PRECISION,NTP_DELAY,NTP_DISPERSION,NTP_REF_ID,NTP_REF,NTP_ORIG,NTP_RECV,NTP_SENT"
+#define NTP_UNIREC_TEMPLATE                                                                        \
+    "NTP_LEAP,NTP_VERSION,NTP_MODE,NTP_STRATUM,NTP_POLL,NTP_PRECISION,NTP_DELAY,NTP_DISPERSION,"   \
+    "NTP_REF_ID,NTP_REF,NTP_ORIG,NTP_RECV,NTP_SENT"
 
-UR_FIELDS (
-   uint8 NTP_LEAP,
-   uint8 NTP_VERSION
-   uint8 NTP_MODE,
-   uint8 NTP_STRATUM,
-   uint8 NTP_POLL,
-   uint8 NTP_PRECISION,
-   uint32 NTP_DELAY,
-   uint32 NTP_DISPERSION,
-   string NTP_REF_ID,
-   string NTP_REF,
-   string NTP_ORIG,
-   string NTP_RECV,
-   string NTP_SENT
-)
+UR_FIELDS(
+    uint8 NTP_LEAP,
+    uint8 NTP_VERSION,
+    uint8 NTP_MODE,
+    uint8 NTP_STRATUM,
+    uint8 NTP_POLL,
+    uint8 NTP_PRECISION,
+    uint32 NTP_DELAY,
+    uint32 NTP_DISPERSION,
+    string NTP_REF_ID,
+    string NTP_REF,
+    string NTP_ORIG,
+    string NTP_RECV,
+    string NTP_SENT)
 
 #define NTP_FIELD_IP 16
 #define NTP_FIELD_LEN64 30
@@ -81,182 +80,173 @@ const char OTHER[] = "OTHER"; /*OTHER Value of NTP reference ID*/
  *\brief Flow record extension header for storing NTP fields.
  */
 struct RecordExtNTP : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint8_t leap;
-   uint8_t version;
-   uint8_t mode;
-   uint8_t stratum;
-   uint8_t poll;
-   uint8_t precision;
-   uint32_t delay;
-   uint32_t dispersion;
-   char reference_id[NTP_FIELD_IP];
-   char reference[NTP_FIELD_LEN64];
-   char origin[NTP_FIELD_LEN64];
-   char receive[NTP_FIELD_LEN64];
-   char sent[NTP_FIELD_LEN64];
+    uint8_t leap;
+    uint8_t version;
+    uint8_t mode;
+    uint8_t stratum;
+    uint8_t poll;
+    uint8_t precision;
+    uint32_t delay;
+    uint32_t dispersion;
+    char reference_id[NTP_FIELD_IP];
+    char reference[NTP_FIELD_LEN64];
+    char origin[NTP_FIELD_LEN64];
+    char receive[NTP_FIELD_LEN64];
+    char sent[NTP_FIELD_LEN64];
 
-   /**
-         *\brief Constructor.
-   */
-   RecordExtNTP() : RecordExt(REGISTERED_ID)
-   {
-      leap = 9;
-      version = 9;
-      mode = 9;
-      stratum = 9;
-      poll = 9;
-      precision = 9;
-      delay = 9;
-      dispersion = 9;
-      reference_id[0] = 9;
-      reference[0] = 9;
-      origin[0] = 9;
-      receive[0] = 9;
-      sent[0] = 9;
-   }
+    /**
+     *\brief Constructor.
+     */
+    RecordExtNTP()
+        : RecordExt(REGISTERED_ID)
+    {
+        leap = 9;
+        version = 9;
+        mode = 9;
+        stratum = 9;
+        poll = 9;
+        precision = 9;
+        delay = 9;
+        dispersion = 9;
+        reference_id[0] = 9;
+        reference[0] = 9;
+        origin[0] = 9;
+        receive[0] = 9;
+        sent[0] = 9;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_NTP_LEAP, leap);
-      ur_set(tmplt, record, F_NTP_VERSION, version);
-      ur_set(tmplt, record, F_NTP_MODE, mode);
-      ur_set(tmplt, record, F_NTP_STRATUM, stratum);
-      ur_set(tmplt, record, F_NTP_POLL, poll);
-      ur_set(tmplt, record, F_NTP_PRECISION, precision);
-      ur_set(tmplt, record, F_NTP_DELAY, delay);
-      ur_set(tmplt, record, F_NTP_DISPERSION, dispersion);
-      ur_set_string(tmplt, record, F_NTP_REF_ID, reference_id);
-      ur_set_string(tmplt, record, F_NTP_REF, reference);
-      ur_set_string(tmplt, record, F_NTP_ORIG, origin);
-      ur_set_string(tmplt, record, F_NTP_RECV, receive);
-      ur_set_string(tmplt, record, F_NTP_SENT, sent);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_NTP_LEAP, leap);
+        ur_set(tmplt, record, F_NTP_VERSION, version);
+        ur_set(tmplt, record, F_NTP_MODE, mode);
+        ur_set(tmplt, record, F_NTP_STRATUM, stratum);
+        ur_set(tmplt, record, F_NTP_POLL, poll);
+        ur_set(tmplt, record, F_NTP_PRECISION, precision);
+        ur_set(tmplt, record, F_NTP_DELAY, delay);
+        ur_set(tmplt, record, F_NTP_DISPERSION, dispersion);
+        ur_set_string(tmplt, record, F_NTP_REF_ID, reference_id);
+        ur_set_string(tmplt, record, F_NTP_REF, reference);
+        ur_set_string(tmplt, record, F_NTP_ORIG, origin);
+        ur_set_string(tmplt, record, F_NTP_RECV, receive);
+        ur_set_string(tmplt, record, F_NTP_SENT, sent);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return NTP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return NTP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length, total_length = 14;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length, total_length = 14;
 
-      if (total_length > size) {
-         return -1;
-      }
-      *(uint8_t *) (buffer) = leap;
-      *(uint8_t *) (buffer + 1) = version;
-      *(uint8_t *) (buffer + 2) = mode;
-      *(uint8_t *) (buffer + 3) = stratum;
-      *(uint8_t *) (buffer + 4) = poll;
-      *(uint8_t *) (buffer + 5) = precision;
-      *(uint32_t *) (buffer + 6) = ntohl(delay);
-      *(uint32_t *) (buffer + 10) = ntohl(dispersion);
+        if (total_length > size) {
+            return -1;
+        }
+        *(uint8_t*) (buffer) = leap;
+        *(uint8_t*) (buffer + 1) = version;
+        *(uint8_t*) (buffer + 2) = mode;
+        *(uint8_t*) (buffer + 3) = stratum;
+        *(uint8_t*) (buffer + 4) = poll;
+        *(uint8_t*) (buffer + 5) = precision;
+        *(uint32_t*) (buffer + 6) = ntohl(delay);
+        *(uint32_t*) (buffer + 10) = ntohl(dispersion);
 
-      length = strlen(reference_id);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, reference_id, length);
-      total_length += length + 1;
+        length = strlen(reference_id);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, reference_id, length);
+        total_length += length + 1;
 
-      length = strlen(reference);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, reference, length);
-      total_length += length + 1;
+        length = strlen(reference);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, reference, length);
+        total_length += length + 1;
 
-      length = strlen(origin);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, origin, length);
-      total_length += length + 1;
+        length = strlen(origin);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, origin, length);
+        total_length += length + 1;
 
-      length = strlen(receive);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, receive, length);
-      total_length += length + 1;
+        length = strlen(receive);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, receive, length);
+        total_length += length + 1;
 
-      length = strlen(sent);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, sent, length);
-      total_length += length + 1;
+        length = strlen(sent);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, sent, length);
+        total_length += length + 1;
 
-      return total_length;
-   }
+        return total_length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_NTP_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_NTP_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "leap=" << (uint16_t) leap
-         << ",version=" << (uint16_t) version
-         << ",mode=" << (uint16_t) mode
-         << ",stratum=" << (uint16_t) stratum
-         << ",poll=" << (uint16_t) poll
-         << ",precision=" << (uint16_t) precision
-         << ",delay=" << delay
-         << ",dispersion=" << dispersion
-         << ",referenceid=\"" << reference_id << "\""
-         << ",reference=\"" << reference << "\""
-         << ",origin=\"" << origin << "\""
-         << ",receive=\"" << receive << "\""
-         << ",sent=\"" << sent << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "leap=" << (uint16_t) leap << ",version=" << (uint16_t) version
+            << ",mode=" << (uint16_t) mode << ",stratum=" << (uint16_t) stratum
+            << ",poll=" << (uint16_t) poll << ",precision=" << (uint16_t) precision
+            << ",delay=" << delay << ",dispersion=" << dispersion << ",referenceid=\""
+            << reference_id << "\""
+            << ",reference=\"" << reference << "\""
+            << ",origin=\"" << origin << "\""
+            << ",receive=\"" << receive << "\""
+            << ",sent=\"" << sent << "\"";
+        return out.str();
+    }
 };
 
 /**
  *\brief Flow cache plugin for parsing DNS packets.
  */
-class NTPPlugin : public ProcessPlugin
-{
+class NTPPlugin : public ProcessPlugin {
 public:
-   NTPPlugin();
-   ~NTPPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("ntp", "Parse NTP traffic"); }
-   std::string get_name() const { return "ntp"; }
-   RecordExt *get_ext() const { return new RecordExtNTP(); }
-   ProcessPlugin *copy();
+    NTPPlugin();
+    ~NTPPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("ntp", "Parse NTP traffic"); }
+    std::string get_name() const { return "ntp"; }
+    RecordExt* get_ext() const { return new RecordExtNTP(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   uint32_t requests;   /**< Total number of parsed NTP queries. */
-   uint32_t responses;  /**< Total number of parsed NTP responses. */
-   uint32_t total;      /**< Total number of parsed DNS packets. */
+    uint32_t requests; /**< Total number of parsed NTP queries. */
+    uint32_t responses; /**< Total number of parsed NTP responses. */
+    uint32_t total; /**< Total number of parsed DNS packets. */
 
-   bool parse_ntp(const Packet &pkt, RecordExtNTP *ntp_data_ext);
-   void add_ext_ntp(Flow &rec, const Packet &pkt);
-   std::string parse_timestamp(const Packet &pkt, uint16_t p1, uint16_t p4, uint16_t p5, uint16_t p8);
+    bool parse_ntp(const Packet& pkt, RecordExtNTP* ntp_data_ext);
+    void add_ext_ntp(Flow& rec, const Packet& pkt);
+    std::string
+    parse_timestamp(const Packet& pkt, uint16_t p1, uint16_t p4, uint16_t p5, uint16_t p8);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_NTP_HPP */

--- a/process/osquery.cpp
+++ b/process/osquery.cpp
@@ -27,11 +27,11 @@
  *
  */
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <cstring>
 #include <cstdio>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 #include "osquery.hpp"
 
@@ -43,372 +43,383 @@ int RecordExtOSQUERY::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("osquery", [](){return new OSQUERYPlugin();});
-   register_plugin(&rec);
-   RecordExtOSQUERY::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("osquery", []() { return new OSQUERYPlugin(); });
+    register_plugin(&rec);
+    RecordExtOSQUERY::REGISTERED_ID = register_extension();
 }
 
-OSQUERYPlugin::OSQUERYPlugin() : manager(nullptr), numberOfSuccessfullyRequests(0)
+OSQUERYPlugin::OSQUERYPlugin()
+    : manager(nullptr)
+    , numberOfSuccessfullyRequests(0)
 {
 }
 
-OSQUERYPlugin::OSQUERYPlugin(const OSQUERYPlugin &p)
+OSQUERYPlugin::OSQUERYPlugin(const OSQUERYPlugin& p)
 {
-   init(nullptr);
+    init(nullptr);
 }
 
 OSQUERYPlugin::~OSQUERYPlugin()
 {
-   close();
+    close();
 }
 
-void OSQUERYPlugin::init(const char *params)
+void OSQUERYPlugin::init(const char* params)
 {
-   manager = new OsqueryRequestManager();
-   manager->readInfoAboutOS();
+    manager = new OsqueryRequestManager();
+    manager->readInfoAboutOS();
 }
 
 void OSQUERYPlugin::close()
 {
-   if (manager != nullptr) {
-      delete manager;
-      manager = nullptr;
-   }
+    if (manager != nullptr) {
+        delete manager;
+        manager = nullptr;
+    }
 }
 
-ProcessPlugin *OSQUERYPlugin::copy()
+ProcessPlugin* OSQUERYPlugin::copy()
 {
-   return new OSQUERYPlugin(*this);
+    return new OSQUERYPlugin(*this);
 }
 
-int OSQUERYPlugin::post_create(Flow &rec, const Packet &pkt)
+int OSQUERYPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   ConvertedFlowData flowDataIPv4(rec.src_ip.v4, rec.dst_ip.v4, rec.src_port, rec.dst_port);
+    ConvertedFlowData flowDataIPv4(rec.src_ip.v4, rec.dst_ip.v4, rec.src_port, rec.dst_port);
 
-   if (manager->readInfoAboutProgram(flowDataIPv4)) {
-      RecordExtOSQUERY *record = new RecordExtOSQUERY(manager->getRecord());
-      rec.add_extension(record);
+    if (manager->readInfoAboutProgram(flowDataIPv4)) {
+        RecordExtOSQUERY* record = new RecordExtOSQUERY(manager->getRecord());
+        rec.add_extension(record);
 
-      numberOfSuccessfullyRequests++;
-   }
+        numberOfSuccessfullyRequests++;
+    }
 
-   return 0;
+    return 0;
 }
 
 void OSQUERYPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "OSQUERY plugin stats:" << std::endl;
-      std::cout << "Number of successfully processed requests: " << numberOfSuccessfullyRequests << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "OSQUERY plugin stats:" << std::endl;
+        std::cout << "Number of successfully processed requests: " << numberOfSuccessfullyRequests
+                  << std::endl;
+    }
 }
 
-ConvertedFlowData::ConvertedFlowData(uint32_t sourceIPv4, uint32_t destinationIPv4, uint16_t sourcePort,
-  uint16_t destinationPort)
+ConvertedFlowData::ConvertedFlowData(
+    uint32_t sourceIPv4,
+    uint32_t destinationIPv4,
+    uint16_t sourcePort,
+    uint16_t destinationPort)
 {
-   convertIPv4(sourceIPv4, true);
-   convertIPv4(destinationIPv4, false);
-   convertPort(sourcePort, true);
-   convertPort(destinationPort, false);
+    convertIPv4(sourceIPv4, true);
+    convertIPv4(destinationIPv4, false);
+    convertPort(sourcePort, true);
+    convertPort(destinationPort, false);
 }
 
-ConvertedFlowData::ConvertedFlowData(const uint8_t *sourceIPv6, const uint8_t *destinationIPv6, uint16_t sourcePort,
-  uint16_t destinationPort)
+ConvertedFlowData::ConvertedFlowData(
+    const uint8_t* sourceIPv6,
+    const uint8_t* destinationIPv6,
+    uint16_t sourcePort,
+    uint16_t destinationPort)
 {
-   convertIPv6(sourceIPv6, true);
-   convertIPv6(destinationIPv6, false);
-   convertPort(sourcePort, true);
-   convertPort(destinationPort, false);
+    convertIPv6(sourceIPv6, true);
+    convertIPv6(destinationIPv6, false);
+    convertPort(sourcePort, true);
+    convertPort(destinationPort, false);
 }
 
 void ConvertedFlowData::convertIPv4(uint32_t addr, bool isSourceIP)
 {
-   std::stringstream ss;
+    std::stringstream ss;
 
-   ss << ((addr) & 0x000000ff) << "."
-      << ((addr >> 8) & 0x000000ff) << "."
-      << ((addr >> 16) & 0x000000ff) << "."
-      << ((addr >> 24) & 0x000000ff);
+    ss << ((addr) &0x000000ff) << "." << ((addr >> 8) & 0x000000ff) << "."
+       << ((addr >> 16) & 0x000000ff) << "." << ((addr >> 24) & 0x000000ff);
 
-   if (isSourceIP) {
-      this->src_ip = ss.str();
-   } else {
-      this->dst_ip = ss.str();
-   }
+    if (isSourceIP) {
+        this->src_ip = ss.str();
+    } else {
+        this->dst_ip = ss.str();
+    }
 }
 
-void ConvertedFlowData::convertIPv6(const uint8_t *addr, bool isSourceIP)
+void ConvertedFlowData::convertIPv6(const uint8_t* addr, bool isSourceIP)
 {
-   std::stringstream ss;
+    std::stringstream ss;
 
-   ss << HEX(addr[0]);
-   for (int i = 1; i < 16; i++) {
-      ss << ":" << HEX(addr[i]);
-   }
+    ss << HEX(addr[0]);
+    for (int i = 1; i < 16; i++) {
+        ss << ":" << HEX(addr[i]);
+    }
 
-   if (isSourceIP) {
-      this->src_ip = ss.str();
-   } else {
-      this->dst_ip = ss.str();
-   }
+    if (isSourceIP) {
+        this->src_ip = ss.str();
+    } else {
+        this->dst_ip = ss.str();
+    }
 }
 
 void ConvertedFlowData::convertPort(uint16_t port, bool isSourcePort)
 {
-   std::stringstream ss;
+    std::stringstream ss;
 
-   ss << port;
+    ss << port;
 
-   if (isSourcePort) {
-      this->src_port = ss.str();
-   } else {
-      this->dst_port = ss.str();
-   }
+    if (isSourcePort) {
+        this->src_port = ss.str();
+    } else {
+        this->dst_port = ss.str();
+    }
 }
 
-OsqueryRequestManager::OsqueryRequestManager() :
-   inputFD(0),
-   outputFD(0),
-   buffer(nullptr),
-   pfd(nullptr),
-   recOsquery(nullptr),
-   isFDOpened(false),
-   numberOfAttempts(0),
-   osqueryProcessId(-1)
+OsqueryRequestManager::OsqueryRequestManager()
+    : inputFD(0)
+    , outputFD(0)
+    , buffer(nullptr)
+    , pfd(nullptr)
+    , recOsquery(nullptr)
+    , isFDOpened(false)
+    , numberOfAttempts(0)
+    , osqueryProcessId(-1)
 {
-   buffer = new char [BUFFER_SIZE];
+    buffer = new char[BUFFER_SIZE];
 
-   pfd         = new pollfd;
-   pfd->events = POLLIN;
+    pfd = new pollfd;
+    pfd->events = POLLIN;
 
-   recOsquery = new RecordExtOSQUERY();
+    recOsquery = new RecordExtOSQUERY();
 
-   while (true) {
-      openOsqueryFD();
-      if (handler.isFatalError()) {
-         break;
-      } else if (handler.isOpenFDError()) {
-         continue;
-      } else {
-         break;
-      }
-   }
+    while (true) {
+        openOsqueryFD();
+        if (handler.isFatalError()) {
+            break;
+        } else if (handler.isOpenFDError()) {
+            continue;
+        } else {
+            break;
+        }
+    }
 }
 
 OsqueryRequestManager::~OsqueryRequestManager()
 {
-   delete[] buffer;
-   delete pfd;
-   delete recOsquery;
-   closeOsqueryFD();
+    delete[] buffer;
+    delete pfd;
+    delete recOsquery;
+    closeOsqueryFD();
 }
 
 void OsqueryRequestManager::readInfoAboutOS()
 {
-   const std::string query =
-     "SELECT ov.name, ov.major, ov.minor, ov.build, ov.platform, ov.platform_like, ov.arch, ki.version, si.hostname FROM os_version AS ov, kernel_info AS ki, system_info AS si;\r\n";
+    const std::string query
+        = "SELECT ov.name, ov.major, ov.minor, ov.build, ov.platform, ov.platform_like, ov.arch, "
+          "ki.version, si.hostname FROM os_version AS ov, kernel_info AS ki, system_info AS "
+          "si;\r\n";
 
-   if (executeQuery(query) > 0) {
-      parseJsonOSVersion();
-   }
+    if (executeQuery(query) > 0) {
+        parseJsonOSVersion();
+    }
 }
 
-bool OsqueryRequestManager::readInfoAboutProgram(const ConvertedFlowData &flowData)
+bool OsqueryRequestManager::readInfoAboutProgram(const ConvertedFlowData& flowData)
 {
-   if (handler.isFatalError()) {
-      return false;
-   }
+    if (handler.isFatalError()) {
+        return false;
+    }
 
-   recOsquery->program_name = DEFAULT_FILL_TEXT;
-   recOsquery->username     = DEFAULT_FILL_TEXT;
+    recOsquery->program_name = DEFAULT_FILL_TEXT;
+    recOsquery->username = DEFAULT_FILL_TEXT;
 
-   std::string pid;
+    std::string pid;
 
-   if (!getPID(pid, flowData)) {
-      return false;
-   }
+    if (!getPID(pid, flowData)) {
+        return false;
+    }
 
-   std::string query = "SELECT p.name, u.username FROM processes AS p INNER JOIN users AS u ON p.uid=u.uid "
-     "WHERE p.pid='" + pid + "';\r\n";
+    std::string query
+        = "SELECT p.name, u.username FROM processes AS p INNER JOIN users AS u ON p.uid=u.uid "
+          "WHERE p.pid='"
+        + pid + "';\r\n";
 
-   if (executeQuery(query) > 0) {
-      if (parseJsonAboutProgram()) {
-         return true;
-      }
-   }
-   return false;
+    if (executeQuery(query) > 0) {
+        if (parseJsonAboutProgram()) {
+            return true;
+        }
+    }
+    return false;
 }
 
-size_t OsqueryRequestManager::executeQuery(const std::string &query, bool reopenFD)
+size_t OsqueryRequestManager::executeQuery(const std::string& query, bool reopenFD)
 {
-   if (reopenFD) {
-      openOsqueryFD();
-   }
+    if (reopenFD) {
+        openOsqueryFD();
+    }
 
-   if (handler.isFatalError()) {
-      return 0;
-   }
+    if (handler.isFatalError()) {
+        return 0;
+    }
 
-   if (handler.isOpenFDError()) {
-      return executeQuery(query, true);
-   }
+    if (handler.isOpenFDError()) {
+        return executeQuery(query, true);
+    }
 
-   handler.refresh();
+    handler.refresh();
 
-   if (!writeToOsquery(query.c_str())) {
-      return executeQuery(query, true);
-   }
+    if (!writeToOsquery(query.c_str())) {
+        return executeQuery(query, true);
+    }
 
-   size_t ret = readFromOsquery();
+    size_t ret = readFromOsquery();
 
-   if (handler.isReadError()) {
-      return executeQuery(query, true);
-   }
+    if (handler.isReadError()) {
+        return executeQuery(query, true);
+    }
 
-   if (handler.isReadSuccess()) {
-      numberOfAttempts = 0;
-      return ret;
-   }
+    if (handler.isReadSuccess()) {
+        numberOfAttempts = 0;
+        return ret;
+    }
 
-   return 0;
+    return 0;
 }
 
-bool OsqueryRequestManager::writeToOsquery(const char *query)
+bool OsqueryRequestManager::writeToOsquery(const char* query)
 {
-   // If expression is true, a logical error has occurred.
-   // There should be no logged errors when executing this method
-   if (handler.isErrorState()) {
-      handler.setFatalError();
-      return false;
-   }
+    // If expression is true, a logical error has occurred.
+    // There should be no logged errors when executing this method
+    if (handler.isErrorState()) {
+        handler.setFatalError();
+        return false;
+    }
 
-   ssize_t length = strlen(query);
-   ssize_t n      = write(inputFD, query, length);
+    ssize_t length = strlen(query);
+    ssize_t n = write(inputFD, query, length);
 
-   return (n != -1 && n == length);
+    return (n != -1 && n == length);
 }
 
 size_t OsqueryRequestManager::readFromOsquery()
 {
-   // If expression is true, a logical error has occurred.
-   // There should be no logged errors when executing this method
-   if (handler.isErrorState()) {
-      handler.setFatalError();
-      return 0;
-   }
+    // If expression is true, a logical error has occurred.
+    // There should be no logged errors when executing this method
+    if (handler.isErrorState()) {
+        handler.setFatalError();
+        return 0;
+    }
 
-   clearBuffer();
-   pfd->revents = 0;
+    clearBuffer();
+    pfd->revents = 0;
 
-   int ret = poll(pfd, 1, POLL_TIMEOUT);
+    int ret = poll(pfd, 1, POLL_TIMEOUT);
 
-   // ret == -1 -> poll error.
-   // ret == 0 -> poll timeout (osquery in json mode always returns at least empty json string("[\n\n]\n"),
-   // if no response has been received, this is considered an error).
-   if (ret == -1 || ret == 0) {
-      handler.setReadError();
-      return 0;
-   }
+    // ret == -1 -> poll error.
+    // ret == 0 -> poll timeout (osquery in json mode always returns at least empty json
+    // string("[\n\n]\n"), if no response has been received, this is considered an error).
+    if (ret == -1 || ret == 0) {
+        handler.setReadError();
+        return 0;
+    }
 
-   if (pfd->revents & POLLIN) {
-      size_t bytesRead = 0;
-      while (true) {
-         if (bytesRead + READ_SIZE < BUFFER_SIZE) {
-            ssize_t n = read(outputFD, buffer + bytesRead, READ_SIZE);
+    if (pfd->revents & POLLIN) {
+        size_t bytesRead = 0;
+        while (true) {
+            if (bytesRead + READ_SIZE < BUFFER_SIZE) {
+                ssize_t n = read(outputFD, buffer + bytesRead, READ_SIZE);
 
-            // read error
-            if (n < 0) {
-               handler.setReadError();
-               return 0;
+                // read error
+                if (n < 0) {
+                    handler.setReadError();
+                    return 0;
+                }
+
+                bytesRead += n;
+
+                // Error: less than 5 bytes were read
+                if (bytesRead < 5) {
+                    clearBuffer();
+                    handler.setReadError();
+                    return 0;
+                }
+
+                if (n < READ_SIZE || buffer[bytesRead - 2] == ']') {
+                    buffer[bytesRead] = 0;
+                    handler.setReadSuccess();
+                    return bytesRead;
+                }
+            } else {
+                ssize_t n = read(outputFD, buffer, READ_SIZE);
+
+                // read error
+                if (n < 0) {
+                    handler.setReadError();
+                    return 0;
+                }
+
+                if (n < READ_SIZE || buffer[n - 2] == ']') {
+                    clearBuffer();
+                    handler.setReadSuccess();
+                    return 0;
+                }
             }
-
-            bytesRead += n;
-
-            // Error: less than 5 bytes were read
-            if (bytesRead < 5) {
-               clearBuffer();
-               handler.setReadError();
-               return 0;
-            }
-
-            if (n < READ_SIZE || buffer[bytesRead - 2] == ']') {
-               buffer[bytesRead] = 0;
-               handler.setReadSuccess();
-               return bytesRead;
-            }
-         } else {
-            ssize_t n = read(outputFD, buffer, READ_SIZE);
-
-            // read error
-            if (n < 0) {
-               handler.setReadError();
-               return 0;
-            }
-
-            if (n < READ_SIZE || buffer[n - 2] == ']') {
-               clearBuffer();
-               handler.setReadSuccess();
-               return 0;
-            }
-         }
-      }
-   }
-   handler.setReadError();
-   return 0;
+        }
+    }
+    handler.setReadError();
+    return 0;
 } // OsqueryRequestManager::readFromOsquery
 
 void OsqueryRequestManager::openOsqueryFD()
 {
-   if (handler.isFatalError()) {
-      return;
-   }
+    if (handler.isFatalError()) {
+        return;
+    }
 
-   // All attempts have been exhausted
-   if (numberOfAttempts >= MAX_NUMBER_OF_ATTEMPTS) {
-      handler.setFatalError();
-      return;
-   }
+    // All attempts have been exhausted
+    if (numberOfAttempts >= MAX_NUMBER_OF_ATTEMPTS) {
+        handler.setFatalError();
+        return;
+    }
 
-   closeOsqueryFD();
-   killPreviousProcesses();
-   handler.reset();
-   numberOfAttempts++;
+    closeOsqueryFD();
+    killPreviousProcesses();
+    handler.reset();
+    numberOfAttempts++;
 
-   osqueryProcessId = popen2("osqueryi --json 2>/dev/null", &inputFD, &outputFD);
+    osqueryProcessId = popen2("osqueryi --json 2>/dev/null", &inputFD, &outputFD);
 
-   if (osqueryProcessId <= 0) {
-      handler.setOpenFDError();
-      return;
-   } else {
-      isFDOpened = true;
-      pfd->fd    = outputFD;
-      return;
-   }
+    if (osqueryProcessId <= 0) {
+        handler.setOpenFDError();
+        return;
+    } else {
+        isFDOpened = true;
+        pfd->fd = outputFD;
+        return;
+    }
 }
 
 void OsqueryRequestManager::closeOsqueryFD()
 {
-   if (isFDOpened) {
-      close(inputFD);
-      close(outputFD);
-      isFDOpened = false;
-   }
+    if (isFDOpened) {
+        close(inputFD);
+        close(outputFD);
+        isFDOpened = false;
+    }
 }
 
 void OsqueryRequestManager::killPreviousProcesses(bool useWhonangOption) const
 {
-   if (useWhonangOption) {
-      waitpid(-1, nullptr, WNOHANG);
-   } else {
-      if (osqueryProcessId > 0) {
-         waitpid(osqueryProcessId, nullptr, 0);
-      }
-   }
+    if (useWhonangOption) {
+        waitpid(-1, nullptr, WNOHANG);
+    } else {
+        if (osqueryProcessId > 0) {
+            waitpid(osqueryProcessId, nullptr, 0);
+        }
+    }
 }
 
-bool OsqueryRequestManager::getPID(std::string &pid, const ConvertedFlowData &flowData)
+bool OsqueryRequestManager::getPID(std::string& pid, const ConvertedFlowData& flowData)
 {
-   std::string query = "SELECT pid FROM process_open_sockets WHERE "
+    std::string query = "SELECT pid FROM process_open_sockets WHERE "
      "(local_address='" + flowData.src_ip + "' AND "
      "remote_address='" + flowData.dst_ip + "' AND "
      "local_port='" + flowData.src_port + "' AND "
@@ -418,220 +429,222 @@ bool OsqueryRequestManager::getPID(std::string &pid, const ConvertedFlowData &fl
      "local_port='" + flowData.dst_port + "' AND "
      "remote_port='" + flowData.src_port + "') LIMIT 1;\r\n";
 
-   if (executeQuery(query) > 0) {
-      if (parseJsonSingleItem("pid", pid)) {
-         return true;
-      }
-   }
+    if (executeQuery(query) > 0) {
+        if (parseJsonSingleItem("pid", pid)) {
+            return true;
+        }
+    }
 
-   return false;
+    return false;
 }
 
-bool OsqueryRequestManager::parseJsonSingleItem(const std::string &singleKey, std::string &singleValue)
+bool OsqueryRequestManager::parseJsonSingleItem(
+    const std::string& singleKey,
+    std::string& singleValue)
 {
-   int pos = getPositionForParseJson();
+    int pos = getPositionForParseJson();
 
-   if (pos == -1) {
-      return false;
-   }
+    if (pos == -1) {
+        return false;
+    }
 
-   int count = 0;
-   std::string key, value;
-   while (true) {
-      key.clear();
-      value.clear();
-      pos = parseJsonItem(pos, key, value);
-      if (pos < 0) {
-         return false;
-      }
-      if (pos == 0) {
-         return count == 1;
-      }
+    int count = 0;
+    std::string key, value;
+    while (true) {
+        key.clear();
+        value.clear();
+        pos = parseJsonItem(pos, key, value);
+        if (pos < 0) {
+            return false;
+        }
+        if (pos == 0) {
+            return count == 1;
+        }
 
-      if (key == singleKey) {
-         singleValue = value;
-         count++;
-      } else {
-         return false;
-      }
-   }
+        if (key == singleKey) {
+            singleValue = value;
+            count++;
+        } else {
+            return false;
+        }
+    }
 }
 
 bool OsqueryRequestManager::parseJsonOSVersion()
 {
-   int pos = getPositionForParseJson();
+    int pos = getPositionForParseJson();
 
-   if (pos == -1) {
-      return false;
-   }
+    if (pos == -1) {
+        return false;
+    }
 
-   int count = 0;
-   std::string key, value;
+    int count = 0;
+    std::string key, value;
 
-   while (true) {
-      key.clear();
-      value.clear();
-      pos = parseJsonItem(pos, key, value);
-      if (pos < 0) {
-         return false;
-      }
-      if (pos == 0) {
-         return count == 9;
-      }
-      if (key == "arch") {
-         recOsquery->os_arch = std::string(value);
-         count++;
-      } else if (key == "build") {
-         recOsquery->os_build = value;
-         count++;
-      } else if (key == "hostname") {
-         recOsquery->system_hostname = value;
-         count++;
-      } else if (key == "major") {
-         recOsquery->os_major = atoi(value.c_str());
-         count++;
-      } else if (key == "minor") {
-         recOsquery->os_minor = atoi(value.c_str());
-         count++;
-      } else if (key == "name") {
-         recOsquery->os_name = value;
-         count++;
-      } else if (key == "platform") {
-         recOsquery->os_platform = value;
-         count++;
-      } else if (key == "platform_like") {
-         recOsquery->os_platform_like = value;
-         count++;
-      } else if (key == "version") {
-         recOsquery->kernel_version = value;
-         count++;
-      } else {
-         return false;
-      }
-   }
+    while (true) {
+        key.clear();
+        value.clear();
+        pos = parseJsonItem(pos, key, value);
+        if (pos < 0) {
+            return false;
+        }
+        if (pos == 0) {
+            return count == 9;
+        }
+        if (key == "arch") {
+            recOsquery->os_arch = std::string(value);
+            count++;
+        } else if (key == "build") {
+            recOsquery->os_build = value;
+            count++;
+        } else if (key == "hostname") {
+            recOsquery->system_hostname = value;
+            count++;
+        } else if (key == "major") {
+            recOsquery->os_major = atoi(value.c_str());
+            count++;
+        } else if (key == "minor") {
+            recOsquery->os_minor = atoi(value.c_str());
+            count++;
+        } else if (key == "name") {
+            recOsquery->os_name = value;
+            count++;
+        } else if (key == "platform") {
+            recOsquery->os_platform = value;
+            count++;
+        } else if (key == "platform_like") {
+            recOsquery->os_platform_like = value;
+            count++;
+        } else if (key == "version") {
+            recOsquery->kernel_version = value;
+            count++;
+        } else {
+            return false;
+        }
+    }
 } // OsqueryRequestManager::parseJsonOSVersion
 
 bool OsqueryRequestManager::parseJsonAboutProgram()
 {
-   int pos = getPositionForParseJson();
+    int pos = getPositionForParseJson();
 
-   if (pos == -1) {
-      return false;
-   }
+    if (pos == -1) {
+        return false;
+    }
 
-   int count = 0;
-   std::string key, value;
+    int count = 0;
+    std::string key, value;
 
-   while (true) {
-      key.clear();
-      value.clear();
-      pos = parseJsonItem(pos, key, value);
-      if (pos < 0) {
-         return false;
-      }
-      if (pos == 0) {
-         return count == 2;
-      }
+    while (true) {
+        key.clear();
+        value.clear();
+        pos = parseJsonItem(pos, key, value);
+        if (pos < 0) {
+            return false;
+        }
+        if (pos == 0) {
+            return count == 2;
+        }
 
-      if (key == "name") {
-         recOsquery->program_name = value;
-         count++;
-      } else if (key == "username") {
-         recOsquery->username = value;
-         count++;
-      } else {
-         return false;
-      }
-   }
+        if (key == "name") {
+            recOsquery->program_name = value;
+            count++;
+        } else if (key == "username") {
+            recOsquery->username = value;
+            count++;
+        } else {
+            return false;
+        }
+    }
 }
 
-int OsqueryRequestManager::parseJsonItem(int from, std::string &key, std::string &value)
+int OsqueryRequestManager::parseJsonItem(int from, std::string& key, std::string& value)
 {
-   int pos = parseString(from, key);
+    int pos = parseString(from, key);
 
-   if (pos < 0) {
-      return -1;
-   }
-   if (pos == 0) {
-      return 0;
-   }
-   if (buffer[pos] != ':') {
-      return -1;
-   }
+    if (pos < 0) {
+        return -1;
+    }
+    if (pos == 0) {
+        return 0;
+    }
+    if (buffer[pos] != ':') {
+        return -1;
+    }
 
-   pos = parseString(pos, value);
-   if (pos <= 0) {
-      return -1;
-   }
-   return pos;
+    pos = parseString(pos, value);
+    if (pos <= 0) {
+        return -1;
+    }
+    return pos;
 }
 
-int OsqueryRequestManager::parseString(int from, std::string &str)
+int OsqueryRequestManager::parseString(int from, std::string& str)
 {
-   int pos         = from;
-   bool findQuotes = false;
-   char c;
+    int pos = from;
+    bool findQuotes = false;
+    char c;
 
-   while (true) {
-      c = buffer[pos];
-      pos++;
-      if (c == 0) {
-         return -1;
-      } else if (c == '}') {
-         return 0;
-      } else if (c == '\"') {
-         if (!findQuotes) {
-            findQuotes = true;
-         } else {
-            break;
-         }
-      } else if (findQuotes) {
-         str += c;
-      }
-   }
-   return pos;
+    while (true) {
+        c = buffer[pos];
+        pos++;
+        if (c == 0) {
+            return -1;
+        } else if (c == '}') {
+            return 0;
+        } else if (c == '\"') {
+            if (!findQuotes) {
+                findQuotes = true;
+            } else {
+                break;
+            }
+        } else if (findQuotes) {
+            str += c;
+        }
+    }
+    return pos;
 }
 
-pid_t OsqueryRequestManager::popen2(const char *command, int *inFD, int *outFD) const
+pid_t OsqueryRequestManager::popen2(const char* command, int* inFD, int* outFD) const
 {
-   int p_stdin[2], p_stdout[2];
-   pid_t pid;
+    int p_stdin[2], p_stdout[2];
+    pid_t pid;
 
-   if (pipe(p_stdin) != 0 || pipe(p_stdout) != 0) {
-      return -1;
-   }
+    if (pipe(p_stdin) != 0 || pipe(p_stdout) != 0) {
+        return -1;
+    }
 
-   pid = fork();
+    pid = fork();
 
-   if (pid < 0) {
-      return pid;
-   } else if (pid == 0) {
-      close(p_stdin[WRITE_FD]);
-      dup2(p_stdin[READ_FD], READ_FD);
-      close(p_stdout[READ_FD]);
-      dup2(p_stdout[WRITE_FD], WRITE_FD);
-      execl("/bin/sh", "sh", "-c", command, nullptr);
-      perror("execl");
-      exit(1);
-   }
+    if (pid < 0) {
+        return pid;
+    } else if (pid == 0) {
+        close(p_stdin[WRITE_FD]);
+        dup2(p_stdin[READ_FD], READ_FD);
+        close(p_stdout[READ_FD]);
+        dup2(p_stdout[WRITE_FD], WRITE_FD);
+        execl("/bin/sh", "sh", "-c", command, nullptr);
+        perror("execl");
+        exit(1);
+    }
 
-   inFD == nullptr ? close(p_stdin[WRITE_FD]) : *inFD   = p_stdin[WRITE_FD];
-   outFD == nullptr ? close(p_stdout[READ_FD]) : *outFD = p_stdout[READ_FD];
+    inFD == nullptr ? close(p_stdin[WRITE_FD]) : * inFD = p_stdin[WRITE_FD];
+    outFD == nullptr ? close(p_stdout[READ_FD]) : * outFD = p_stdout[READ_FD];
 
-   return pid;
+    return pid;
 }
 
 int OsqueryRequestManager::getPositionForParseJson()
 {
-   int position = 0;
+    int position = 0;
 
-   while (buffer[position] != 0) {
-      if (buffer[position] == '[') {
-         return position + 1;
-      }
-      position++;
-   }
-   return -1;
+    while (buffer[position] != 0) {
+        if (buffer[position] == '[') {
+            return position + 1;
+        }
+        position++;
+    }
+    return -1;
 }
 
-}
+} // namespace ipxp

--- a/process/osquery.hpp
+++ b/process/osquery.hpp
@@ -30,53 +30,54 @@
 #ifndef IPXP_PROCESS_OSQUERY_HPP
 #define IPXP_PROCESS_OSQUERY_HPP
 
-#include <string>
-#include <sstream>
 #include <poll.h>
-#include <unistd.h>
+#include <sstream>
+#include <string>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 #define DEFAULT_FILL_TEXT "UNDEFINED"
 
 // OsqueryStateHandler
-#define FATAL_ERROR   0b00000001 // 1;  Fatal error, cannot be fixed
+#define FATAL_ERROR 0b00000001 // 1;  Fatal error, cannot be fixed
 #define OPEN_FD_ERROR 0b00000010 // 2;  Failed to open osquery FD
-#define READ_ERROR    0b00000100 // 4;  Error while reading
-#define READ_SUCCESS  0b00001000 // 8;  Data read successfully
+#define READ_ERROR 0b00000100 // 4;  Error while reading
+#define READ_SUCCESS 0b00001000 // 8;  Data read successfully
 
 // OsqueryRequestManager
-#define BUFFER_SIZE            1024 * 20 + 1
-#define READ_SIZE              1024
-#define POLL_TIMEOUT           200 // millis
-#define READ_FD                0
-#define WRITE_FD               1
+#define BUFFER_SIZE 1024 * 20 + 1
+#define READ_SIZE 1024
+#define POLL_TIMEOUT 200 // millis
+#define READ_FD 0
+#define WRITE_FD 1
 #define MAX_NUMBER_OF_ATTEMPTS 2 // Max number of osquery error correction attempts
 
-#define OSQUERY_UNIREC_TEMPLATE \
-   "OSQUERY_PROGRAM_NAME,OSQUERY_USERNAME,OSQUERY_OS_NAME,OSQUERY_OS_MAJOR,OSQUERY_OS_MINOR,OSQUERY_OS_BUILD,OSQUERY_OS_PLATFORM,OSQUERY_OS_PLATFORM_LIKE,OSQUERY_OS_ARCH,OSQUERY_KERNEL_VERSION,OSQUERY_SYSTEM_HOSTNAME"
+#define OSQUERY_UNIREC_TEMPLATE                                                                    \
+    "OSQUERY_PROGRAM_NAME,OSQUERY_USERNAME,OSQUERY_OS_NAME,OSQUERY_OS_MAJOR,OSQUERY_OS_MINOR,"     \
+    "OSQUERY_OS_BUILD,OSQUERY_OS_PLATFORM,OSQUERY_OS_PLATFORM_LIKE,OSQUERY_OS_ARCH,OSQUERY_"       \
+    "KERNEL_VERSION,OSQUERY_SYSTEM_HOSTNAME"
 
 UR_FIELDS(
-   string OSQUERY_PROGRAM_NAME,
-   string OSQUERY_USERNAME,
-   string OSQUERY_OS_NAME,
-   uint16 OSQUERY_OS_MAJOR,
-   uint16 OSQUERY_OS_MINOR,
-   string OSQUERY_OS_BUILD,
-   string OSQUERY_OS_PLATFORM,
-   string OSQUERY_OS_PLATFORM_LIKE,
-   string OSQUERY_OS_ARCH,
-   string OSQUERY_KERNEL_VERSION,
-   string OSQUERY_SYSTEM_HOSTNAME
-)
+    string OSQUERY_PROGRAM_NAME,
+    string OSQUERY_USERNAME,
+    string OSQUERY_OS_NAME,
+    uint16 OSQUERY_OS_MAJOR,
+    uint16 OSQUERY_OS_MINOR,
+    string OSQUERY_OS_BUILD,
+    string OSQUERY_OS_PLATFORM,
+    string OSQUERY_OS_PLATFORM_LIKE,
+    string OSQUERY_OS_ARCH,
+    string OSQUERY_KERNEL_VERSION,
+    string OSQUERY_SYSTEM_HOSTNAME)
 
 namespace ipxp {
 
@@ -84,461 +85,471 @@ namespace ipxp {
  * \brief Flow record extension header for storing parsed OSQUERY packets.
  */
 struct RecordExtOSQUERY : public RecordExt {
-   static int REGISTERED_ID;
-   std::string   program_name;
-   std::string   username;
-   std::string   os_name;
-   uint16_t os_major;
-   uint16_t os_minor;
-   std::string   os_build;
-   std::string   os_platform;
-   std::string   os_platform_like;
-   std::string   os_arch;
-   std::string   kernel_version;
-   std::string   system_hostname;
+    static int REGISTERED_ID;
+    std::string program_name;
+    std::string username;
+    std::string os_name;
+    uint16_t os_major;
+    uint16_t os_minor;
+    std::string os_build;
+    std::string os_platform;
+    std::string os_platform_like;
+    std::string os_arch;
+    std::string kernel_version;
+    std::string system_hostname;
 
+    RecordExtOSQUERY()
+        : RecordExt(REGISTERED_ID)
+    {
+        program_name = DEFAULT_FILL_TEXT;
+        username = DEFAULT_FILL_TEXT;
+        os_name = DEFAULT_FILL_TEXT;
+        os_major = 0;
+        os_minor = 0;
+        os_build = DEFAULT_FILL_TEXT;
+        os_platform = DEFAULT_FILL_TEXT;
+        os_platform_like = DEFAULT_FILL_TEXT;
+        os_arch = DEFAULT_FILL_TEXT;
+        kernel_version = DEFAULT_FILL_TEXT;
+        system_hostname = DEFAULT_FILL_TEXT;
+    }
 
-   RecordExtOSQUERY() : RecordExt(REGISTERED_ID)
-   {
-      program_name     = DEFAULT_FILL_TEXT;
-      username         = DEFAULT_FILL_TEXT;
-      os_name          = DEFAULT_FILL_TEXT;
-      os_major         = 0;
-      os_minor         = 0;
-      os_build         = DEFAULT_FILL_TEXT;
-      os_platform      = DEFAULT_FILL_TEXT;
-      os_platform_like = DEFAULT_FILL_TEXT;
-      os_arch          = DEFAULT_FILL_TEXT;
-      kernel_version   = DEFAULT_FILL_TEXT;
-      system_hostname  = DEFAULT_FILL_TEXT;
-   }
+    RecordExtOSQUERY(const RecordExtOSQUERY* record)
+        : RecordExt(REGISTERED_ID)
+    {
+        program_name = record->program_name;
+        username = record->username;
+        os_name = record->os_name;
+        os_major = record->os_major;
+        os_minor = record->os_minor;
+        os_build = record->os_build;
+        os_platform = record->os_platform;
+        os_platform_like = record->os_platform_like;
+        os_arch = record->os_arch;
+        kernel_version = record->kernel_version;
+        system_hostname = record->system_hostname;
+    }
 
-   RecordExtOSQUERY(const RecordExtOSQUERY *record) : RecordExt(REGISTERED_ID)
-   {
-      program_name     = record->program_name;
-      username         = record->username;
-      os_name          = record->os_name;
-      os_major         = record->os_major;
-      os_minor         = record->os_minor;
-      os_build         = record->os_build;
-      os_platform      = record->os_platform;
-      os_platform_like = record->os_platform_like;
-      os_arch          = record->os_arch;
-      kernel_version   = record->kernel_version;
-      system_hostname  = record->system_hostname;
-   }
+#ifdef WITH_NEMEA
+    virtual void fillUnirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set_string(tmplt, record, F_OSQUERY_PROGRAM_NAME, program_name.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_USERNAME, username.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_OS_NAME, os_name.c_str());
+        ur_set(tmplt, record, F_OSQUERY_OS_MAJOR, os_major);
+        ur_set(tmplt, record, F_OSQUERY_OS_MINOR, os_minor);
+        ur_set_string(tmplt, record, F_OSQUERY_OS_BUILD, os_build.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_OS_PLATFORM, os_platform.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_OS_PLATFORM_LIKE, os_platform_like.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_OS_ARCH, os_arch.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_KERNEL_VERSION, kernel_version.c_str());
+        ur_set_string(tmplt, record, F_OSQUERY_SYSTEM_HOSTNAME, system_hostname.c_str());
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fillUnirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set_string(tmplt, record, F_OSQUERY_PROGRAM_NAME, program_name.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_USERNAME, username.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_OS_NAME, os_name.c_str());
-      ur_set(tmplt, record, F_OSQUERY_OS_MAJOR, os_major);
-      ur_set(tmplt, record, F_OSQUERY_OS_MINOR, os_minor);
-      ur_set_string(tmplt, record, F_OSQUERY_OS_BUILD, os_build.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_OS_PLATFORM, os_platform.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_OS_PLATFORM_LIKE, os_platform_like.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_OS_ARCH, os_arch.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_KERNEL_VERSION, kernel_version.c_str());
-      ur_set_string(tmplt, record, F_OSQUERY_SYSTEM_HOSTNAME, system_hostname.c_str());
-   }
+    const char* get_unirec_tmplt() const { return OSQUERY_UNIREC_TEMPLATE; }
+#endif // ifdef WITH_NEMEA
 
-   const char *get_unirec_tmplt() const
-   {
-      return OSQUERY_UNIREC_TEMPLATE;
-   }
-   #endif // ifdef WITH_NEMEA
+    virtual int fillIPFIX(uint8_t* buffer, int size)
+    {
+        int length, total_length = 0;
 
-   virtual int fillIPFIX(uint8_t *buffer, int size)
-   {
-      int length, total_length = 0;
+        // OSQUERY_PROGRAM_NAME
+        length = program_name.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, program_name.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_PROGRAM_NAME
-      length = program_name.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, program_name.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_USERNAME
+        length = username.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, username.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_USERNAME
-      length = username.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, username.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_OS_NAME
+        length = os_name.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, os_name.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_OS_NAME
-      length = os_name.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, os_name.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_OS_MAJOR
+        *(uint16_t*) (buffer + total_length) = ntohs(os_major);
+        total_length += 2;
 
-      // OSQUERY_OS_MAJOR
-      *(uint16_t *) (buffer + total_length) = ntohs(os_major);
-      total_length += 2;
+        // OSQUERY_OS_MINOR
+        *(uint16_t*) (buffer + total_length) = ntohs(os_minor);
+        total_length += 2;
 
-      // OSQUERY_OS_MINOR
-      *(uint16_t *) (buffer + total_length) = ntohs(os_minor);
-      total_length += 2;
+        // OSQUERY_OS_BUILD
+        length = os_build.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, os_build.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_OS_BUILD
-      length = os_build.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, os_build.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_OS_PLATFORM
+        length = os_platform.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, os_platform.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_OS_PLATFORM
-      length = os_platform.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, os_platform.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_OS_PLATFORM_LIKE
+        length = os_platform_like.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, os_platform_like.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_OS_PLATFORM_LIKE
-      length = os_platform_like.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, os_platform_like.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_OS_ARCH
+        length = os_arch.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, os_arch.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_OS_ARCH
-      length = os_arch.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, os_arch.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_KERNEL_VERSION
+        length = kernel_version.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, kernel_version.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_KERNEL_VERSION
-      length = kernel_version.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, kernel_version.c_str(), length);
-      total_length += length + 1;
+        // OSQUERY_SYSTEM_HOSTNAME
+        length = system_hostname.length();
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, system_hostname.c_str(), length);
+        total_length += length + 1;
 
-      // OSQUERY_SYSTEM_HOSTNAME
-      length = system_hostname.length();
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, system_hostname.c_str(), length);
-      total_length += length + 1;
+        return total_length;
+    } // fillIPFIX
 
-      return total_length;
-   } // fillIPFIX
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_OSQUERY_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_OSQUERY_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+        return ipfix_template;
+    }
 
-      return ipfix_template;
-   }
-
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "program=\"" << program_name << "\""
-         << ",username=\"" << username << "\""
-         << ",osname=\"" << os_name << "\""
-         << ",major=" << os_major
-         << ",minor=" << os_minor
-         << ",build=\"" << os_build << "\""
-         << ",platform=\"" << os_platform << "\""
-         << ",arch=\"" << os_arch << "\""
-         << ",kernel=\"" << kernel_version << "\""
-         << ",hostname=\"" << system_hostname << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "program=\"" << program_name << "\""
+            << ",username=\"" << username << "\""
+            << ",osname=\"" << os_name << "\""
+            << ",major=" << os_major << ",minor=" << os_minor << ",build=\"" << os_build << "\""
+            << ",platform=\"" << os_platform << "\""
+            << ",arch=\"" << os_arch << "\""
+            << ",kernel=\"" << kernel_version << "\""
+            << ",hostname=\"" << system_hostname << "\"";
+        return out.str();
+    }
 };
-
 
 /**
  * \brief Additional structure for handling osquery states.
  */
 struct OsqueryStateHandler {
-   OsqueryStateHandler() : OSQUERY_STATE(0){ }
+    OsqueryStateHandler()
+        : OSQUERY_STATE(0)
+    {
+    }
 
-   bool isErrorState() const { return (OSQUERY_STATE & (FATAL_ERROR | OPEN_FD_ERROR | READ_ERROR)); }
+    bool isErrorState() const
+    {
+        return (OSQUERY_STATE & (FATAL_ERROR | OPEN_FD_ERROR | READ_ERROR));
+    }
 
-   void setFatalError(){ OSQUERY_STATE |= FATAL_ERROR; }
+    void setFatalError() { OSQUERY_STATE |= FATAL_ERROR; }
 
-   bool isFatalError() const { return (OSQUERY_STATE & FATAL_ERROR); }
+    bool isFatalError() const { return (OSQUERY_STATE & FATAL_ERROR); }
 
-   void setOpenFDError(){ OSQUERY_STATE |= OPEN_FD_ERROR; }
+    void setOpenFDError() { OSQUERY_STATE |= OPEN_FD_ERROR; }
 
-   bool isOpenFDError() const { return (OSQUERY_STATE & OPEN_FD_ERROR); }
+    bool isOpenFDError() const { return (OSQUERY_STATE & OPEN_FD_ERROR); }
 
-   void setReadError(){ OSQUERY_STATE |= READ_ERROR; }
+    void setReadError() { OSQUERY_STATE |= READ_ERROR; }
 
-   bool isReadError() const { return (OSQUERY_STATE & READ_ERROR); }
+    bool isReadError() const { return (OSQUERY_STATE & READ_ERROR); }
 
-   void setReadSuccess(){ OSQUERY_STATE |= READ_SUCCESS; }
+    void setReadSuccess() { OSQUERY_STATE |= READ_SUCCESS; }
 
-   bool isReadSuccess() const { return (OSQUERY_STATE & READ_SUCCESS); }
+    bool isReadSuccess() const { return (OSQUERY_STATE & READ_SUCCESS); }
 
-   /**
-    * Reset the \p OSQUERY_STATE. Fatal and open fd errors will not be reset.
-    */
-   void refresh(){ OSQUERY_STATE = OSQUERY_STATE & (FATAL_ERROR | OPEN_FD_ERROR); }
+    /**
+     * Reset the \p OSQUERY_STATE. Fatal and open fd errors will not be reset.
+     */
+    void refresh() { OSQUERY_STATE = OSQUERY_STATE & (FATAL_ERROR | OPEN_FD_ERROR); }
 
-   /**
-    * Reset the \p OSQUERY_STATE. Fatal and open fd errors will be reset.
-    */
-   void reset(){ OSQUERY_STATE = 0; }
+    /**
+     * Reset the \p OSQUERY_STATE. Fatal and open fd errors will be reset.
+     */
+    void reset() { OSQUERY_STATE = 0; }
 
 private:
-   uint8_t OSQUERY_STATE;
+    uint8_t OSQUERY_STATE;
 };
-
 
 /**
- * \brief Additional structure for store and convert data from flow (src_ip, dst_ip, src_port, dst_port) to string.
+ * \brief Additional structure for store and convert data from flow (src_ip, dst_ip, src_port,
+ * dst_port) to string.
  */
 struct ConvertedFlowData {
-   /**
-    * Constructor for IPv4-based flow.
-    * @param sourceIPv4 source IPv4 address.
-    * @param destinationIPv4 destination IPv4 address.
-    * @param sourcePort source port.
-    * @param destinationPort destination port.
-    */
-   ConvertedFlowData(uint32_t sourceIPv4, uint32_t destinationIPv4, uint16_t sourcePort, uint16_t destinationPort);
+    /**
+     * Constructor for IPv4-based flow.
+     * @param sourceIPv4 source IPv4 address.
+     * @param destinationIPv4 destination IPv4 address.
+     * @param sourcePort source port.
+     * @param destinationPort destination port.
+     */
+    ConvertedFlowData(
+        uint32_t sourceIPv4,
+        uint32_t destinationIPv4,
+        uint16_t sourcePort,
+        uint16_t destinationPort);
 
-   /**
-    * Constructor for IPv6-based flow.
-    * @param sourceIPv6 source IPv6 address.
-    * @param destinationIPv6 destination IPv6 address.
-    * @param sourcePort source port.
-    * @param destinationPort destination port.
-    */
-   ConvertedFlowData(const uint8_t *sourceIPv6, const uint8_t *destinationIPv6, uint16_t sourcePort,
-     uint16_t destinationPort);
+    /**
+     * Constructor for IPv6-based flow.
+     * @param sourceIPv6 source IPv6 address.
+     * @param destinationIPv6 destination IPv6 address.
+     * @param sourcePort source port.
+     * @param destinationPort destination port.
+     */
+    ConvertedFlowData(
+        const uint8_t* sourceIPv6,
+        const uint8_t* destinationIPv6,
+        uint16_t sourcePort,
+        uint16_t destinationPort);
 
-   std::string src_ip;
-   std::string dst_ip;
-   std::string src_port;
-   std::string dst_port;
+    std::string src_ip;
+    std::string dst_ip;
+    std::string src_port;
+    std::string dst_port;
 
 private:
+    /**
+     * Converts an IPv4 numeric value to a string.
+     * @param addr IPv4 address.
+     * @param isSourceIP if true - source IP conversion mode, if false - destination IP conversion
+     * mode.
+     */
+    void convertIPv4(uint32_t addr, bool isSourceIP);
 
-   /**
-    * Converts an IPv4 numeric value to a string.
-    * @param addr IPv4 address.
-    * @param isSourceIP if true - source IP conversion mode, if false - destination IP conversion mode.
-    */
-   void convertIPv4(uint32_t addr, bool isSourceIP);
+    /**
+     * Converts an IPv6 numeric value to a string.
+     * @param addr IPv6 address.
+     * @param isSourceIP if true - source IP conversion mode, if false - destination IP conversion
+     * mode.
+     */
+    void convertIPv6(const uint8_t* addr, bool isSourceIP);
 
-   /**
-    * Converts an IPv6 numeric value to a string.
-    * @param addr IPv6 address.
-    * @param isSourceIP if true - source IP conversion mode, if false - destination IP conversion mode.
-    */
-   void convertIPv6(const uint8_t *addr, bool isSourceIP);
-
-   /**
-    * Converts the numeric port value to a string.
-    * @param port
-    * @param isSourcePort if true - source port conversion mode, if false - destination port conversion mode.
-    */
-   void convertPort(uint16_t port, bool isSourcePort);
+    /**
+     * Converts the numeric port value to a string.
+     * @param port
+     * @param isSourcePort if true - source port conversion mode, if false - destination port
+     * conversion mode.
+     */
+    void convertPort(uint16_t port, bool isSourcePort);
 };
-
 
 /**
  * \brief Manager for communication with osquery
  */
 struct OsqueryRequestManager {
-   OsqueryRequestManager();
+    OsqueryRequestManager();
 
-   ~OsqueryRequestManager();
+    ~OsqueryRequestManager();
 
-   const RecordExtOSQUERY *getRecord(){ return recOsquery; }
+    const RecordExtOSQUERY* getRecord() { return recOsquery; }
 
-   /**
-    * Fills the record with OS values from osquery.
-    */
-   void readInfoAboutOS();
+    /**
+     * Fills the record with OS values from osquery.
+     */
+    void readInfoAboutOS();
 
-   /**
-    * Fills the record with program values from osquery.
-    * @param flowData flow data converted to string.
-    * @return true if success or false.
-    */
-   bool readInfoAboutProgram(const ConvertedFlowData &flowData);
+    /**
+     * Fills the record with program values from osquery.
+     * @param flowData flow data converted to string.
+     * @return true if success or false.
+     */
+    bool readInfoAboutProgram(const ConvertedFlowData& flowData);
 
 private:
+    /**
+     * Sends a request and receives a response from osquery.
+     * @param query sql query according to osquery standards.
+     * @param reopenFD if true - tries to reopen fd.
+     * @return number of bytes read.
+     */
+    size_t executeQuery(const std::string& query, bool reopenFD = false);
 
-   /**
-    * Sends a request and receives a response from osquery.
-    * @param query sql query according to osquery standards.
-    * @param reopenFD if true - tries to reopen fd.
-    * @return number of bytes read.
-    */
-   size_t executeQuery(const std::string &query, bool reopenFD = false);
+    /**
+     * Writes query to osquery input FD.
+     * @param query sql query according to osquery standards.
+     * @return true if success or false.
+     */
+    bool writeToOsquery(const char* query);
 
-   /**
-    * Writes query to osquery input FD.
-    * @param query sql query according to osquery standards.
-    * @return true if success or false.
-    */
-   bool writeToOsquery(const char *query);
+    /**
+     * Reads data from osquery output FD.
+     * \note Can change osquery state. Possible changes: READ_ERROR, READ_SUCCESS.
+     * @return number of bytes read.
+     */
+    size_t readFromOsquery();
 
-   /**
-    * Reads data from osquery output FD.
-    * \note Can change osquery state. Possible changes: READ_ERROR, READ_SUCCESS.
-    * @return number of bytes read.
-    */
-   size_t readFromOsquery();
+    /**
+     * Opens osquery FD.
+     * \note Can change osquery state. Possible changes: FATAL_ERROR, OPEN_FD_ERROR.
+     */
+    void openOsqueryFD();
 
-   /**
-    * Opens osquery FD.
-    * \note Can change osquery state. Possible changes: FATAL_ERROR, OPEN_FD_ERROR.
-    */
-   void openOsqueryFD();
+    /**
+     * Closes osquery FD.
+     */
+    void closeOsqueryFD();
 
-   /**
-    * Closes osquery FD.
-    */
-   void closeOsqueryFD();
+    /**
+     * Before reopening osquery tries to kill the previous osquery process.
+     *
+     * If \p useWhonangOption is true then the waitpid() function will be used
+     * in non-blocking mode(can be called before the process is ready to close,
+     * the process will remain in a zombie state). At the end of the application,
+     * a zombie process may remain, it will be killed when the application is closed.
+     * Else if \p useWhonangOption is false then the waitpid() function will be used
+     * in blocking mode(will wait for the process to complete). Will kill all unnecessary
+     * processes, but will block the application until the killed process is finished.
+     *
+     * @param useWhonangOption if true will be used non-blocking mode.
+     */
+    void killPreviousProcesses(bool useWhonangOption = true) const;
 
-   /**
-    * Before reopening osquery tries to kill the previous osquery process.
-    *
-    * If \p useWhonangOption is true then the waitpid() function will be used
-    * in non-blocking mode(can be called before the process is ready to close,
-    * the process will remain in a zombie state). At the end of the application,
-    * a zombie process may remain, it will be killed when the application is closed.
-    * Else if \p useWhonangOption is false then the waitpid() function will be used
-    * in blocking mode(will wait for the process to complete). Will kill all unnecessary
-    * processes, but will block the application until the killed process is finished.
-    *
-    * @param useWhonangOption if true will be used non-blocking mode.
-    */
-   void killPreviousProcesses(bool useWhonangOption = true) const;
+    /**
+     * Tries to get the process id from table "process_open_sockets".
+     * @param[out] pid      process id.
+     * @param[in]  flowData flow data converted to string.
+     * @return true true if success or false.
+     */
+    bool getPID(std::string& pid, const ConvertedFlowData& flowData);
 
-   /**
-    * Tries to get the process id from table "process_open_sockets".
-    * @param[out] pid      process id.
-    * @param[in]  flowData flow data converted to string.
-    * @return true true if success or false.
-    */
-   bool getPID(std::string &pid, const ConvertedFlowData &flowData);
+    /**
+     * Parses json string with only one element.
+     * @param[in]  singleKey    key.
+     * @param[out] singleValue  value.
+     * @return true if success or false.
+     */
+    bool parseJsonSingleItem(const std::string& singleKey, std::string& singleValue);
 
-   /**
-    * Parses json string with only one element.
-    * @param[in]  singleKey    key.
-    * @param[out] singleValue  value.
-    * @return true if success or false.
-    */
-   bool parseJsonSingleItem(const std::string &singleKey, std::string &singleValue);
+    /**
+     * Parses json by template.
+     * @return true if success or false.
+     */
+    bool parseJsonOSVersion();
 
-   /**
-    * Parses json by template.
-    * @return true if success or false.
-    */
-   bool parseJsonOSVersion();
+    /**
+     * Parses json by template.
+     * @return true if success or false.
+     */
+    bool parseJsonAboutProgram();
 
-   /**
-    * Parses json by template.
-    * @return true if success or false.
-    */
-   bool parseJsonAboutProgram();
+    /**
+     * From position \p from tries to find two strings between quotes ["key":"value"].
+     * @param[in]  from  start position in the buffer.
+     * @param[out] key   value for the "key" parsing result.
+     * @param[out] value value for the "value" parsing result.
+     * @return the position where the text search ended, 0 if end of json row or -1 if end of
+     * buffer.
+     */
+    int parseJsonItem(int from, std::string& key, std::string& value);
 
-   /**
-    * From position \p from tries to find two strings between quotes ["key":"value"].
-    * @param[in]  from  start position in the buffer.
-    * @param[out] key   value for the "key" parsing result.
-    * @param[out] value value for the "value" parsing result.
-    * @return the position where the text search ended, 0 if end of json row or -1 if end of buffer.
-    */
-   int parseJsonItem(int from, std::string &key, std::string &value);
+    /**
+     * From position \p from tries to find string between quotes.
+     * @param[in]  from start position in the buffer.
+     * @param[out] str  value for the parsing result.
+     * @return the position where the text search ended, 0 if end of json row or -1 if end of
+     * buffer.
+     */
+    int parseString(int from, std::string& str);
 
-   /**
-    * From position \p from tries to find string between quotes.
-    * @param[in]  from start position in the buffer.
-    * @param[out] str  value for the parsing result.
-    * @return the position where the text search ended, 0 if end of json row or -1 if end of buffer.
-    */
-   int parseString(int from, std::string &str);
+    /**
+     * Create a new process for connecting FD.
+     * @param[in]  command  command to execute in sh.
+     * @param[out] inFD     input FD.
+     * @param[out] outFD    output FD.
+     * @return pid of the new process.
+     */
+    pid_t popen2(const char* command, int* inFD, int* outFD) const;
 
-   /**
-    * Create a new process for connecting FD.
-    * @param[in]  command  command to execute in sh.
-    * @param[out] inFD     input FD.
-    * @param[out] outFD    output FD.
-    * @return pid of the new process.
-    */
-   pid_t popen2(const char *command, int *inFD, int *outFD) const;
+    /**
+     * Sets the first byte in the buffer to zero
+     */
+    void clearBuffer() { buffer[0] = 0; }
 
-   /**
-    * Sets the first byte in the buffer to zero
-    */
-   void clearBuffer(){ buffer[0] = 0; }
+    /**
+     * Tries to find the position in the buffer where the json data starts.
+     * @return position number or -1 if position was not found.
+     */
+    int getPositionForParseJson();
 
-   /**
-    * Tries to find the position in the buffer where the json data starts.
-    * @return position number or -1 if position was not found.
-    */
-   int getPositionForParseJson();
+    int inputFD;
+    int outputFD;
+    char* buffer;
+    pollfd* pfd;
+    RecordExtOSQUERY* recOsquery;
+    bool isFDOpened;
+    int numberOfAttempts;
+    pid_t osqueryProcessId;
 
-   int                 inputFD;
-   int                 outputFD;
-   char *              buffer;
-   pollfd *            pfd;
-   RecordExtOSQUERY *  recOsquery;
-   bool                isFDOpened;
-   int                 numberOfAttempts;
-   pid_t               osqueryProcessId;
-
-   OsqueryStateHandler handler;
+    OsqueryStateHandler handler;
 };
-
 
 /**
  * \brief Flow cache plugin for parsing OSQUERY packets.
  */
-class OSQUERYPlugin : public ProcessPlugin
-{
+class OSQUERYPlugin : public ProcessPlugin {
 public:
-   OSQUERYPlugin();
-   ~OSQUERYPlugin();
-   OSQUERYPlugin(const OSQUERYPlugin &p);
-   void init(const char *params);
-   void close();
-   RecordExt *get_ext() const { return new RecordExtOSQUERY(); }
-   OptionsParser *get_parser() const { return new OptionsParser("osquery", "Collect information about locally outbound flows from OS"); }
-   std::string get_name() const { return "osquery"; }
-   ProcessPlugin *copy();
+    OSQUERYPlugin();
+    ~OSQUERYPlugin();
+    OSQUERYPlugin(const OSQUERYPlugin& p);
+    void init(const char* params);
+    void close();
+    RecordExt* get_ext() const { return new RecordExtOSQUERY(); }
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser(
+            "osquery",
+            "Collect information about locally outbound flows from OS");
+    }
+    std::string get_name() const { return "osquery"; }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   OsqueryRequestManager *manager;
-   int numberOfSuccessfullyRequests;
+    OsqueryRequestManager* manager;
+    int numberOfSuccessfullyRequests;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_OSQUERY_HPP */

--- a/process/passivedns.hpp
+++ b/process/passivedns.hpp
@@ -30,165 +30,153 @@
 #define IPXP_PROCESS_PASSIVEDNS_HPP
 
 #include <config.h>
-#include <string>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
 #include "dns-utils.hpp"
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #define DNS_UNIREC_TEMPLATE "DNS_ID,DNS_ATYPE,DNS_NAME,DNS_RR_TTL,DNS_IP"
 
-UR_FIELDS (
-   uint16 DNS_ID,
-   uint16 DNS_ATYPE,
-   string DNS_NAME,
-   uint32 DNS_RR_TTL,
-   ipaddr DNS_IP
-)
+UR_FIELDS(uint16 DNS_ID, uint16 DNS_ATYPE, string DNS_NAME, uint32 DNS_RR_TTL, ipaddr DNS_IP)
 
 /**
  * \brief Flow record extension header for storing parsed DNS packets.
  */
 struct RecordExtPassiveDNS : public RecordExt {
-   static int REGISTERED_ID;
-   uint16_t atype;
-   uint16_t id;
-   uint8_t ip_version;
-   char aname[255];
-   uint32_t rr_ttl;
-   ipaddr_t ip;
+    static int REGISTERED_ID;
+    uint16_t atype;
+    uint16_t id;
+    uint8_t ip_version;
+    char aname[255];
+    uint32_t rr_ttl;
+    ipaddr_t ip;
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtPassiveDNS() : RecordExt(REGISTERED_ID)
-   {
-      id = 0;
-      atype = 0;
-      ip_version = 0;
-      aname[0] = 0;
-      rr_ttl = 0;
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtPassiveDNS()
+        : RecordExt(REGISTERED_ID)
+    {
+        id = 0;
+        atype = 0;
+        ip_version = 0;
+        aname[0] = 0;
+        rr_ttl = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_DNS_ID, id);
-      ur_set(tmplt, record, F_DNS_ATYPE, atype);
-      ur_set_string(tmplt, record, F_DNS_NAME, aname);
-      ur_set(tmplt, record, F_DNS_RR_TTL, rr_ttl);
-      if (ip_version == 4) {
-         ur_set(tmplt, record, F_DNS_IP, ip_from_4_bytes_be((char *) &ip.v4));
-      } else if (ip_version == 6) {
-         ur_set(tmplt, record, F_DNS_IP, ip_from_16_bytes_be((char *) ip.v6));
-      }
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_DNS_ID, id);
+        ur_set(tmplt, record, F_DNS_ATYPE, atype);
+        ur_set_string(tmplt, record, F_DNS_NAME, aname);
+        ur_set(tmplt, record, F_DNS_RR_TTL, rr_ttl);
+        if (ip_version == 4) {
+            ur_set(tmplt, record, F_DNS_IP, ip_from_4_bytes_be((char*) &ip.v4));
+        } else if (ip_version == 6) {
+            ur_set(tmplt, record, F_DNS_IP, ip_from_16_bytes_be((char*) ip.v6));
+        }
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return DNS_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return DNS_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length;
-      int rdata_len = (ip_version == 4 ? 4 : 16);
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length;
+        int rdata_len = (ip_version == 4 ? 4 : 16);
 
-      length = strlen(aname);
-      if (length + rdata_len + 10 > size) {
-         return -1;
-      }
+        length = strlen(aname);
+        if (length + rdata_len + 10 > size) {
+            return -1;
+        }
 
-      *(uint16_t *) (buffer) = ntohs(id);
-      *(uint32_t *) (buffer + 2) = ntohl(rr_ttl);
-      *(uint16_t *) (buffer + 6) = ntohs(atype);
-      buffer[8] = rdata_len;
-      if (ip_version == 4) {
-         *(uint32_t *) (buffer + 9) = ntohl(ip.v4);
-      } else {
-         memcpy(buffer + 9, ip.v6, sizeof(ip.v6));
-      }
-      buffer[9 + rdata_len] = length;
-      memcpy(buffer + rdata_len + 10, aname, length);
+        *(uint16_t*) (buffer) = ntohs(id);
+        *(uint32_t*) (buffer + 2) = ntohl(rr_ttl);
+        *(uint16_t*) (buffer + 6) = ntohs(atype);
+        buffer[8] = rdata_len;
+        if (ip_version == 4) {
+            *(uint32_t*) (buffer + 9) = ntohl(ip.v4);
+        } else {
+            memcpy(buffer + 9, ip.v6, sizeof(ip.v6));
+        }
+        buffer[9 + rdata_len] = length;
+        memcpy(buffer + rdata_len + 10, aname, length);
 
-      return length + rdata_len + 10;
-   }
+        return length + rdata_len + 10;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_PASSIVEDNS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_PASSIVEDNS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      char ip_str[INET6_ADDRSTRLEN];
-      std::ostringstream out;
+    std::string get_text() const
+    {
+        char ip_str[INET6_ADDRSTRLEN];
+        std::ostringstream out;
 
-      if (ip_version == 4) {
-         inet_ntop(AF_INET, (const void *) &ip.v4, ip_str, INET6_ADDRSTRLEN);
-      } else if (ip_version == 6) {
-         inet_ntop(AF_INET6, (const void *) &ip.v6, ip_str, INET6_ADDRSTRLEN);
-      }
+        if (ip_version == 4) {
+            inet_ntop(AF_INET, (const void*) &ip.v4, ip_str, INET6_ADDRSTRLEN);
+        } else if (ip_version == 6) {
+            inet_ntop(AF_INET6, (const void*) &ip.v6, ip_str, INET6_ADDRSTRLEN);
+        }
 
-      out << "dnsid=" << id
-         << ",atype=" << atype
-         << ",aname=\"" << aname << "\""
-         << ",rrttl=" << rr_ttl
-         << ",ip=" << ip_str;
-      return out.str();
-   }
+        out << "dnsid=" << id << ",atype=" << atype << ",aname=\"" << aname << "\""
+            << ",rrttl=" << rr_ttl << ",ip=" << ip_str;
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing DNS packets.
  */
-class PassiveDNSPlugin : public ProcessPlugin
-{
+class PassiveDNSPlugin : public ProcessPlugin {
 public:
-   PassiveDNSPlugin();
-   ~PassiveDNSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("passivedns", "Parse A, AAAA and PTR records from DNS traffic"); }
-   std::string get_name() const { return "passivedns"; }
-   RecordExt *get_ext() const { return new RecordExtPassiveDNS(); }
-   ProcessPlugin *copy();
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void finish(bool print_stats);
+    PassiveDNSPlugin();
+    ~PassiveDNSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser("passivedns", "Parse A, AAAA and PTR records from DNS traffic");
+    }
+    std::string get_name() const { return "passivedns"; }
+    RecordExt* get_ext() const { return new RecordExtPassiveDNS(); }
+    ProcessPlugin* copy();
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   uint32_t total;         /**< Total number of parsed DNS responses. */
-   uint32_t parsed_a;      /**< Number of parsed A records. */
-   uint32_t parsed_aaaa;   /**< Number of parsed AAAA records. */
-   uint32_t parsed_ptr;    /**< Number of parsed PTR records. */
+    uint32_t total; /**< Total number of parsed DNS responses. */
+    uint32_t parsed_a; /**< Number of parsed A records. */
+    uint32_t parsed_aaaa; /**< Number of parsed AAAA records. */
+    uint32_t parsed_ptr; /**< Number of parsed PTR records. */
 
-   const char *data_begin; /**< Pointer to begin of payload. */
-   uint32_t data_len;      /**< Length of packet payload. */
+    const char* data_begin; /**< Pointer to begin of payload. */
+    uint32_t data_len; /**< Length of packet payload. */
 
-   RecordExtPassiveDNS *parse_dns(const char *data, unsigned int payload_len, bool tcp);
-   int add_ext_dns(const char *data, unsigned int payload_len, bool tcp, Flow &rec);
+    RecordExtPassiveDNS* parse_dns(const char* data, unsigned int payload_len, bool tcp);
+    int add_ext_dns(const char* data, unsigned int payload_len, bool tcp, Flow& rec);
 
-   std::string get_name(const char *data) const;
-   size_t get_name_length(const char *data) const;
-   bool process_ptr_record(std::string name, RecordExtPassiveDNS *rec);
-   bool str_to_uint4(std::string str, uint8_t &dst);
+    std::string get_name(const char* data) const;
+    size_t get_name_length(const char* data) const;
+    bool process_ptr_record(std::string name, RecordExtPassiveDNS* rec);
+    bool str_to_uint4(std::string str, uint8_t& dst);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_PASSIVEDNS_HPP */

--- a/process/phists.cpp
+++ b/process/phists.cpp
@@ -26,13 +26,13 @@
  *
  */
 
+#include <algorithm>
 #include <iostream>
+#include <limits>
+#include <math.h>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <limits>
-#include <math.h>
 
 #include "phists.hpp"
 
@@ -42,9 +42,9 @@ int RecordExtPHISTS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("phists", [](){return new PHISTSPlugin();});
-   register_plugin(&rec);
-   RecordExtPHISTS::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("phists", []() { return new PHISTSPlugin(); });
+    register_plugin(&rec);
+    RecordExtPHISTS::REGISTERED_ID = register_extension();
 }
 
 #define PHISTS_INCLUDE_ZEROS_OPT "includezeros"
@@ -55,39 +55,37 @@ __attribute__((constructor)) static void register_this_plugin()
 #define DEBUG_MSG(format, ...)
 #endif
 
-const uint32_t PHISTSPlugin::log2_lookup32[32] = { 0,  9,  1,  10, 13, 21, 2,  29,
-                                                   11, 14, 16, 18, 22, 25, 3,  30,
-                                                   8,  12, 20, 28, 15, 17, 24, 7,
-                                                   19, 27, 23, 6,  26, 5,  4,  31 };
+const uint32_t PHISTSPlugin::log2_lookup32[32]
+    = {0, 9,  1,  10, 13, 21, 2,  29, 11, 14, 16, 18, 22, 25, 3, 30,
+       8, 12, 20, 28, 15, 17, 24, 7,  19, 27, 23, 6,  26, 5,  4, 31};
 
-PHISTSPlugin::PHISTSPlugin() : use_zeros(false)
+PHISTSPlugin::PHISTSPlugin()
+    : use_zeros(false)
 {
 }
 
 PHISTSPlugin::~PHISTSPlugin()
 {
-   close();
+    close();
 }
 
-void PHISTSPlugin::init(const char *params)
+void PHISTSPlugin::init(const char* params)
 {
-   PHISTSOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    PHISTSOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   use_zeros = parser.m_include_zeroes;
+    use_zeros = parser.m_include_zeroes;
 }
 
-void PHISTSPlugin::close()
-{
-}
+void PHISTSPlugin::close() {}
 
-ProcessPlugin *PHISTSPlugin::copy()
+ProcessPlugin* PHISTSPlugin::copy()
 {
-   return new PHISTSPlugin(*this);
+    return new PHISTSPlugin(*this);
 }
 
 /*
@@ -100,74 +98,78 @@ ProcessPlugin *PHISTSPlugin::copy()
  * 512-1023 7. bin
  * 1024 >   8. bin
  */
-void PHISTSPlugin::update_hist(RecordExtPHISTS *phists_data, uint32_t value, uint32_t *histogram)
+void PHISTSPlugin::update_hist(RecordExtPHISTS* phists_data, uint32_t value, uint32_t* histogram)
 {
-   if (value < 16) {
-      histogram[0] = no_overflow_increment(histogram[0]);
-   } else if (value > 1023) {
-      histogram[HISTOGRAM_SIZE - 1] = no_overflow_increment(histogram[HISTOGRAM_SIZE - 1]);
-   } else {
-      histogram[fastlog2_32(value) - 2 - 1] = no_overflow_increment(histogram[fastlog2_32(value) - 2 -1]);// -2 means shift cause first bin corresponds to 2^4
-   }
-   return;
+    if (value < 16) {
+        histogram[0] = no_overflow_increment(histogram[0]);
+    } else if (value > 1023) {
+        histogram[HISTOGRAM_SIZE - 1] = no_overflow_increment(histogram[HISTOGRAM_SIZE - 1]);
+    } else {
+        histogram[fastlog2_32(value) - 2 - 1] = no_overflow_increment(
+            histogram[fastlog2_32(value) - 2 - 1]); // -2 means shift cause first bin corresponds to
+                                                    // 2^4
+    }
+    return;
 }
 
-uint64_t PHISTSPlugin::calculate_ipt(RecordExtPHISTS *phists_data, const struct timeval tv, uint8_t direction)
+uint64_t PHISTSPlugin::calculate_ipt(
+    RecordExtPHISTS* phists_data,
+    const struct timeval tv,
+    uint8_t direction)
 {
-   int64_t ts = IpfixBasicList::Tv2Ts(tv);
+    int64_t ts = IpfixBasicList::Tv2Ts(tv);
 
-   if (phists_data->last_ts[direction] == 0) {
-      phists_data->last_ts[direction] = ts;
-      return -1;
-   }
-   int64_t diff = ts - phists_data->last_ts[direction];
+    if (phists_data->last_ts[direction] == 0) {
+        phists_data->last_ts[direction] = ts;
+        return -1;
+    }
+    int64_t diff = ts - phists_data->last_ts[direction];
 
-   phists_data->last_ts[direction] = ts;
-   return diff;
+    phists_data->last_ts[direction] = ts;
+    return diff;
 }
 
-void PHISTSPlugin::update_record(RecordExtPHISTS *phists_data, const Packet &pkt)
+void PHISTSPlugin::update_record(RecordExtPHISTS* phists_data, const Packet& pkt)
 {
-   if (pkt.payload_len_wire == 0 && use_zeros == false){
-      return;
-   }
-   uint8_t direction = (uint8_t) !pkt.source_pkt;
-   update_hist(phists_data, (uint32_t) pkt.payload_len_wire, phists_data->size_hist[direction]);
-   int32_t ipt_diff = (uint32_t) calculate_ipt(phists_data, pkt.ts, direction);
-   if (ipt_diff != -1) {
-      update_hist(phists_data, (uint32_t) ipt_diff, phists_data->ipt_hist[direction]);
-   }
+    if (pkt.payload_len_wire == 0 && use_zeros == false) {
+        return;
+    }
+    uint8_t direction = (uint8_t) !pkt.source_pkt;
+    update_hist(phists_data, (uint32_t) pkt.payload_len_wire, phists_data->size_hist[direction]);
+    int32_t ipt_diff = (uint32_t) calculate_ipt(phists_data, pkt.ts, direction);
+    if (ipt_diff != -1) {
+        update_hist(phists_data, (uint32_t) ipt_diff, phists_data->ipt_hist[direction]);
+    }
 }
 
-
-
-void PHISTSPlugin::pre_export(Flow &rec)
+void PHISTSPlugin::pre_export(Flow& rec)
 {
-   //do not export phists for single packets flows, usually port scans
-   uint32_t packets = rec.src_packets + rec.dst_packets;
-   uint8_t flags = rec.src_tcp_flags | rec.dst_tcp_flags;
+    // do not export phists for single packets flows, usually port scans
+    uint32_t packets = rec.src_packets + rec.dst_packets;
+    uint8_t flags = rec.src_tcp_flags | rec.dst_tcp_flags;
 
-   if (packets <= PHISTS_MINLEN && (flags & 0x02)) { //tcp SYN set
-      rec.remove_extension(RecordExtPHISTS::REGISTERED_ID);
-   }
+    if (packets <= PHISTS_MINLEN && (flags & 0x02)) { // tcp SYN set
+        rec.remove_extension(RecordExtPHISTS::REGISTERED_ID);
+    }
 }
 
-int PHISTSPlugin::post_create(Flow &rec, const Packet &pkt)
+int PHISTSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   RecordExtPHISTS *phists_data = new RecordExtPHISTS();
+    RecordExtPHISTS* phists_data = new RecordExtPHISTS();
 
-   rec.add_extension(phists_data);
+    rec.add_extension(phists_data);
 
-   update_record(phists_data, pkt);
-   return 0;
+    update_record(phists_data, pkt);
+    return 0;
 }
 
-int PHISTSPlugin::post_update(Flow &rec, const Packet &pkt)
+int PHISTSPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   RecordExtPHISTS *phists_data = (RecordExtPHISTS *) rec.get_extension(RecordExtPHISTS::REGISTERED_ID);
+    RecordExtPHISTS* phists_data
+        = (RecordExtPHISTS*) rec.get_extension(RecordExtPHISTS::REGISTERED_ID);
 
-   update_record(phists_data, pkt);
-   return 0;
+    update_record(phists_data, pkt);
+    return 0;
 }
 
-}
+} // namespace ipxp

--- a/process/phists.hpp
+++ b/process/phists.hpp
@@ -29,24 +29,24 @@
 #ifndef IPXP_PROCESS_PHISTS_HPP
 #define IPXP_PROCESS_PHISTS_HPP
 
-#include <string>
 #include <limits>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-basiclist.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 #ifndef PHISTS_MINLEN
-# define PHISTS_MINLEN 1
+#define PHISTS_MINLEN 1
 #endif
 
 #define HISTOGRAM_SIZE 8
@@ -54,177 +54,193 @@ namespace ipxp {
 #define PHISTS_UNIREC_TEMPLATE "S_PHISTS_SIZES,S_PHISTS_IPT,D_PHISTS_SIZES,D_PHISTS_IPT"
 
 UR_FIELDS(
-   uint32* S_PHISTS_SIZES,
-   uint32* S_PHISTS_IPT,
-   uint32* D_PHISTS_SIZES,
-   uint32* D_PHISTS_IPT
-)
+    uint32* S_PHISTS_SIZES,
+    uint32* S_PHISTS_IPT,
+    uint32* D_PHISTS_SIZES,
+    uint32* D_PHISTS_IPT)
 
-class PHISTSOptParser : public OptionsParser
-{
+class PHISTSOptParser : public OptionsParser {
 public:
-   bool m_include_zeroes;
+    bool m_include_zeroes;
 
-   PHISTSOptParser() : OptionsParser("phists", "Processing plugin for packet histograms"), m_include_zeroes(false)
-   {
-      register_option("i", "includezeroes", "", "Include zero payload packets", [this](const char *arg){m_include_zeroes = true; return true;}, OptionFlags::NoArgument);
-   }
+    PHISTSOptParser()
+        : OptionsParser("phists", "Processing plugin for packet histograms")
+        , m_include_zeroes(false)
+    {
+        register_option(
+            "i",
+            "includezeroes",
+            "",
+            "Include zero payload packets",
+            [this](const char* arg) {
+                m_include_zeroes = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
 /**
  * \brief Flow record extension header for storing parsed PHISTS packets.
  */
 struct RecordExtPHISTS : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   typedef enum eHdrFieldID {
-      SPhistsSizes = 1060,
-      SPhistsIpt   = 1061,
-      DPhistsSizes = 1062,
-      DPhistsIpt   = 1063
-   } eHdrSemantic;
+    typedef enum eHdrFieldID {
+        SPhistsSizes = 1060,
+        SPhistsIpt = 1061,
+        DPhistsSizes = 1062,
+        DPhistsIpt = 1063
+    } eHdrSemantic;
 
-   uint32_t size_hist[2][HISTOGRAM_SIZE];
-   uint32_t ipt_hist[2][HISTOGRAM_SIZE];
-   uint32_t last_ts[2];
+    uint32_t size_hist[2][HISTOGRAM_SIZE];
+    uint32_t ipt_hist[2][HISTOGRAM_SIZE];
+    uint32_t last_ts[2];
 
-   RecordExtPHISTS() : RecordExt(REGISTERED_ID)
-   {
-      // inicializing histograms with zeros
-      for (int i = 0; i < 2; i++) {
-         memset(size_hist[i], 0, sizeof(uint32_t) * HISTOGRAM_SIZE);
-         memset(ipt_hist[i], 0, sizeof(uint32_t) * HISTOGRAM_SIZE);
-         last_ts[i] = 0;
-      }
-   }
+    RecordExtPHISTS()
+        : RecordExt(REGISTERED_ID)
+    {
+        // inicializing histograms with zeros
+        for (int i = 0; i < 2; i++) {
+            memset(size_hist[i], 0, sizeof(uint32_t) * HISTOGRAM_SIZE);
+            memset(ipt_hist[i], 0, sizeof(uint32_t) * HISTOGRAM_SIZE);
+            last_ts[i] = 0;
+        }
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_array_allocate(tmplt, record, F_S_PHISTS_SIZES, HISTOGRAM_SIZE);
-      ur_array_allocate(tmplt, record, F_S_PHISTS_IPT, HISTOGRAM_SIZE);
-      ur_array_allocate(tmplt, record, F_D_PHISTS_SIZES, HISTOGRAM_SIZE);
-      ur_array_allocate(tmplt, record, F_D_PHISTS_IPT, HISTOGRAM_SIZE);
-      for (int i = 0; i < HISTOGRAM_SIZE; i++) {
-         ur_array_set(tmplt, record, F_S_PHISTS_SIZES, i, size_hist[0][i]);
-         ur_array_set(tmplt, record, F_S_PHISTS_IPT, i, ipt_hist[0][i]);
-         ur_array_set(tmplt, record, F_D_PHISTS_SIZES, i, size_hist[1][i]);
-         ur_array_set(tmplt, record, F_D_PHISTS_IPT, i, ipt_hist[1][i]);
-      }
-   }
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_array_allocate(tmplt, record, F_S_PHISTS_SIZES, HISTOGRAM_SIZE);
+        ur_array_allocate(tmplt, record, F_S_PHISTS_IPT, HISTOGRAM_SIZE);
+        ur_array_allocate(tmplt, record, F_D_PHISTS_SIZES, HISTOGRAM_SIZE);
+        ur_array_allocate(tmplt, record, F_D_PHISTS_IPT, HISTOGRAM_SIZE);
+        for (int i = 0; i < HISTOGRAM_SIZE; i++) {
+            ur_array_set(tmplt, record, F_S_PHISTS_SIZES, i, size_hist[0][i]);
+            ur_array_set(tmplt, record, F_S_PHISTS_IPT, i, ipt_hist[0][i]);
+            ur_array_set(tmplt, record, F_D_PHISTS_SIZES, i, size_hist[1][i]);
+            ur_array_set(tmplt, record, F_D_PHISTS_IPT, i, ipt_hist[1][i]);
+        }
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return PHISTS_UNIREC_TEMPLATE;
-   }
-   #endif // ifdef WITH_NEMEA
+    const char* get_unirec_tmplt() const { return PHISTS_UNIREC_TEMPLATE; }
+#endif // ifdef WITH_NEMEA
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int32_t bufferPtr;
-      IpfixBasicList basiclist;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int32_t bufferPtr;
+        IpfixBasicList basiclist;
 
-      basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
-      // Check sufficient size of buffer
-      int req_size = 4 * basiclist.HeaderSize()  /* sizes, times, flags, dirs */
-        + 4 * HISTOGRAM_SIZE * sizeof(uint32_t); /* sizes */
+        basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
+        // Check sufficient size of buffer
+        int req_size = 4 * basiclist.HeaderSize() /* sizes, times, flags, dirs */
+            + 4 * HISTOGRAM_SIZE * sizeof(uint32_t); /* sizes */
 
-      if (req_size > size) {
-         return -1;
-      }
-      // Fill sizes
-      // fill buffer with basic list header and SPhistsSizes
-      bufferPtr  = basiclist.FillBuffer(buffer, size_hist[0], HISTOGRAM_SIZE, (uint32_t) SPhistsSizes);
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, size_hist[1], HISTOGRAM_SIZE, (uint32_t) DPhistsSizes);
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, ipt_hist[0], HISTOGRAM_SIZE, (uint32_t) SPhistsIpt);
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, ipt_hist[1], HISTOGRAM_SIZE, (uint32_t) DPhistsIpt);
+        if (req_size > size) {
+            return -1;
+        }
+        // Fill sizes
+        // fill buffer with basic list header and SPhistsSizes
+        bufferPtr
+            = basiclist.FillBuffer(buffer, size_hist[0], HISTOGRAM_SIZE, (uint32_t) SPhistsSizes);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            size_hist[1],
+            HISTOGRAM_SIZE,
+            (uint32_t) DPhistsSizes);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            ipt_hist[0],
+            HISTOGRAM_SIZE,
+            (uint32_t) SPhistsIpt);
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            ipt_hist[1],
+            HISTOGRAM_SIZE,
+            (uint32_t) DPhistsIpt);
 
-      return bufferPtr;
-   } // fill_ipfix
+        return bufferPtr;
+    } // fill_ipfix
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_PHISTS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_PHISTS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      char dirs_c[2] = {'s', 'd'};
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        char dirs_c[2] = {'s', 'd'};
 
-      for (int dir = 0; dir < 2; dir++) {
-         out << dirs_c[dir] << "phistsize=(";
-         for (int i = 0; i < HISTOGRAM_SIZE; i++) {
-            out << size_hist[dir][i];
-            if (i != HISTOGRAM_SIZE - 1) {
-               out << ",";
+        for (int dir = 0; dir < 2; dir++) {
+            out << dirs_c[dir] << "phistsize=(";
+            for (int i = 0; i < HISTOGRAM_SIZE; i++) {
+                out << size_hist[dir][i];
+                if (i != HISTOGRAM_SIZE - 1) {
+                    out << ",";
+                }
             }
-         }
-         out << ")," << dirs_c[dir] << "phistipt=(";
-         for (int i = 0; i < HISTOGRAM_SIZE; i++) {
-            out << ipt_hist[dir][i];
-            if (i != HISTOGRAM_SIZE - 1) {
-               out << ",";
+            out << ")," << dirs_c[dir] << "phistipt=(";
+            for (int i = 0; i < HISTOGRAM_SIZE; i++) {
+                out << ipt_hist[dir][i];
+                if (i != HISTOGRAM_SIZE - 1) {
+                    out << ",";
+                }
             }
-         }
-         out << "),";
-      }
-      return out.str();
-   }
+            out << "),";
+        }
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing PHISTS packets.
  */
-class PHISTSPlugin : public ProcessPlugin
-{
+class PHISTSPlugin : public ProcessPlugin {
 public:
-   PHISTSPlugin();
-   ~PHISTSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new PHISTSOptParser(); }
-   std::string get_name() const { return "phists"; }
-   RecordExt *get_ext() const { return new RecordExtPHISTS(); }
-   ProcessPlugin *copy();
+    PHISTSPlugin();
+    ~PHISTSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new PHISTSOptParser(); }
+    std::string get_name() const { return "phists"; }
+    RecordExt* get_ext() const { return new RecordExtPHISTS(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
 
 private:
-   bool use_zeros;
+    bool use_zeros;
 
-   void update_record(RecordExtPHISTS *phists_data, const Packet &pkt);
-   void update_hist(RecordExtPHISTS *phists_data, uint32_t value, uint32_t *histogram);
-   void pre_export(Flow &rec);
-   uint64_t calculate_ipt(RecordExtPHISTS *phists_data, const struct timeval tv, uint8_t direction);
+    void update_record(RecordExtPHISTS* phists_data, const Packet& pkt);
+    void update_hist(RecordExtPHISTS* phists_data, uint32_t value, uint32_t* histogram);
+    void pre_export(Flow& rec);
+    uint64_t
+    calculate_ipt(RecordExtPHISTS* phists_data, const struct timeval tv, uint8_t direction);
 
-   static const uint32_t log2_lookup32[32];
+    static const uint32_t log2_lookup32[32];
 
-   static inline uint32_t fastlog2_32(uint32_t value)
-   {
-      value |= value >> 1;
-      value |= value >> 2;
-      value |= value >> 4;
-      value |= value >> 8;
-      value |= value >> 16;
-      return log2_lookup32[(uint32_t) (value * 0x07C4ACDD) >> 27];
-   }
+    static inline uint32_t fastlog2_32(uint32_t value)
+    {
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        return log2_lookup32[(uint32_t) (value * 0x07C4ACDD) >> 27];
+    }
 
-   static inline uint32_t no_overflow_increment(uint32_t value)
-   {
-      if (value == std::numeric_limits<uint32_t>::max()) {
-         return value;
-      }
-      return value + 1;
-   }
-
+    static inline uint32_t no_overflow_increment(uint32_t value)
+    {
+        if (value == std::numeric_limits<uint32_t>::max()) {
+            return value;
+        }
+        return value + 1;
+    }
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_PHISTS_HPP */

--- a/process/pstats.cpp
+++ b/process/pstats.cpp
@@ -27,12 +27,12 @@
  *
  */
 
+#include <algorithm>
+#include <cctype>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <cctype>
 
 #include "pstats.hpp"
 
@@ -42,12 +42,12 @@ int RecordExtPSTATS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("pstats", [](){return new PSTATSPlugin();});
-   register_plugin(&rec);
-   RecordExtPSTATS::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("pstats", []() { return new PSTATSPlugin(); });
+    register_plugin(&rec);
+    RecordExtPSTATS::REGISTERED_ID = register_extension();
 }
 
-//#define DEBUG_PSTATS
+// #define DEBUG_PSTATS
 
 // Print debug message if debugging is allowed.
 #ifdef DEBUG_PSTATS
@@ -56,121 +56,125 @@ __attribute__((constructor)) static void register_this_plugin()
 #define DEBUG_MSG(format, ...)
 #endif
 
-PSTATSPlugin::PSTATSPlugin() : use_zeros(false), skip_dup_pkts(false)
+PSTATSPlugin::PSTATSPlugin()
+    : use_zeros(false)
+    , skip_dup_pkts(false)
 {
 }
 
 PSTATSPlugin::~PSTATSPlugin()
 {
-   close();
+    close();
 }
 
-void PSTATSPlugin::init(const char *params)
+void PSTATSPlugin::init(const char* params)
 {
-   PSTATSOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    PSTATSOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   use_zeros = parser.m_include_zeroes;
-   skip_dup_pkts = parser.m_skipdup;
+    use_zeros = parser.m_include_zeroes;
+    skip_dup_pkts = parser.m_skipdup;
 }
 
-void PSTATSPlugin::close()
-{
-}
+void PSTATSPlugin::close() {}
 
-ProcessPlugin *PSTATSPlugin::copy()
+ProcessPlugin* PSTATSPlugin::copy()
 {
-   return new PSTATSPlugin(*this);
+    return new PSTATSPlugin(*this);
 }
 
 inline bool seq_overflowed(uint32_t curr, uint32_t prev)
 {
-   return (int64_t) curr - (int64_t) prev < -4252017623LL;
+    return (int64_t) curr - (int64_t) prev < -4252017623LL;
 }
 
-void PSTATSPlugin::update_record(RecordExtPSTATS *pstats_data, const Packet &pkt)
+void PSTATSPlugin::update_record(RecordExtPSTATS* pstats_data, const Packet& pkt)
 {
-   /**
-    * 0 - client -> server
-    * 1 - server -> client
-    */
-   int8_t dir = pkt.source_pkt ? 0 : 1;
-   if (skip_dup_pkts && pkt.ip_proto == IPPROTO_TCP) {
-      // Current seq <= previous ack?
-      bool seq_susp = (pkt.tcp_seq <= pstats_data->tcp_seq[dir] && !seq_overflowed(pkt.tcp_seq, pstats_data->tcp_seq[dir])) ||
-                      (pkt.tcp_seq > pstats_data->tcp_seq[dir] && seq_overflowed(pkt.tcp_seq, pstats_data->tcp_seq[dir]));
-      // Current ack <= previous ack?
-      bool ack_susp = (pkt.tcp_ack <= pstats_data->tcp_ack[dir] && !seq_overflowed(pkt.tcp_ack, pstats_data->tcp_ack[dir])) ||
-                      (pkt.tcp_ack > pstats_data->tcp_ack[dir] && seq_overflowed(pkt.tcp_ack, pstats_data->tcp_ack[dir]));
-      if (seq_susp && ack_susp &&
-            pkt.payload_len == pstats_data->tcp_len[dir] &&
-            pkt.tcp_flags == pstats_data->tcp_flg[dir] &&
-            pstats_data->pkt_count != 0) {
-         return;
-      }
-   }
-   pstats_data->tcp_seq[dir] = pkt.tcp_seq;
-   pstats_data->tcp_ack[dir] = pkt.tcp_ack;
-   pstats_data->tcp_len[dir] = pkt.payload_len;
-   pstats_data->tcp_flg[dir] = pkt.tcp_flags;
+    /**
+     * 0 - client -> server
+     * 1 - server -> client
+     */
+    int8_t dir = pkt.source_pkt ? 0 : 1;
+    if (skip_dup_pkts && pkt.ip_proto == IPPROTO_TCP) {
+        // Current seq <= previous ack?
+        bool seq_susp = (pkt.tcp_seq <= pstats_data->tcp_seq[dir]
+                         && !seq_overflowed(pkt.tcp_seq, pstats_data->tcp_seq[dir]))
+            || (pkt.tcp_seq > pstats_data->tcp_seq[dir]
+                && seq_overflowed(pkt.tcp_seq, pstats_data->tcp_seq[dir]));
+        // Current ack <= previous ack?
+        bool ack_susp = (pkt.tcp_ack <= pstats_data->tcp_ack[dir]
+                         && !seq_overflowed(pkt.tcp_ack, pstats_data->tcp_ack[dir]))
+            || (pkt.tcp_ack > pstats_data->tcp_ack[dir]
+                && seq_overflowed(pkt.tcp_ack, pstats_data->tcp_ack[dir]));
+        if (seq_susp && ack_susp && pkt.payload_len == pstats_data->tcp_len[dir]
+            && pkt.tcp_flags == pstats_data->tcp_flg[dir] && pstats_data->pkt_count != 0) {
+            return;
+        }
+    }
+    pstats_data->tcp_seq[dir] = pkt.tcp_seq;
+    pstats_data->tcp_ack[dir] = pkt.tcp_ack;
+    pstats_data->tcp_len[dir] = pkt.payload_len;
+    pstats_data->tcp_flg[dir] = pkt.tcp_flags;
 
-   if (pkt.payload_len_wire == 0 && use_zeros == false) {
-      return;
-   }
+    if (pkt.payload_len_wire == 0 && use_zeros == false) {
+        return;
+    }
 
-   /*
-    * dir =  1 iff client -> server
-    * dir = -1 iff server -> client
-    */
-   dir = pkt.source_pkt ? 1 : -1;
-   if (pstats_data->pkt_count < PSTATS_MAXELEMCOUNT) {
-      uint16_t pkt_cnt = pstats_data->pkt_count;
-      pstats_data->pkt_sizes[pkt_cnt] = pkt.payload_len_wire;
-      pstats_data->pkt_tcp_flgs[pkt_cnt] = pkt.tcp_flags;
+    /*
+     * dir =  1 iff client -> server
+     * dir = -1 iff server -> client
+     */
+    dir = pkt.source_pkt ? 1 : -1;
+    if (pstats_data->pkt_count < PSTATS_MAXELEMCOUNT) {
+        uint16_t pkt_cnt = pstats_data->pkt_count;
+        pstats_data->pkt_sizes[pkt_cnt] = pkt.payload_len_wire;
+        pstats_data->pkt_tcp_flgs[pkt_cnt] = pkt.tcp_flags;
 
-      pstats_data->pkt_timestamps[pkt_cnt] = pkt.ts;
+        pstats_data->pkt_timestamps[pkt_cnt] = pkt.ts;
 
-      DEBUG_MSG("PSTATS processed packet %d: Size: %d Timestamp: %ld.%ld\n", pkt_cnt,
+        DEBUG_MSG(
+            "PSTATS processed packet %d: Size: %d Timestamp: %ld.%ld\n",
+            pkt_cnt,
             pstats_data->pkt_sizes[pkt_cnt],
             pstats_data->pkt_timestamps[pkt_cnt].tv_sec,
             pstats_data->pkt_timestamps[pkt_cnt].tv_usec);
 
-      pstats_data->pkt_dirs[pkt_cnt] = dir;
-      pstats_data->pkt_count++;
-   } else {
-      /* Do not count more than PSTATS_MAXELEMCOUNT packets */
-   }
+        pstats_data->pkt_dirs[pkt_cnt] = dir;
+        pstats_data->pkt_count++;
+    } else {
+        /* Do not count more than PSTATS_MAXELEMCOUNT packets */
+    }
 }
 
-int PSTATSPlugin::post_create(Flow &rec, const Packet &pkt)
+int PSTATSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   RecordExtPSTATS *pstats_data = new RecordExtPSTATS();
-   rec.add_extension(pstats_data);
+    RecordExtPSTATS* pstats_data = new RecordExtPSTATS();
+    rec.add_extension(pstats_data);
 
-   update_record(pstats_data, pkt);
-   return 0;
+    update_record(pstats_data, pkt);
+    return 0;
 }
 
-void PSTATSPlugin::pre_export(Flow &rec)
+void PSTATSPlugin::pre_export(Flow& rec)
 {
-   //do not export pstats for single packets flows, usually port scans
-   uint32_t packets = rec.src_packets + rec.dst_packets;
-   uint8_t flags = rec.src_tcp_flags | rec.dst_tcp_flags;
-   if (packets <= PSTATS_MINLEN && (flags & 0x02)) { //tcp SYN set
-      rec.remove_extension(RecordExtPSTATS::REGISTERED_ID);
-   }
-
+    // do not export pstats for single packets flows, usually port scans
+    uint32_t packets = rec.src_packets + rec.dst_packets;
+    uint8_t flags = rec.src_tcp_flags | rec.dst_tcp_flags;
+    if (packets <= PSTATS_MINLEN && (flags & 0x02)) { // tcp SYN set
+        rec.remove_extension(RecordExtPSTATS::REGISTERED_ID);
+    }
 }
 
-int PSTATSPlugin::post_update(Flow &rec, const Packet &pkt)
+int PSTATSPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   RecordExtPSTATS *pstats_data = (RecordExtPSTATS *) rec.get_extension(RecordExtPSTATS::REGISTERED_ID);
-   update_record(pstats_data, pkt);
-   return 0;
+    RecordExtPSTATS* pstats_data
+        = (RecordExtPSTATS*) rec.get_extension(RecordExtPSTATS::REGISTERED_ID);
+    update_record(pstats_data, pkt);
+    return 0;
 }
 
-}
+} // namespace ipxp

--- a/process/pstats.hpp
+++ b/process/pstats.hpp
@@ -30,18 +30,18 @@
 #ifndef IPXP_PROCESS_PSTATS_HPP
 #define IPXP_PROCESS_PSTATS_HPP
 
-#include <string>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/options.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 #include <ipfixprobe/byte-utils.hpp>
 #include <ipfixprobe/ipfix-basiclist.hpp>
@@ -50,183 +50,204 @@
 namespace ipxp {
 
 #ifndef PSTATS_MAXELEMCOUNT
-# define PSTATS_MAXELEMCOUNT 30
+#define PSTATS_MAXELEMCOUNT 30
 #endif
 
 #ifndef PSTATS_MINLEN
-# define PSTATS_MINLEN 1
+#define PSTATS_MINLEN 1
 #endif
 
 #define PSTATS_UNIREC_TEMPLATE "PPI_PKT_LENGTHS,PPI_PKT_TIMES,PPI_PKT_FLAGS,PPI_PKT_DIRECTIONS"
 
-UR_FIELDS (
-   uint16* PPI_PKT_LENGTHS,
-   time* PPI_PKT_TIMES,
-   uint8* PPI_PKT_FLAGS,
-   int8* PPI_PKT_DIRECTIONS
-)
+UR_FIELDS(
+    uint16* PPI_PKT_LENGTHS,
+    time* PPI_PKT_TIMES,
+    uint8* PPI_PKT_FLAGS,
+    int8* PPI_PKT_DIRECTIONS)
 
-class PSTATSOptParser : public OptionsParser
-{
+class PSTATSOptParser : public OptionsParser {
 public:
-   bool m_include_zeroes;
-   bool m_skipdup;
+    bool m_include_zeroes;
+    bool m_skipdup;
 
-   PSTATSOptParser() : OptionsParser("pstats", "Processing plugin for packet stats"), m_include_zeroes(false), m_skipdup(false)
-   {
-      register_option("i", "includezeroes", "", "Include zero payload packets", [this](const char *arg){m_include_zeroes = true; return true;}, OptionFlags::NoArgument);
-      register_option("s", "skipdup", "", "Skip duplicated TCP packets", [this](const char *arg){m_skipdup = true; return true;}, OptionFlags::NoArgument);
-   }
+    PSTATSOptParser()
+        : OptionsParser("pstats", "Processing plugin for packet stats")
+        , m_include_zeroes(false)
+        , m_skipdup(false)
+    {
+        register_option(
+            "i",
+            "includezeroes",
+            "",
+            "Include zero payload packets",
+            [this](const char* arg) {
+                m_include_zeroes = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+        register_option(
+            "s",
+            "skipdup",
+            "",
+            "Skip duplicated TCP packets",
+            [this](const char* arg) {
+                m_skipdup = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
 /**
  * \brief Flow record extension header for storing parsed PSTATS packets.
  */
 struct RecordExtPSTATS : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t       pkt_sizes[PSTATS_MAXELEMCOUNT];
-   uint8_t        pkt_tcp_flgs[PSTATS_MAXELEMCOUNT];
-   struct timeval pkt_timestamps[PSTATS_MAXELEMCOUNT];
-   int8_t         pkt_dirs[PSTATS_MAXELEMCOUNT];
-   uint16_t       pkt_count;
-   uint32_t       tcp_seq[2];
-   uint32_t       tcp_ack[2];
-   uint16_t       tcp_len[2];
-   uint8_t        tcp_flg[2];
+    uint16_t pkt_sizes[PSTATS_MAXELEMCOUNT];
+    uint8_t pkt_tcp_flgs[PSTATS_MAXELEMCOUNT];
+    struct timeval pkt_timestamps[PSTATS_MAXELEMCOUNT];
+    int8_t pkt_dirs[PSTATS_MAXELEMCOUNT];
+    uint16_t pkt_count;
+    uint32_t tcp_seq[2];
+    uint32_t tcp_ack[2];
+    uint16_t tcp_len[2];
+    uint8_t tcp_flg[2];
 
-   typedef enum eHdrFieldID {
-      PktSize  = 1013,
-      PktFlags = 1015,
-      PktDir   = 1016,
-      PktTmstp = 1014
-   } eHdrSemantic;
+    typedef enum eHdrFieldID {
+        PktSize = 1013,
+        PktFlags = 1015,
+        PktDir = 1016,
+        PktTmstp = 1014
+    } eHdrSemantic;
 
-   static const uint32_t CesnetPem = 8057;
+    static const uint32_t CesnetPem = 8057;
 
+    RecordExtPSTATS()
+        : RecordExt(REGISTERED_ID)
+    {
+        pkt_count = 0;
+    }
 
-   RecordExtPSTATS() : RecordExt(REGISTERED_ID)
-   {
-      pkt_count = 0;
-   }
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_array_allocate(tmplt, record, F_PPI_PKT_TIMES, pkt_count);
+        ur_array_allocate(tmplt, record, F_PPI_PKT_LENGTHS, pkt_count);
+        ur_array_allocate(tmplt, record, F_PPI_PKT_FLAGS, pkt_count);
+        ur_array_allocate(tmplt, record, F_PPI_PKT_DIRECTIONS, pkt_count);
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_array_allocate(tmplt, record, F_PPI_PKT_TIMES, pkt_count);
-      ur_array_allocate(tmplt, record, F_PPI_PKT_LENGTHS, pkt_count);
-      ur_array_allocate(tmplt, record, F_PPI_PKT_FLAGS, pkt_count);
-      ur_array_allocate(tmplt, record, F_PPI_PKT_DIRECTIONS, pkt_count);
+        for (int i = 0; i < pkt_count; i++) {
+            ur_time_t ts
+                = ur_time_from_sec_usec(pkt_timestamps[i].tv_sec, pkt_timestamps[i].tv_usec);
+            ur_array_set(tmplt, record, F_PPI_PKT_TIMES, i, ts);
+            ur_array_set(tmplt, record, F_PPI_PKT_LENGTHS, i, pkt_sizes[i]);
+            ur_array_set(tmplt, record, F_PPI_PKT_FLAGS, i, pkt_tcp_flgs[i]);
+            ur_array_set(tmplt, record, F_PPI_PKT_DIRECTIONS, i, pkt_dirs[i]);
+        }
+    }
 
-      for (int i = 0; i < pkt_count; i++) {
-         ur_time_t ts = ur_time_from_sec_usec(pkt_timestamps[i].tv_sec, pkt_timestamps[i].tv_usec);
-         ur_array_set(tmplt, record, F_PPI_PKT_TIMES, i, ts);
-         ur_array_set(tmplt, record, F_PPI_PKT_LENGTHS, i, pkt_sizes[i]);
-         ur_array_set(tmplt, record, F_PPI_PKT_FLAGS, i, pkt_tcp_flgs[i]);
-         ur_array_set(tmplt, record, F_PPI_PKT_DIRECTIONS, i, pkt_dirs[i]);
-      }
-   }
+    const char* get_unirec_tmplt() const { return PSTATS_UNIREC_TEMPLATE; }
+#endif // ifdef WITH_NEMEA
 
-   const char *get_unirec_tmplt() const
-   {
-      return PSTATS_UNIREC_TEMPLATE;
-   }
-   #endif // ifdef WITH_NEMEA
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int32_t bufferPtr;
+        IpfixBasicList basiclist;
+        basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
+        // Check sufficient size of buffer
+        int req_size = 4 * basiclist.HeaderSize() /* sizes, times, flags, dirs */
+            + pkt_count * sizeof(uint16_t) /* sizes */ + 2 * pkt_count * sizeof(uint32_t) /* times
+                                                                                           */
+            + pkt_count /* flags */ + pkt_count /* dirs */;
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int32_t bufferPtr;
-      IpfixBasicList basiclist;
-      basiclist.hdrEnterpriseNum = IpfixBasicList::CesnetPEM;
-      //Check sufficient size of buffer
-      int req_size = 4 * basiclist.HeaderSize() /* sizes, times, flags, dirs */ +
-                       pkt_count * sizeof(uint16_t) /* sizes */ +
-                       2 * pkt_count * sizeof(uint32_t) /* times */ +
-                       pkt_count /* flags */ +
-                       pkt_count /* dirs */;
+        if (req_size > size) {
+            return -1;
+        }
+        // Fill packet sizes
+        bufferPtr = basiclist.FillBuffer(buffer, pkt_sizes, pkt_count, (uint16_t) PktSize);
+        // Fill timestamps
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            pkt_timestamps,
+            pkt_count,
+            (uint16_t) PktTmstp);
+        // Fill tcp flags
+        bufferPtr += basiclist.FillBuffer(
+            buffer + bufferPtr,
+            pkt_tcp_flgs,
+            pkt_count,
+            (uint16_t) PktFlags);
+        // Fill directions
+        bufferPtr
+            += basiclist.FillBuffer(buffer + bufferPtr, pkt_dirs, pkt_count, (uint16_t) PktDir);
 
-      if (req_size > size) {
-         return -1;
-      }
-      // Fill packet sizes
-      bufferPtr = basiclist.FillBuffer(buffer, pkt_sizes, pkt_count, (uint16_t) PktSize);
-      // Fill timestamps
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, pkt_timestamps, pkt_count,(uint16_t) PktTmstp);
-      // Fill tcp flags
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, pkt_tcp_flgs, pkt_count, (uint16_t) PktFlags);
-      // Fill directions
-      bufferPtr += basiclist.FillBuffer(buffer + bufferPtr, pkt_dirs, pkt_count,(uint16_t) PktDir);
+        return bufferPtr;
+    } // fill_ipfix
 
-      return bufferPtr;
-   } // fill_ipfix
-
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_PSTATS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_tmplt;
-   }
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "ppisizes=(";
-      for (int i = 0; i < pkt_count; i++) {
-         out << pkt_sizes[i];
-         if (i != pkt_count - 1) {
-            out << ",";
-         }
-      }
-      out << "),ppitimes=(";
-      for (int i = 0; i < pkt_count; i++) {
-         out << pkt_timestamps[i].tv_sec << "." << pkt_timestamps[i].tv_usec;
-         if (i != pkt_count - 1) {
-            out << ",";
-         }
-      }
-      out << "),ppiflags=(";
-      for (int i = 0; i < pkt_count; i++) {
-         out << (uint16_t) pkt_tcp_flgs[i];
-         if (i != pkt_count - 1) {
-            out << ",";
-         }
-      }
-      out << "),ppidirs=(";
-      for (int i = 0; i < pkt_count; i++) {
-         out << (int16_t) pkt_dirs[i];
-         if (i != pkt_count - 1) {
-            out << ",";
-         }
-      }
-      out << ")";
-      return out.str();
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_PSTATS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_tmplt;
+    }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "ppisizes=(";
+        for (int i = 0; i < pkt_count; i++) {
+            out << pkt_sizes[i];
+            if (i != pkt_count - 1) {
+                out << ",";
+            }
+        }
+        out << "),ppitimes=(";
+        for (int i = 0; i < pkt_count; i++) {
+            out << pkt_timestamps[i].tv_sec << "." << pkt_timestamps[i].tv_usec;
+            if (i != pkt_count - 1) {
+                out << ",";
+            }
+        }
+        out << "),ppiflags=(";
+        for (int i = 0; i < pkt_count; i++) {
+            out << (uint16_t) pkt_tcp_flgs[i];
+            if (i != pkt_count - 1) {
+                out << ",";
+            }
+        }
+        out << "),ppidirs=(";
+        for (int i = 0; i < pkt_count; i++) {
+            out << (int16_t) pkt_dirs[i];
+            if (i != pkt_count - 1) {
+                out << ",";
+            }
+        }
+        out << ")";
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing PSTATS packets.
  */
-class PSTATSPlugin : public ProcessPlugin
-{
+class PSTATSPlugin : public ProcessPlugin {
 public:
-   PSTATSPlugin();
-   ~PSTATSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new PSTATSOptParser(); }
-   std::string get_name() const { return "pstats"; }
-   RecordExt *get_ext() const { return new RecordExtPSTATS(); }
-   ProcessPlugin *copy();
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void update_record(RecordExtPSTATS *pstats_data, const Packet &pkt);
-   void pre_export(Flow &rec);
+    PSTATSPlugin();
+    ~PSTATSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new PSTATSOptParser(); }
+    std::string get_name() const { return "pstats"; }
+    RecordExt* get_ext() const { return new RecordExtPSTATS(); }
+    ProcessPlugin* copy();
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void update_record(RecordExtPSTATS* pstats_data, const Packet& pkt);
+    void pre_export(Flow& rec);
 
 private:
-   bool use_zeros;
-   bool skip_dup_pkts;
+    bool use_zeros;
+    bool skip_dup_pkts;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_PSTATS_HPP */

--- a/process/quic.cpp
+++ b/process/quic.cpp
@@ -10,11 +10,9 @@
  * \date 2022
  */
 
-
 #ifdef WITH_NEMEA
-# include <unirec/unirec.h>
+#include <unirec/unirec.h>
 #endif
-
 
 #include "quic.hpp"
 
@@ -23,99 +21,96 @@ int RecordExtQUIC::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("quic", [](){
-         return new QUICPlugin();
-      });
+    static PluginRecord rec = PluginRecord("quic", []() { return new QUICPlugin(); });
 
-   register_plugin(&rec);
-   RecordExtQUIC::REGISTERED_ID = register_extension();
+    register_plugin(&rec);
+    RecordExtQUIC::REGISTERED_ID = register_extension();
 }
 
 QUICPlugin::QUICPlugin()
 {
-   quic_ptr = nullptr;
+    quic_ptr = nullptr;
 }
 
 QUICPlugin::~QUICPlugin()
 {
-   close();
+    close();
 }
 
-void QUICPlugin::init(const char *params)
-{ }
+void QUICPlugin::init(const char* params) {}
 
 void QUICPlugin::close()
 {
-   if (quic_ptr != nullptr) {
-      delete quic_ptr;
-   }
-   quic_ptr = nullptr;
+    if (quic_ptr != nullptr) {
+        delete quic_ptr;
+    }
+    quic_ptr = nullptr;
 }
 
-ProcessPlugin *QUICPlugin::copy()
+ProcessPlugin* QUICPlugin::copy()
 {
-   return new QUICPlugin(*this);
+    return new QUICPlugin(*this);
 }
 
-bool QUICPlugin::process_quic(RecordExtQUIC *quic_data, const Packet &pkt)
+bool QUICPlugin::process_quic(RecordExtQUIC* quic_data, const Packet& pkt)
 {
-   QUICParser process_quic;
+    QUICParser process_quic;
 
-   if (!process_quic.quic_start(pkt)) {
-      return false;
-   } else   {
-      process_quic.quic_get_sni(quic_data->sni);
-      process_quic.quic_get_user_agent(quic_data->user_agent);
-      process_quic.quic_get_version(quic_data->quic_version);
-      return true;
-   }
+    if (!process_quic.quic_start(pkt)) {
+        return false;
+    } else {
+        process_quic.quic_get_sni(quic_data->sni);
+        process_quic.quic_get_user_agent(quic_data->user_agent);
+        process_quic.quic_get_version(quic_data->quic_version);
+        return true;
+    }
 } // QUICPlugin::process_quic
 
-int QUICPlugin::pre_create(Packet &pkt)
+int QUICPlugin::pre_create(Packet& pkt)
 {
-   return 0;
+    return 0;
 }
 
-int QUICPlugin::post_create(Flow &rec, const Packet &pkt)
+int QUICPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   add_quic(rec, pkt);
-   return 0;
+    add_quic(rec, pkt);
+    return 0;
 }
 
-int QUICPlugin::pre_update(Flow &rec, Packet &pkt)
+int QUICPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   return 0;
+    return 0;
 }
 
-int QUICPlugin::post_update(Flow &rec, const Packet &pkt)
+int QUICPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   RecordExtQUIC *ext = (RecordExtQUIC *) rec.get_extension(RecordExtQUIC::REGISTERED_ID);
+    RecordExtQUIC* ext = (RecordExtQUIC*) rec.get_extension(RecordExtQUIC::REGISTERED_ID);
 
-   if (ext == nullptr) {
-      return 0;
-   }
+    if (ext == nullptr) {
+        return 0;
+    }
 
-   add_quic(rec, pkt);
-   return 0;
+    add_quic(rec, pkt);
+    return 0;
 }
 
-void QUICPlugin::add_quic(Flow &rec, const Packet &pkt)
+void QUICPlugin::add_quic(Flow& rec, const Packet& pkt)
 {
-   if (quic_ptr == nullptr) {
-      quic_ptr = new RecordExtQUIC();
-   }
+    if (quic_ptr == nullptr) {
+        quic_ptr = new RecordExtQUIC();
+    }
 
-   if (process_quic(quic_ptr, pkt)) {
-      rec.add_extension(quic_ptr);
-      quic_ptr = nullptr;
-   }
+    if (process_quic(quic_ptr, pkt)) {
+        rec.add_extension(quic_ptr);
+        quic_ptr = nullptr;
+    }
 }
 
 void QUICPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "QUIC plugin stats:" << std::endl;
-      std::cout << "   Parsed SNI: " << parsed_initial << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "QUIC plugin stats:" << std::endl;
+        std::cout << "   Parsed SNI: " << parsed_initial << std::endl;
+    }
 }
-}
+} // namespace ipxp

--- a/process/quic.hpp
+++ b/process/quic.hpp
@@ -10,128 +10,115 @@
  * \date 2022
  */
 
-
 #ifndef IPXP_PROCESS_QUIC_HPP
 #define IPXP_PROCESS_QUIC_HPP
 
-
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-
 #include "quic_parser.hpp"
-#include <ipfixprobe/utils.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/utils.hpp>
 #include <sstream>
-
 
 namespace ipxp {
 #define QUIC_UNIREC_TEMPLATE "QUIC_SNI,QUIC_USER_AGENT,QUIC_VERSION"
-UR_FIELDS(
-   string QUIC_SNI,
-   string QUIC_USER_AGENT,
-   uint32 QUIC_VERSION
-)
+UR_FIELDS(string QUIC_SNI, string QUIC_USER_AGENT, uint32 QUIC_VERSION)
 
 /**
  * \brief Flow record extension header for storing parsed QUIC packets.
  */
 struct RecordExtQUIC : public RecordExt {
-   static int REGISTERED_ID;
-   char       sni[BUFF_SIZE]        = { 0 };
-   char       user_agent[BUFF_SIZE] = { 0 };
-   uint32_t   quic_version;
+    static int REGISTERED_ID;
+    char sni[BUFF_SIZE] = {0};
+    char user_agent[BUFF_SIZE] = {0};
+    uint32_t quic_version;
 
-   RecordExtQUIC() : RecordExt(REGISTERED_ID)
-   {
-      sni[0]        = 0;
-      user_agent[0] = 0;
-      quic_version  = 0;
-   }
+    RecordExtQUIC()
+        : RecordExt(REGISTERED_ID)
+    {
+        sni[0] = 0;
+        user_agent[0] = 0;
+        quic_version = 0;
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set_string(tmplt, record, F_QUIC_SNI, sni);
-      ur_set_string(tmplt, record, F_QUIC_USER_AGENT, user_agent);
-      ur_set(tmplt, record, F_QUIC_VERSION, quic_version);
-   }
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set_string(tmplt, record, F_QUIC_SNI, sni);
+        ur_set_string(tmplt, record, F_QUIC_USER_AGENT, user_agent);
+        ur_set(tmplt, record, F_QUIC_VERSION, quic_version);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return QUIC_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return QUIC_UNIREC_TEMPLATE; }
 
-   #endif // ifdef WITH_NEMEA
+#endif // ifdef WITH_NEMEA
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      uint16_t len_sni        = strlen(sni);
-      uint16_t len_user_agent = strlen(user_agent);
-      uint16_t len_version    = sizeof(quic_version);
-      int pos = 0;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        uint16_t len_sni = strlen(sni);
+        uint16_t len_user_agent = strlen(user_agent);
+        uint16_t len_version = sizeof(quic_version);
+        int pos = 0;
 
-      if ((len_sni + 3) + (len_user_agent + 3) + len_version > size) {
-         return -1;
-      }
+        if ((len_sni + 3) + (len_user_agent + 3) + len_version > size) {
+            return -1;
+        }
 
-      pos += variable2ipfix_buffer(buffer + pos, (uint8_t *) sni, len_sni);
-      pos += variable2ipfix_buffer(buffer + pos, (uint8_t *) user_agent, len_user_agent);
-      *(uint32_t *) (buffer + pos) = htonl(quic_version);
-      pos += len_version;
-      return pos;
-   }
+        pos += variable2ipfix_buffer(buffer + pos, (uint8_t*) sni, len_sni);
+        pos += variable2ipfix_buffer(buffer + pos, (uint8_t*) user_agent, len_user_agent);
+        *(uint32_t*) (buffer + pos) = htonl(quic_version);
+        pos += len_version;
+        return pos;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_QUIC_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_QUIC_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_template;
-   }
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
+    std::string get_text() const
+    {
+        std::ostringstream out;
 
-      out << "quicsni=\"" << sni << "\"" << "quicuseragent=\"" << user_agent << "\"" << "quicversion=\"" <<
-           quic_version << "\"";
-      return out.str();
-   }
+        out << "quicsni=\"" << sni << "\""
+            << "quicuseragent=\"" << user_agent << "\""
+            << "quicversion=\"" << quic_version << "\"";
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing QUIC packets.
  */
-class QUICPlugin : public ProcessPlugin
-{
+class QUICPlugin : public ProcessPlugin {
 public:
-   QUICPlugin();
-   ~QUICPlugin();
-   void init(const char *params);
-   void close();
-   RecordExt *get_ext() const { return new RecordExtQUIC(); }
+    QUICPlugin();
+    ~QUICPlugin();
+    void init(const char* params);
+    void close();
+    RecordExt* get_ext() const { return new RecordExtQUIC(); }
 
-   OptionsParser *get_parser() const { return new OptionsParser("quic", "Parse QUIC traffic"); }
+    OptionsParser* get_parser() const { return new OptionsParser("quic", "Parse QUIC traffic"); }
 
-   std::string get_name() const { return "quic"; }
+    std::string get_name() const { return "quic"; }
 
-   ProcessPlugin *copy();
+    ProcessPlugin* copy();
 
-   int pre_create(Packet &pkt);
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void add_quic(Flow &rec, const Packet &pkt);
-   void finish(bool print_stats);
+    int pre_create(Packet& pkt);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void add_quic(Flow& rec, const Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   bool     process_quic(RecordExtQUIC *, const Packet&);
-   int parsed_initial;
-   RecordExtQUIC *quic_ptr;
+    bool process_quic(RecordExtQUIC*, const Packet&);
+    int parsed_initial;
+    RecordExtQUIC* quic_ptr;
 };
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_QUIC_HPP */

--- a/process/rtsp.cpp
+++ b/process/rtsp.cpp
@@ -26,9 +26,9 @@
  *
  */
 
-#include <iostream>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
+#include <iostream>
 
 #ifdef WITH_NEMEA
 #include <unirec/unirec.h>
@@ -43,12 +43,12 @@ int RecordExtRTSP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("rtsp", [](){return new RTSPPlugin();});
-   register_plugin(&rec);
-   RecordExtRTSP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("rtsp", []() { return new RTSPPlugin(); });
+    register_plugin(&rec);
+    RecordExtRTSP::REGISTERED_ID = register_extension();
 }
 
-//#define DEBUG_RTSP
+// #define DEBUG_RTSP
 
 // Print debug message if debugging is allowed.
 #ifdef DEBUG_RTSP
@@ -64,113 +64,115 @@ __attribute__((constructor)) static void register_this_plugin()
 #define DEBUG_CODE(code)
 #endif
 
-#define RTSP_LINE_DELIMITER   '\n'
+#define RTSP_LINE_DELIMITER '\n'
 #define RTSP_KEYVAL_DELIMITER ':'
 
-RTSPPlugin::RTSPPlugin() : recPrealloc(nullptr), flow_flush(false),
-   requests(0), responses(0), total(0)
+RTSPPlugin::RTSPPlugin()
+    : recPrealloc(nullptr)
+    , flow_flush(false)
+    , requests(0)
+    , responses(0)
+    , total(0)
 {
 }
 
 RTSPPlugin::~RTSPPlugin()
 {
-   close();
+    close();
 }
 
-void RTSPPlugin::init(const char *params)
-{
-}
+void RTSPPlugin::init(const char* params) {}
 
 void RTSPPlugin::close()
 {
-   if (recPrealloc != nullptr) {
-      delete recPrealloc;
-      recPrealloc = nullptr;
-   }
+    if (recPrealloc != nullptr) {
+        delete recPrealloc;
+        recPrealloc = nullptr;
+    }
 }
 
-ProcessPlugin *RTSPPlugin::copy()
+ProcessPlugin* RTSPPlugin::copy()
 {
-   return new RTSPPlugin(*this);
+    return new RTSPPlugin(*this);
 }
 
-int RTSPPlugin::post_create(Flow &rec, const Packet &pkt)
+int RTSPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   const char *payload = reinterpret_cast<const char *>(pkt.payload);
-   if (is_request(payload, pkt.payload_len)) {
-      add_ext_rtsp_request(payload, pkt.payload_len, rec);
-   } else if (is_response(payload, pkt.payload_len)) {
-      add_ext_rtsp_response(payload, pkt.payload_len, rec);
-   }
+    const char* payload = reinterpret_cast<const char*>(pkt.payload);
+    if (is_request(payload, pkt.payload_len)) {
+        add_ext_rtsp_request(payload, pkt.payload_len, rec);
+    } else if (is_response(payload, pkt.payload_len)) {
+        add_ext_rtsp_response(payload, pkt.payload_len, rec);
+    }
 
-   return 0;
+    return 0;
 }
 
-int RTSPPlugin::pre_update(Flow &rec, Packet &pkt)
+int RTSPPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   RecordExt *ext = nullptr;
-   const char *payload = reinterpret_cast<const char *>(pkt.payload);
-   if (is_request(payload, pkt.payload_len)) {
-      ext = rec.get_extension(RecordExtRTSP::REGISTERED_ID);
-      if (ext == nullptr) { /* Check if header is present in flow. */
-         add_ext_rtsp_request(payload, pkt.payload_len, rec);
-         return 0;
-      }
+    RecordExt* ext = nullptr;
+    const char* payload = reinterpret_cast<const char*>(pkt.payload);
+    if (is_request(payload, pkt.payload_len)) {
+        ext = rec.get_extension(RecordExtRTSP::REGISTERED_ID);
+        if (ext == nullptr) { /* Check if header is present in flow. */
+            add_ext_rtsp_request(payload, pkt.payload_len, rec);
+            return 0;
+        }
 
-      parse_rtsp_request(payload, pkt.payload_len, static_cast<RecordExtRTSP *>(ext));
-      if (flow_flush) {
-         flow_flush = false;
-         return FLOW_FLUSH_WITH_REINSERT;
-      }
-   } else if (is_response(payload, pkt.payload_len)) {
-      ext = rec.get_extension(RecordExtRTSP::REGISTERED_ID);
-      if (ext == nullptr) { /* Check if header is present in flow. */
-         add_ext_rtsp_response(payload, pkt.payload_len, rec);
-         return 0;
-      }
+        parse_rtsp_request(payload, pkt.payload_len, static_cast<RecordExtRTSP*>(ext));
+        if (flow_flush) {
+            flow_flush = false;
+            return FLOW_FLUSH_WITH_REINSERT;
+        }
+    } else if (is_response(payload, pkt.payload_len)) {
+        ext = rec.get_extension(RecordExtRTSP::REGISTERED_ID);
+        if (ext == nullptr) { /* Check if header is present in flow. */
+            add_ext_rtsp_response(payload, pkt.payload_len, rec);
+            return 0;
+        }
 
-      parse_rtsp_response(payload, pkt.payload_len, static_cast<RecordExtRTSP *>(ext));
-      if (flow_flush) {
-         flow_flush = false;
-         return FLOW_FLUSH_WITH_REINSERT;
-      }
-   }
+        parse_rtsp_response(payload, pkt.payload_len, static_cast<RecordExtRTSP*>(ext));
+        if (flow_flush) {
+            flow_flush = false;
+            return FLOW_FLUSH_WITH_REINSERT;
+        }
+    }
 
-   return 0;
+    return 0;
 }
 
 void RTSPPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "RTSP plugin stats:" << std::endl;
-      std::cout << "   Parsed rtsp requests: " << requests << std::endl;
-      std::cout << "   Parsed rtsp responses: " << responses << std::endl;
-      std::cout << "   Total rtsp packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "RTSP plugin stats:" << std::endl;
+        std::cout << "   Parsed rtsp requests: " << requests << std::endl;
+        std::cout << "   Parsed rtsp responses: " << responses << std::endl;
+        std::cout << "   Total rtsp packets processed: " << total << std::endl;
+    }
 }
 
-bool RTSPPlugin::is_request(const char *data, int payload_len)
+bool RTSPPlugin::is_request(const char* data, int payload_len)
 {
-   char chars[5];
+    char chars[5];
 
-   if (payload_len < 4) {
-      return false;
-   }
-   memcpy(chars, data, 4);
-   chars[4] = 0;
-   return valid_rtsp_method(chars);
+    if (payload_len < 4) {
+        return false;
+    }
+    memcpy(chars, data, 4);
+    chars[4] = 0;
+    return valid_rtsp_method(chars);
 }
 
-bool RTSPPlugin::is_response(const char *data, int payload_len)
+bool RTSPPlugin::is_response(const char* data, int payload_len)
 {
-   char chars[5];
+    char chars[5];
 
-   if (payload_len < 4) {
-      return false;
-   }
-   memcpy(chars, data, 4);
-   chars[4] = 0;
-   return !strcmp(chars, "RTSP");
+    if (payload_len < 4) {
+        return false;
+    }
+    memcpy(chars, data, 4);
+    chars[4] = 0;
+    return !strcmp(chars, "RTSP");
 }
 
 #ifdef DEBUG_RTSP
@@ -184,131 +186,132 @@ static uint32_t s_requests = 0, s_responses = 0;
  * \param [out] rec Variable where rtsp request will be stored.
  * \return True if request was parsed, false if error occured.
  */
-bool RTSPPlugin::parse_rtsp_request(const char *data, int payload_len, RecordExtRTSP *rec)
+bool RTSPPlugin::parse_rtsp_request(const char* data, int payload_len, RecordExtRTSP* rec)
 {
-   char buffer[64];
-   const char *begin;
-   const char *end;
-   const char *keyval_delimiter;
-   size_t remaining;
+    char buffer[64];
+    const char* begin;
+    const char* end;
+    const char* keyval_delimiter;
+    size_t remaining;
 
-   total++;
+    total++;
 
-   DEBUG_MSG("---------- rtsp parser #%u ----------\n", total);
-   DEBUG_MSG("Parsing request number: %u\n", ++s_requests);
-   DEBUG_MSG("Payload length: %u\n\n",       payload_len);
+    DEBUG_MSG("---------- rtsp parser #%u ----------\n", total);
+    DEBUG_MSG("Parsing request number: %u\n", ++s_requests);
+    DEBUG_MSG("Payload length: %u\n\n", payload_len);
 
-   if (payload_len == 0) {
-      DEBUG_MSG("Parser quits:\tpayload length = 0\n");
-      return false;
-   }
+    if (payload_len == 0) {
+        DEBUG_MSG("Parser quits:\tpayload length = 0\n");
+        return false;
+    }
 
-   /* Request line:
-    *
-    * METHOD URI VERSION
-    * |     |   |
-    * |     |   -------- end
-    * |     ------------ begin
-    * ----- ------------ data
-    */
+    /* Request line:
+     *
+     * METHOD URI VERSION
+     * |     |   |
+     * |     |   -------- end
+     * |     ------------ begin
+     * ----- ------------ data
+     */
 
-   /* Find begin of URI. */
-   begin = static_cast<const char *>(memchr(data, ' ', payload_len));
-   if (begin == nullptr) {
-      DEBUG_MSG("Parser quits:\tnot a rtsp request header\n");
-      return false;
-   }
+    /* Find begin of URI. */
+    begin = static_cast<const char*>(memchr(data, ' ', payload_len));
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tnot a rtsp request header\n");
+        return false;
+    }
 
-   /* Find end of URI. */
-   
-   if (check_payload_len(payload_len, (begin + 1) - data)) {
-      DEBUG_MSG("Parser quits:\tpayload end\n");
-      return false;
-   }
-   remaining = payload_len - ((begin + 1) - data);
-   end = static_cast<const char *>(memchr(begin + 1, ' ', remaining));
-   if (end == nullptr) {
-      DEBUG_MSG("Parser quits:\trequest is fragmented\n");
-      return false;
-   }
+    /* Find end of URI. */
 
-   if (memcmp(end + 1, "RTSP", 4)) {
-      DEBUG_MSG("Parser quits:\tnot a RTSP request\n");
-      return false;
-   }
+    if (check_payload_len(payload_len, (begin + 1) - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - ((begin + 1) - data);
+    end = static_cast<const char*>(memchr(begin + 1, ' ', remaining));
+    if (end == nullptr) {
+        DEBUG_MSG("Parser quits:\trequest is fragmented\n");
+        return false;
+    }
 
-   /* Copy and check RTSP method */
-   copy_str(buffer, sizeof(buffer), data, begin);
-   if (rec->req) {
-      flow_flush = true;
-      total--;
-      DEBUG_MSG("Parser quits:\tflushing flow\n");
-      return false;
-   }
-   strncpy(rec->method, buffer, sizeof(rec->method));
-   rec->method[sizeof(rec->method) - 1] = 0;
+    if (memcmp(end + 1, "RTSP", 4)) {
+        DEBUG_MSG("Parser quits:\tnot a RTSP request\n");
+        return false;
+    }
 
-   copy_str(rec->uri, sizeof(rec->uri), begin + 1, end);
-   DEBUG_MSG("\tMethod: %s\n",   rec->method);
-   DEBUG_MSG("\tURI: %s\n",      rec->uri);
+    /* Copy and check RTSP method */
+    copy_str(buffer, sizeof(buffer), data, begin);
+    if (rec->req) {
+        flow_flush = true;
+        total--;
+        DEBUG_MSG("Parser quits:\tflushing flow\n");
+        return false;
+    }
+    strncpy(rec->method, buffer, sizeof(rec->method));
+    rec->method[sizeof(rec->method) - 1] = 0;
 
-   /* Find begin of next line after request line. */
-   if (check_payload_len(payload_len, end - data)) {
-      DEBUG_MSG("Parser quits:\tpayload end\n");
-      return false;
-   }
-   remaining = payload_len - (end - data);
-   begin = static_cast<const char *>(memchr(end, RTSP_LINE_DELIMITER, remaining));
-   if (begin == nullptr) {
-      DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
-      return false;
-   }
-   begin++;
+    copy_str(rec->uri, sizeof(rec->uri), begin + 1, end);
+    DEBUG_MSG("\tMethod: %s\n", rec->method);
+    DEBUG_MSG("\tURI: %s\n", rec->uri);
 
-   /* Header:
-    *
-    * REQ-FIELD: VALUE
-    * |        |      |
-    * |        |      ----- end
-    * |        ------------ keyval_delimiter
-    * --------------------- begin
-    */
+    /* Find begin of next line after request line. */
+    if (check_payload_len(payload_len, end - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - (end - data);
+    begin = static_cast<const char*>(memchr(end, RTSP_LINE_DELIMITER, remaining));
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
+        return false;
+    }
+    begin++;
 
-   rec->user_agent[0] = 0;
-   /* Process headers. */
-   while (begin - data < payload_len) {
-      remaining = payload_len - (begin - data);
-      end = static_cast<const char *>(memchr(begin, RTSP_LINE_DELIMITER, remaining));
-      keyval_delimiter = static_cast<const char *>(memchr(begin, RTSP_KEYVAL_DELIMITER, remaining));
+    /* Header:
+     *
+     * REQ-FIELD: VALUE
+     * |        |      |
+     * |        |      ----- end
+     * |        ------------ keyval_delimiter
+     * --------------------- begin
+     */
 
-      int tmp = end - begin;
-      if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
-         break; /* Double LF found - end of header section. */
-      } else if (end == nullptr || keyval_delimiter == NULL) {
-         DEBUG_MSG("Parser quits:\theader is fragmented\n");
-         return  false;
-      }
+    rec->user_agent[0] = 0;
+    /* Process headers. */
+    while (begin - data < payload_len) {
+        remaining = payload_len - (begin - data);
+        end = static_cast<const char*>(memchr(begin, RTSP_LINE_DELIMITER, remaining));
+        keyval_delimiter
+            = static_cast<const char*>(memchr(begin, RTSP_KEYVAL_DELIMITER, remaining));
 
-      /* Copy field name. */
-      copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
+        int tmp = end - begin;
+        if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
+            break; /* Double LF found - end of header section. */
+        } else if (end == nullptr || keyval_delimiter == NULL) {
+            DEBUG_MSG("Parser quits:\theader is fragmented\n");
+            return false;
+        }
 
-      DEBUG_CODE(char debug_buffer[4096]);
-      DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
-      DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
+        /* Copy field name. */
+        copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
 
-      /* Copy interesting field values. */
-      if (!strcmp(buffer, "User-Agent")) {
-         copy_str(rec->user_agent, sizeof(rec->user_agent), keyval_delimiter + 2, end);
-      }
+        DEBUG_CODE(char debug_buffer[4096]);
+        DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
+        DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
 
-      /* Go to next line. */
-      begin = end + 1 ;
-   }
+        /* Copy interesting field values. */
+        if (!strcmp(buffer, "User-Agent")) {
+            copy_str(rec->user_agent, sizeof(rec->user_agent), keyval_delimiter + 2, end);
+        }
 
-   DEBUG_MSG("Parser quits:\tend of header section\n");
-   rec->req = true;
-   requests++;
-   return true;
+        /* Go to next line. */
+        begin = end + 1;
+    }
+
+    DEBUG_MSG("Parser quits:\tend of header section\n");
+    rec->req = true;
+    requests++;
+    return true;
 }
 
 /**
@@ -318,136 +321,137 @@ bool RTSPPlugin::parse_rtsp_request(const char *data, int payload_len, RecordExt
  * \param [out] rec Variable where rtsp response will be stored.
  * \return True if request was parsed, false if error occured.
  */
-bool RTSPPlugin::parse_rtsp_response(const char *data, int payload_len, RecordExtRTSP *rec)
+bool RTSPPlugin::parse_rtsp_response(const char* data, int payload_len, RecordExtRTSP* rec)
 {
-   char buffer[64];
-   const char *begin;
-   const char *end;
-   const char *keyval_delimiter;
-   size_t remaining;
-   int code;
+    char buffer[64];
+    const char* begin;
+    const char* end;
+    const char* keyval_delimiter;
+    size_t remaining;
+    int code;
 
-   total++;
+    total++;
 
-   DEBUG_MSG("---------- rtsp parser #%u ----------\n", total);
-   DEBUG_MSG("Parsing response number: %u\n",   ++s_responses);
-   DEBUG_MSG("Payload length: %u\n\n",          payload_len);
+    DEBUG_MSG("---------- rtsp parser #%u ----------\n", total);
+    DEBUG_MSG("Parsing response number: %u\n", ++s_responses);
+    DEBUG_MSG("Payload length: %u\n\n", payload_len);
 
-   if (payload_len == 0) {
-      DEBUG_MSG("Parser quits:\tpayload length = 0\n");
-      return false;
-   }
+    if (payload_len == 0) {
+        DEBUG_MSG("Parser quits:\tpayload length = 0\n");
+        return false;
+    }
 
-   /* Check begin of response header. */
-   if (memcmp(data, "RTSP", 4)) {
-      DEBUG_MSG("Parser quits:\tpacket contains rtsp response data\n");
-      return false;
-   }
+    /* Check begin of response header. */
+    if (memcmp(data, "RTSP", 4)) {
+        DEBUG_MSG("Parser quits:\tpacket contains rtsp response data\n");
+        return false;
+    }
 
-   /* Response line:
-    *
-    * VERSION CODE REASON
-    * |      |    |
-    * |      |    --------- end
-    * |      -------------- begin
-    * --------------------- data
-    */
+    /* Response line:
+     *
+     * VERSION CODE REASON
+     * |      |    |
+     * |      |    --------- end
+     * |      -------------- begin
+     * --------------------- data
+     */
 
-   /* Find begin of status code. */
-   begin = static_cast<const char *>(memchr(data, ' ', payload_len));
-   if (begin == nullptr) {
-      DEBUG_MSG("Parser quits:\tnot a rtsp response header\n");
-      return false;
-   }
+    /* Find begin of status code. */
+    begin = static_cast<const char*>(memchr(data, ' ', payload_len));
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tnot a rtsp response header\n");
+        return false;
+    }
 
-   /* Find end of status code. */
-   if (check_payload_len(payload_len, (begin + 1) - data)) {
-      DEBUG_MSG("Parser quits:\tpayload end\n");
-      return false;
-   }
-   remaining = payload_len - ((begin + 1) - data);
-   end = static_cast<const char *>(memchr(begin + 1, ' ', remaining));
-   if (end == nullptr) {
-      DEBUG_MSG("Parser quits:\tresponse is fragmented\n");
-      return false;
-   }
+    /* Find end of status code. */
+    if (check_payload_len(payload_len, (begin + 1) - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - ((begin + 1) - data);
+    end = static_cast<const char*>(memchr(begin + 1, ' ', remaining));
+    if (end == nullptr) {
+        DEBUG_MSG("Parser quits:\tresponse is fragmented\n");
+        return false;
+    }
 
-   /* Copy and check RTSP response code. */
-   copy_str(buffer, sizeof(buffer), begin + 1, end);
-   code = atoi(buffer);
-   if (code <= 0) {
-      DEBUG_MSG("Parser quits:\twrong response code: %d\n", code);
-      return false;
-   }
+    /* Copy and check RTSP response code. */
+    copy_str(buffer, sizeof(buffer), begin + 1, end);
+    code = atoi(buffer);
+    if (code <= 0) {
+        DEBUG_MSG("Parser quits:\twrong response code: %d\n", code);
+        return false;
+    }
 
-   DEBUG_MSG("\tCode: %d\n", code);
-   if (rec->resp) {
-      flow_flush = true;
-      total--;
-      DEBUG_MSG("Parser quits:\tflushing flow\n");
-      return false;
-   }
-   rec->code = code;
+    DEBUG_MSG("\tCode: %d\n", code);
+    if (rec->resp) {
+        flow_flush = true;
+        total--;
+        DEBUG_MSG("Parser quits:\tflushing flow\n");
+        return false;
+    }
+    rec->code = code;
 
-   /* Find begin of next line after request line. */
-   if (check_payload_len(payload_len, end - data)) {
-      DEBUG_MSG("Parser quits:\tpayload end\n");
-      return false;
-   }
-   remaining = payload_len - (end - data);
-   begin = static_cast<const char *>(memchr(end, RTSP_LINE_DELIMITER, remaining));
-   if (begin == nullptr) {
-      DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
-      return false;
-   }
-   begin++;
+    /* Find begin of next line after request line. */
+    if (check_payload_len(payload_len, end - data)) {
+        DEBUG_MSG("Parser quits:\tpayload end\n");
+        return false;
+    }
+    remaining = payload_len - (end - data);
+    begin = static_cast<const char*>(memchr(end, RTSP_LINE_DELIMITER, remaining));
+    if (begin == nullptr) {
+        DEBUG_MSG("Parser quits:\tNo line delim after request line\n");
+        return false;
+    }
+    begin++;
 
-   /* Header:
-    *
-    * REQ-FIELD: VALUE
-    * |        |      |
-    * |        |      ----- end
-    * |        ------------ keyval_delimiter
-    * --------------------- begin
-    */
+    /* Header:
+     *
+     * REQ-FIELD: VALUE
+     * |        |      |
+     * |        |      ----- end
+     * |        ------------ keyval_delimiter
+     * --------------------- begin
+     */
 
-   rec->content_type[0] = 0;
-   /* Process headers. */
-   while (begin - data < payload_len) {
-      remaining = payload_len - (begin - data);
-      end = static_cast<const char *>(memchr(begin, RTSP_LINE_DELIMITER, remaining));
-      keyval_delimiter = static_cast<const char *>(memchr(begin, RTSP_KEYVAL_DELIMITER, remaining));
+    rec->content_type[0] = 0;
+    /* Process headers. */
+    while (begin - data < payload_len) {
+        remaining = payload_len - (begin - data);
+        end = static_cast<const char*>(memchr(begin, RTSP_LINE_DELIMITER, remaining));
+        keyval_delimiter
+            = static_cast<const char*>(memchr(begin, RTSP_KEYVAL_DELIMITER, remaining));
 
-      int tmp = end - begin;
-      if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
-         break; /* Double LF found - end of header section. */
-      } else if (end == nullptr || keyval_delimiter == NULL) {
-         DEBUG_MSG("Parser quits:\theader is fragmented\n");
-         return  false;
-      }
+        int tmp = end - begin;
+        if (tmp == 0 || tmp == 1) { /* Check for blank line with \r\n or \n ending. */
+            break; /* Double LF found - end of header section. */
+        } else if (end == nullptr || keyval_delimiter == NULL) {
+            DEBUG_MSG("Parser quits:\theader is fragmented\n");
+            return false;
+        }
 
-      /* Copy field name. */
-      copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
+        /* Copy field name. */
+        copy_str(buffer, sizeof(buffer), begin, keyval_delimiter);
 
-      DEBUG_CODE(char debug_buffer[4096]);
-      DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
-      DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
+        DEBUG_CODE(char debug_buffer[4096]);
+        DEBUG_CODE(copy_str(debug_buffer, sizeof(debug_buffer), keyval_delimiter + 2, end));
+        DEBUG_MSG("\t%s: %s\n", buffer, debug_buffer);
 
-      /* Copy interesting field values. */
-      if (!strcmp(buffer, "Content-Type")) {
-         copy_str(rec->content_type, sizeof(rec->content_type), keyval_delimiter + 2, end);
-      } else if (!strcmp(buffer, "Server")) {
-         copy_str(rec->server, sizeof(rec->server), keyval_delimiter + 2, end);
-      }
+        /* Copy interesting field values. */
+        if (!strcmp(buffer, "Content-Type")) {
+            copy_str(rec->content_type, sizeof(rec->content_type), keyval_delimiter + 2, end);
+        } else if (!strcmp(buffer, "Server")) {
+            copy_str(rec->server, sizeof(rec->server), keyval_delimiter + 2, end);
+        }
 
-      /* Go to next line. */
-      begin = end + 1 ;
-   }
+        /* Go to next line. */
+        begin = end + 1;
+    }
 
-   DEBUG_MSG("Parser quits:\tend of header section\n");
-   rec->resp = true;
-   responses++;
-   return true;
+    DEBUG_MSG("Parser quits:\tend of header section\n");
+    rec->resp = true;
+    responses++;
+    return true;
 }
 
 /**
@@ -455,17 +459,15 @@ bool RTSPPlugin::parse_rtsp_response(const char *data, int payload_len, RecordEx
  * \param [in] method C string with rtsp method.
  * \return True if rtsp method is valid.
  */
-bool RTSPPlugin::valid_rtsp_method(const char *method) const
+bool RTSPPlugin::valid_rtsp_method(const char* method) const
 {
-   return (!strcmp(method, "GET ") || !strcmp(method, "POST") ||
-           !strcmp(method, "PUT ") || !strcmp(method, "HEAD") ||
-           !strcmp(method, "DELE") || !strcmp(method, "TRAC") ||
-           !strcmp(method, "OPTI") || !strcmp(method, "CONN") ||
-           !strcmp(method, "PATC") ||
-           !strcmp(method, "DESC") || !strcmp(method, "SETU") ||
-           !strcmp(method, "PLAY") || !strcmp(method, "PAUS") ||
-           !strcmp(method, "TEAR") || !strcmp(method, "RECO") ||
-           !strcmp(method, "ANNO"));
+    return (
+        !strcmp(method, "GET ") || !strcmp(method, "POST") || !strcmp(method, "PUT ")
+        || !strcmp(method, "HEAD") || !strcmp(method, "DELE") || !strcmp(method, "TRAC")
+        || !strcmp(method, "OPTI") || !strcmp(method, "CONN") || !strcmp(method, "PATC")
+        || !strcmp(method, "DESC") || !strcmp(method, "SETU") || !strcmp(method, "PLAY")
+        || !strcmp(method, "PAUS") || !strcmp(method, "TEAR") || !strcmp(method, "RECO")
+        || !strcmp(method, "ANNO"));
 }
 
 /**
@@ -474,16 +476,16 @@ bool RTSPPlugin::valid_rtsp_method(const char *method) const
  * \param [in] payload_len Length of packet payload.
  * \param [out] flow Flow record where to store created extension header.
  */
-void RTSPPlugin::add_ext_rtsp_request(const char *data, int payload_len, Flow &flow)
+void RTSPPlugin::add_ext_rtsp_request(const char* data, int payload_len, Flow& flow)
 {
-   if (recPrealloc == nullptr) {
-      recPrealloc = new RecordExtRTSP();
-   }
+    if (recPrealloc == nullptr) {
+        recPrealloc = new RecordExtRTSP();
+    }
 
-   if (parse_rtsp_request(data, payload_len, recPrealloc)) {
-      flow.add_extension(recPrealloc);
-      recPrealloc = nullptr;
-   }
+    if (parse_rtsp_request(data, payload_len, recPrealloc)) {
+        flow.add_extension(recPrealloc);
+        recPrealloc = nullptr;
+    }
 }
 
 /**
@@ -492,16 +494,16 @@ void RTSPPlugin::add_ext_rtsp_request(const char *data, int payload_len, Flow &f
  * \param [in] payload_len Length of packet payload.
  * \param [out] flow Flow record where to store created extension header.
  */
-void RTSPPlugin::add_ext_rtsp_response(const char *data, int payload_len, Flow &flow)
+void RTSPPlugin::add_ext_rtsp_response(const char* data, int payload_len, Flow& flow)
 {
-   if (recPrealloc == nullptr) {
-      recPrealloc = new RecordExtRTSP();
-   }
+    if (recPrealloc == nullptr) {
+        recPrealloc = new RecordExtRTSP();
+    }
 
-   if (parse_rtsp_response(data, payload_len, recPrealloc)) {
-      flow.add_extension(recPrealloc);
-      recPrealloc = nullptr;
-   }
+    if (parse_rtsp_response(data, payload_len, recPrealloc)) {
+        flow.add_extension(recPrealloc);
+        recPrealloc = nullptr;
+    }
 }
 
-}
+} // namespace ipxp

--- a/process/rtsp.hpp
+++ b/process/rtsp.hpp
@@ -29,8 +29,8 @@
 #ifndef IPXP_PROCESS_RTSP_HPP
 #define IPXP_PROCESS_RTSP_HPP
 
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 
@@ -38,189 +38,183 @@
 #include <fields.h>
 #endif
 
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
-#include <ipfixprobe/ipfix-elements.hpp>
 #include "http.hpp"
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
-#define RTSP_UNIREC_TEMPLATE "RTSP_REQUEST_METHOD,RTSP_REQUEST_AGENT,RTSP_REQUEST_URI,RTSP_RESPONSE_STATUS_CODE,RTSP_RESPONSE_SERVER,RTSP_RESPONSE_CONTENT_TYPE"
-UR_FIELDS (
-   string RTSP_REQUEST_METHOD,
-   string RTSP_REQUEST_AGENT,
-   string RTSP_REQUEST_URI,
+#define RTSP_UNIREC_TEMPLATE                                                                       \
+    "RTSP_REQUEST_METHOD,RTSP_REQUEST_AGENT,RTSP_REQUEST_URI,RTSP_RESPONSE_STATUS_CODE,RTSP_"      \
+    "RESPONSE_SERVER,RTSP_RESPONSE_CONTENT_TYPE"
+UR_FIELDS(
+    string RTSP_REQUEST_METHOD,
+    string RTSP_REQUEST_AGENT,
+    string RTSP_REQUEST_URI,
 
-   uint16 RTSP_RESPONSE_STATUS_CODE,
-   string RTSP_RESPONSE_SERVER,
-   string RTSP_RESPONSE_CONTENT_TYPE
-)
+    uint16 RTSP_RESPONSE_STATUS_CODE,
+    string RTSP_RESPONSE_SERVER,
+    string RTSP_RESPONSE_CONTENT_TYPE)
 
 /**
  * \brief Flow record extension header for storing RTSP requests.
  */
 struct RecordExtRTSP : public RecordExt {
-   static int REGISTERED_ID;
-   bool req;
-   bool resp;
+    static int REGISTERED_ID;
+    bool req;
+    bool resp;
 
-   char method[10];
-   char user_agent[128];
-   char uri[128];
+    char method[10];
+    char user_agent[128];
+    char uri[128];
 
+    uint16_t code;
+    char content_type[32];
+    char server[128];
 
-   uint16_t code;
-   char content_type[32];
-   char server[128];
+    /**
+     * \brief Constructor.
+     */
+    RecordExtRTSP()
+        : RecordExt(REGISTERED_ID)
+    {
+        req = false;
+        resp = false;
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtRTSP() : RecordExt(REGISTERED_ID)
-   {
-      req = false;
-      resp = false;
+        method[0] = 0;
+        user_agent[0] = 0;
+        uri[0] = 0;
 
-      method[0] = 0;
-      user_agent[0] = 0;
-      uri[0] = 0;
-
-      code = 0;
-      content_type[0] = 0;
-      server[0] = 0;
-   }
+        code = 0;
+        content_type[0] = 0;
+        server[0] = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set_string(tmplt, record, F_RTSP_REQUEST_METHOD, method);
-      ur_set_string(tmplt, record, F_RTSP_REQUEST_AGENT, user_agent);
-      ur_set_string(tmplt, record, F_RTSP_REQUEST_URI, uri);
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set_string(tmplt, record, F_RTSP_REQUEST_METHOD, method);
+        ur_set_string(tmplt, record, F_RTSP_REQUEST_AGENT, user_agent);
+        ur_set_string(tmplt, record, F_RTSP_REQUEST_URI, uri);
 
-      ur_set(tmplt, record, F_RTSP_RESPONSE_STATUS_CODE, code);
-      ur_set_string(tmplt, record, F_RTSP_RESPONSE_SERVER, server);
-      ur_set_string(tmplt, record, F_RTSP_RESPONSE_CONTENT_TYPE, content_type);
-   }
+        ur_set(tmplt, record, F_RTSP_RESPONSE_STATUS_CODE, code);
+        ur_set_string(tmplt, record, F_RTSP_RESPONSE_SERVER, server);
+        ur_set_string(tmplt, record, F_RTSP_RESPONSE_CONTENT_TYPE, content_type);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return RTSP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return RTSP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length, total_length = 0;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length, total_length = 0;
 
-      // Method
-      length = strlen(method);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, method, length);
-      total_length += length + 1;
+        // Method
+        length = strlen(method);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, method, length);
+        total_length += length + 1;
 
-      // User Agent
-      length = strlen(user_agent);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, user_agent, length);
-      total_length += length + 1;
+        // User Agent
+        length = strlen(user_agent);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, user_agent, length);
+        total_length += length + 1;
 
-      // URI
-      length = strlen(uri);
-      if (total_length + length + 3 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, uri, length);
-      total_length += length + 1;
+        // URI
+        length = strlen(uri);
+        if (total_length + length + 3 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, uri, length);
+        total_length += length + 1;
 
-      // Response code
-      *(uint16_t *) (buffer + total_length) = ntohs(code);
-      total_length += 2;
+        // Response code
+        *(uint16_t*) (buffer + total_length) = ntohs(code);
+        total_length += 2;
 
-      // Server
-      length = strlen(server);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, server, length);
-      total_length += length + 1;
+        // Server
+        length = strlen(server);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, server, length);
+        total_length += length + 1;
 
-      // Content type
-      length = strlen(content_type);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, content_type, length);
-      total_length += length + 1;
+        // Content type
+        length = strlen(content_type);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, content_type, length);
+        total_length += length + 1;
 
-      return total_length;
-   }
+        return total_length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_RTSP_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_RTSP_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "httpmethod=\"" << method << "\""
-         << ",uri=\"" << uri << "\""
-         << ",agent=\"" << user_agent << "\""
-         << ",server=\"" << server << "\""
-         << ",content=\"" << content_type << "\""
-         << ",status=" << code;
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "httpmethod=\"" << method << "\""
+            << ",uri=\"" << uri << "\""
+            << ",agent=\"" << user_agent << "\""
+            << ",server=\"" << server << "\""
+            << ",content=\"" << content_type << "\""
+            << ",status=" << code;
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin used to parse RTSP requests / responses.
  */
-class RTSPPlugin : public ProcessPlugin
-{
+class RTSPPlugin : public ProcessPlugin {
 public:
-   RTSPPlugin();
-   ~RTSPPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("rtsp", "Parse RTSP traffic"); }
-   std::string get_name() const { return "rtsp"; }
-   RecordExt *get_ext() const { return new RecordExtRTSP(); }
-   ProcessPlugin *copy();
+    RTSPPlugin();
+    ~RTSPPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("rtsp", "Parse RTSP traffic"); }
+    std::string get_name() const { return "rtsp"; }
+    RecordExt* get_ext() const { return new RecordExtRTSP(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   bool is_response(const char *data, int payload_len);
-   bool is_request(const char *data, int payload_len);
-   bool parse_rtsp_request(const char *data, int payload_len, RecordExtRTSP *rec);
-   bool parse_rtsp_response(const char *data, int payload_len, RecordExtRTSP *rec);
-   void add_ext_rtsp_request(const char *data, int payload_len, Flow &flow);
-   void add_ext_rtsp_response(const char *data, int payload_len, Flow &flow);
-   bool valid_rtsp_method(const char *method) const;
+    bool is_response(const char* data, int payload_len);
+    bool is_request(const char* data, int payload_len);
+    bool parse_rtsp_request(const char* data, int payload_len, RecordExtRTSP* rec);
+    bool parse_rtsp_response(const char* data, int payload_len, RecordExtRTSP* rec);
+    void add_ext_rtsp_request(const char* data, int payload_len, Flow& flow);
+    void add_ext_rtsp_response(const char* data, int payload_len, Flow& flow);
+    bool valid_rtsp_method(const char* method) const;
 
-   RecordExtRTSP *recPrealloc;/**< Preallocated extension. */
-   bool flow_flush;           /**< Tell storage plugin to flush current Flow. */
-   uint32_t requests;         /**< Total number of parsed RTSP requests. */
-   uint32_t responses;        /**< Total number of parsed RTSP responses. */
-   uint32_t total;            /**< Total number of parsed RTSP packets. */
+    RecordExtRTSP* recPrealloc; /**< Preallocated extension. */
+    bool flow_flush; /**< Tell storage plugin to flush current Flow. */
+    uint32_t requests; /**< Total number of parsed RTSP requests. */
+    uint32_t responses; /**< Total number of parsed RTSP responses. */
+    uint32_t total; /**< Total number of parsed RTSP packets. */
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_RTSP_HPP */

--- a/process/sip.cpp
+++ b/process/sip.cpp
@@ -26,9 +26,9 @@
  *
  */
 
-#include <iostream>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
 #ifdef WITH_NEMEA
 #include <unirec/unirec.h>
@@ -42,523 +42,582 @@ int RecordExtSIP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("sip", [](){return new SIPPlugin();});
-   register_plugin(&rec);
-   RecordExtSIP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("sip", []() { return new SIPPlugin(); });
+    register_plugin(&rec);
+    RecordExtSIP::REGISTERED_ID = register_extension();
 }
 
-SIPPlugin::SIPPlugin() : requests(0), responses(0), total(0), flow_flush(false)
+SIPPlugin::SIPPlugin()
+    : requests(0)
+    , responses(0)
+    , total(0)
+    , flow_flush(false)
 {
 }
 
 SIPPlugin::~SIPPlugin()
 {
-   close();
+    close();
 }
 
-void SIPPlugin::init(const char *params)
+void SIPPlugin::init(const char* params) {}
+
+void SIPPlugin::close() {}
+
+ProcessPlugin* SIPPlugin::copy()
 {
+    return new SIPPlugin(*this);
 }
 
-void SIPPlugin::close()
+int SIPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
+    uint16_t msg_type;
+
+    msg_type = parse_msg_type(pkt);
+    if (msg_type == SIP_MSG_TYPE_INVALID) {
+        return 0;
+    }
+
+    RecordExtSIP* sip_data = new RecordExtSIP();
+    sip_data->msg_type = msg_type;
+    rec.add_extension(sip_data);
+    parser_process_sip(pkt, sip_data);
+
+    return 0;
 }
 
-ProcessPlugin *SIPPlugin::copy()
+int SIPPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   return new SIPPlugin(*this);
-}
+    uint16_t msg_type;
 
-int SIPPlugin::post_create(Flow &rec, const Packet &pkt)
-{
-   uint16_t msg_type;
+    msg_type = parse_msg_type(pkt);
+    if (msg_type != SIP_MSG_TYPE_INVALID) {
+        return FLOW_FLUSH_WITH_REINSERT;
+    }
 
-   msg_type = parse_msg_type(pkt);
-   if (msg_type == SIP_MSG_TYPE_INVALID) {
-      return 0;
-   }
-
-   RecordExtSIP *sip_data = new RecordExtSIP();
-   sip_data->msg_type = msg_type;
-   rec.add_extension(sip_data);
-   parser_process_sip(pkt, sip_data);
-
-   return 0;
-}
-
-int SIPPlugin::pre_update(Flow &rec, Packet &pkt)
-{
-   uint16_t msg_type;
-
-   msg_type = parse_msg_type(pkt);
-   if (msg_type != SIP_MSG_TYPE_INVALID) {
-      return FLOW_FLUSH_WITH_REINSERT;
-   }
-
-   return 0;
+    return 0;
 }
 
 void SIPPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "SIP plugin stats:" << std::endl;
-      std::cout << "   Parsed sip requests: " << requests << std::endl;
-      std::cout << "   Parsed sip responses: " << responses << std::endl;
-      std::cout << "   Total sip packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "SIP plugin stats:" << std::endl;
+        std::cout << "   Parsed sip requests: " << requests << std::endl;
+        std::cout << "   Parsed sip responses: " << responses << std::endl;
+        std::cout << "   Total sip packets processed: " << total << std::endl;
+    }
 }
 
-uint16_t SIPPlugin::parse_msg_type(const Packet &pkt)
+uint16_t SIPPlugin::parse_msg_type(const Packet& pkt)
 {
-   if (pkt.payload_len == 0) {
-      return SIP_MSG_TYPE_INVALID;
-   }
+    if (pkt.payload_len == 0) {
+        return SIP_MSG_TYPE_INVALID;
+    }
 
-   uint32_t *first_bytes;
-   uint32_t check;
+    uint32_t* first_bytes;
+    uint32_t check;
 
-   /* Is there any payload to process? */
-   if (pkt.payload_len < SIP_MIN_MSG_LEN) {
-      return SIP_MSG_TYPE_INVALID;
-   }
+    /* Is there any payload to process? */
+    if (pkt.payload_len < SIP_MIN_MSG_LEN) {
+        return SIP_MSG_TYPE_INVALID;
+    }
 
-   /* Get first four bytes of the packet and compare them against the patterns: */
-   first_bytes = (uint32_t *) pkt.payload;
+    /* Get first four bytes of the packet and compare them against the patterns: */
+    first_bytes = (uint32_t*) pkt.payload;
 
-   /* Apply the pattern on the packet: */
-   check = *first_bytes ^ SIP_TEST_1;
+    /* Apply the pattern on the packet: */
+    check = *first_bytes ^ SIP_TEST_1;
 
-   /*
-    * Here we will check if at least one of bytes in the SIP pattern is present in the packet.
-    * Add magic_bits to longword
-    *                |      Set those bits which were unchanged by the addition
-    *                |             |        Look at the hole bits. If some of them is unchanged,
-    *                |             |            |    most likely there is zero byte, ie. our separator.
-    *                v             v            v                                                       */
-   if ((((check + MAGIC_BITS) ^ ~check) & MAGIC_BITS_NEG) != 0) {
-      /* At least one byte of the test pattern was found -> the packet *may* contain one of the searched SIP messages: */
-      switch (*first_bytes) {
-      case SIP_REGISTER:
-         return SIP_MSG_TYPE_REGISTER;
-      case SIP_INVITE:
-         return SIP_MSG_TYPE_INVITE;
-      case SIP_OPTIONS:
-                /* OPTIONS message is also a request in HTTP - we must identify false positives here: */
-         if (first_bytes[1] == SIP_NOT_OPTIONS1 && first_bytes[2] == SIP_NOT_OPTIONS2) {
-            return SIP_MSG_TYPE_OPTIONS;
-         }
-
-         return SIP_MSG_TYPE_INVALID;
-      case SIP_NOTIFY:	/* Notify message is a bit tricky because also Microsoft's SSDP protocol uses HTTP-like structure
-                * and NOTIFY message - we must identify false positives here: */
-         if (first_bytes[1] == SIP_NOT_NOTIFY1 && first_bytes[2] == SIP_NOT_NOTIFY2) {
-            return SIP_MSG_TYPE_INVALID;
-         }
-
-         return SIP_MSG_TYPE_NOTIFY;
-      case SIP_CANCEL:
-         return SIP_MSG_TYPE_CANCEL;
-      case SIP_INFO:
-         return SIP_MSG_TYPE_INFO;
-      default:
-         break;
-      }
-   }
-
-   /* Do the same thing for the second pattern: */
-   check = *first_bytes ^ SIP_TEST_2;
-   if ((((check + MAGIC_BITS) ^ ~check) & MAGIC_BITS_NEG) != 0) {
-      switch (*first_bytes) {
-      case SIP_REPLY:
-         return SIP_MSG_TYPE_STATUS;
-      case SIP_ACK:
-         return SIP_MSG_TYPE_ACK;
-      case SIP_BYE:
-         return SIP_MSG_TYPE_BYE;
-      case SIP_SUBSCRIBE:
-         return SIP_MSG_TYPE_SUBSCRIBE;
-      case SIP_PUBLISH:
-         return SIP_MSG_TYPE_PUBLISH;
-      default:
-         break;
-      }
-   }
-
-   /* No pattern found, this is probably not SIP packet: */
-   return SIP_MSG_TYPE_INVALID;
-}
-
-const unsigned char * SIPPlugin::parser_strtok(const unsigned char *str, unsigned int instrlen, char separator, unsigned int *strlen, parser_strtok_t * nst)
-{
-   const unsigned char *char_ptr;	/* Currently processed characters */
-   const unsigned char *beginning;	/* Beginning of the original string */
-   MAGIC_INT *longword_ptr;	/* Currently processed word */
-   MAGIC_INT longword;	/* Dereferenced longword_ptr useful for the next work */
-   MAGIC_INT longword_mask;	/* Dereferenced longword_ptr with applied separator mask */
-   const unsigned char *cp;	/* A byte which is supposed to be the next separator */
-   int len;		/* Length of the string */
-   MAGIC_INT i;
-
-   /*
-    * The idea of the algorithm comes from the implementation of stdlib function strlen().
-    * See http://www.stdlib.net/~colmmacc/strlen.c.html for further details.
-    */
-
-   /* First or next run? */
-   if (str != nullptr) {
-
-      char_ptr = str;
-      nst->saveptr = nullptr;
-      nst->separator = separator;
-      nst->instrlen = instrlen;
-
-      /* Create a separator mask - put the separator to each byte of the integer: */
-      nst->separator_mask = 0;
-      for (i = 0; i < sizeof(longword) * 8; i += 8) {
-         nst->separator_mask |= (((MAGIC_INT) separator) << i);
-      }
-
-   } else if (nst->saveptr != nullptr && nst->instrlen > 0) {
-      /* Next run: */
-      char_ptr = nst->saveptr;
-   } else {
-      /* Last run: */
-      return nullptr;
-   }
-
-   /*
-    * Handle the first few characters by reading one character at a time.
-    * Do this until CHAR_PTR is aligned on a longword boundary:
-    */
-   len = 0;
-   beginning = char_ptr;
-   for (; ((unsigned long int)char_ptr & (sizeof(longword) - 1)) != 0; ++char_ptr) {
-
-      /* We found the separator - return the string immediately: */
-      if (*char_ptr == nst->separator) {
-         *strlen = len;
-         nst->saveptr = char_ptr + 1;
-         if (nst->instrlen > 0) {
-            nst->instrlen--;
-         }
-         return beginning;
-      }
-      len++;
-
-      /* This is end of string - return the string as it is: */
-      nst->instrlen--;
-      if (nst->instrlen == 0) {
-         *strlen = len;
-         nst->saveptr = nullptr;
-         return beginning;
-      }
-   }
-
-#define FOUND(A)        { nst->saveptr = cp + (A) + 1; *strlen = len + A; nst->instrlen -= A + 1; return beginning; }
-
-   /* Go across the string word by word: */
-   longword_ptr = (MAGIC_INT *)char_ptr;
-   for (;;) {
-      /*
-       * Get the current item and move to the next one. The XOR operator does the following thing:
-       * If the byte is separator, sets it to zero. Otherwise it is nonzero.
-       */
-      longword = *longword_ptr++;
-      longword_mask = longword ^ nst->separator_mask;
-
-      /* Check the end of string. If we don't have enough bytes for the next longword, return what we have: */
-      if (nst->instrlen < sizeof(longword)) {
-
-         /* The separator could be just before the end of the buffer: */
-         cp = (const unsigned char *)(longword_ptr - 1);
-         for (i = 0; i < nst->instrlen; i++) {
-
-            if (cp[i] == nst->separator) {
-               /* Correct string length: */
-               *strlen = len + i;
-
-               /* If the separator is the last character in the buffer: */
-               if (nst->instrlen == i + 1) {
-                  nst->saveptr = nullptr;
-               } else {
-                  nst->saveptr = cp + i + 1;
-                  nst->instrlen -= i + 1;
-               }
-               return beginning;
+    /*
+     * Here we will check if at least one of bytes in the SIP pattern is present in the packet.
+     * Add magic_bits to longword
+     *                |      Set those bits which were unchanged by the addition
+     *                |             |        Look at the hole bits. If some of them is unchanged,
+     *                |             |            |    most likely there is zero byte, ie. our
+     * separator. v             v            v */
+    if ((((check + MAGIC_BITS) ^ ~check) & MAGIC_BITS_NEG) != 0) {
+        /* At least one byte of the test pattern was found -> the packet *may* contain one of the
+         * searched SIP messages: */
+        switch (*first_bytes) {
+        case SIP_REGISTER:
+            return SIP_MSG_TYPE_REGISTER;
+        case SIP_INVITE:
+            return SIP_MSG_TYPE_INVITE;
+        case SIP_OPTIONS:
+            /* OPTIONS message is also a request in HTTP - we must identify false positives here: */
+            if (first_bytes[1] == SIP_NOT_OPTIONS1 && first_bytes[2] == SIP_NOT_OPTIONS2) {
+                return SIP_MSG_TYPE_OPTIONS;
             }
-         }
-         /* Separator not found, so return the rest of buffer: */
-         *strlen = len + nst->instrlen;
-         nst->saveptr = nullptr;
-         return beginning;
-      }
 
-      /*
-       * Here we will try to find the separator:
-       * Add magic_bits to longword
-       *             |      Set those bits which were unchanged by the addition
-       *             |             |        Look at the hole bits. If some of them is unchanged,
-       *             |             |            |    most likely there is zero byte, ie. our separator.
-       *             v             v            v                                                       */
-      if ((((longword_mask + MAGIC_BITS) ^ ~longword_mask) & MAGIC_BITS_NEG) != 0) {
+            return SIP_MSG_TYPE_INVALID;
+        case SIP_NOTIFY: /* Notify message is a bit tricky because also Microsoft's SSDP protocol
+                          * uses HTTP-like structure and NOTIFY message - we must identify false
+                          * positives here: */
+            if (first_bytes[1] == SIP_NOT_NOTIFY1 && first_bytes[2] == SIP_NOT_NOTIFY2) {
+                return SIP_MSG_TYPE_INVALID;
+            }
 
-         /* Convert the integer back to the string: */
-         cp = (const unsigned char *)(longword_ptr - 1);
+            return SIP_MSG_TYPE_NOTIFY;
+        case SIP_CANCEL:
+            return SIP_MSG_TYPE_CANCEL;
+        case SIP_INFO:
+            return SIP_MSG_TYPE_INFO;
+        default:
+            break;
+        }
+    }
 
-         /* Find out which byte is the separator: */
-         if (cp[0] == nst->separator)
-            FOUND(0);
-         if (cp[1] == nst->separator)
-            FOUND(1);
-         if (cp[2] == nst->separator)
-            FOUND(2);
-         if (cp[3] == nst->separator)
-            FOUND(3);
-         if (sizeof(longword) > 4) {
-            if (cp[4] == nst->separator)
-               FOUND(4);
-            if (cp[5] == nst->separator)
-               FOUND(5);
-            if (cp[6] == nst->separator)
-               FOUND(6);
-            if (cp[7] == nst->separator)
-               FOUND(7);
-         }
-      }
+    /* Do the same thing for the second pattern: */
+    check = *first_bytes ^ SIP_TEST_2;
+    if ((((check + MAGIC_BITS) ^ ~check) & MAGIC_BITS_NEG) != 0) {
+        switch (*first_bytes) {
+        case SIP_REPLY:
+            return SIP_MSG_TYPE_STATUS;
+        case SIP_ACK:
+            return SIP_MSG_TYPE_ACK;
+        case SIP_BYE:
+            return SIP_MSG_TYPE_BYE;
+        case SIP_SUBSCRIBE:
+            return SIP_MSG_TYPE_SUBSCRIBE;
+        case SIP_PUBLISH:
+            return SIP_MSG_TYPE_PUBLISH;
+        default:
+            break;
+        }
+    }
 
-      /* Add the length: */
-      len += sizeof(longword);
-      nst->instrlen -= sizeof(longword);
-   }
+    /* No pattern found, this is probably not SIP packet: */
+    return SIP_MSG_TYPE_INVALID;
 }
 
-void SIPPlugin::parser_field_value(const unsigned char *line, int linelen, int skip, char *dst, unsigned int dstlen)
+const unsigned char* SIPPlugin::parser_strtok(
+    const unsigned char* str,
+    unsigned int instrlen,
+    char separator,
+    unsigned int* strlen,
+    parser_strtok_t* nst)
 {
-   parser_strtok_t pst;
-   unsigned int newlen;
+    const unsigned char* char_ptr; /* Currently processed characters */
+    const unsigned char* beginning; /* Beginning of the original string */
+    MAGIC_INT* longword_ptr; /* Currently processed word */
+    MAGIC_INT longword; /* Dereferenced longword_ptr useful for the next work */
+    MAGIC_INT longword_mask; /* Dereferenced longword_ptr with applied separator mask */
+    const unsigned char* cp; /* A byte which is supposed to be the next separator */
+    int len; /* Length of the string */
+    MAGIC_INT i;
 
-   /* Skip the leading characters: */
-   line += skip;
-   linelen -= skip;
+    /*
+     * The idea of the algorithm comes from the implementation of stdlib function strlen().
+     * See http://www.stdlib.net/~colmmacc/strlen.c.html for further details.
+     */
 
-   /* Skip whitespaces: */
-   while (isalnum(*line) == 0 && linelen > 0) {
-      line++;
-      linelen--;
-   }
+    /* First or next run? */
+    if (str != nullptr) {
+        char_ptr = str;
+        nst->saveptr = nullptr;
+        nst->separator = separator;
+        nst->instrlen = instrlen;
 
-   /* Trim trailing whitespaces: */
-   while (isalnum(line[linelen - 1]) == 0 && linelen > 0) {
-      linelen--;
-   }
+        /* Create a separator mask - put the separator to each byte of the integer: */
+        nst->separator_mask = 0;
+        for (i = 0; i < sizeof(longword) * 8; i += 8) {
+            nst->separator_mask |= (((MAGIC_INT) separator) << i);
+        }
 
-   /* Find the first field value: */
-   line = parser_strtok(line, linelen, ';', &newlen, &pst);
+    } else if (nst->saveptr != nullptr && nst->instrlen > 0) {
+        /* Next run: */
+        char_ptr = nst->saveptr;
+    } else {
+        /* Last run: */
+        return nullptr;
+    }
 
-   /* Trim to the length of the destination buffer: */
-   if (newlen > dstlen - 1) {
-      newlen = dstlen - 1;
-   }
+    /*
+     * Handle the first few characters by reading one character at a time.
+     * Do this until CHAR_PTR is aligned on a longword boundary:
+     */
+    len = 0;
+    beginning = char_ptr;
+    for (; ((unsigned long int) char_ptr & (sizeof(longword) - 1)) != 0; ++char_ptr) {
+        /* We found the separator - return the string immediately: */
+        if (*char_ptr == nst->separator) {
+            *strlen = len;
+            nst->saveptr = char_ptr + 1;
+            if (nst->instrlen > 0) {
+                nst->instrlen--;
+            }
+            return beginning;
+        }
+        len++;
 
-   /* Copy the buffer: */
-   memcpy(dst, line, newlen);
-   dst[newlen] = 0;
+        /* This is end of string - return the string as it is: */
+        nst->instrlen--;
+        if (nst->instrlen == 0) {
+            *strlen = len;
+            nst->saveptr = nullptr;
+            return beginning;
+        }
+    }
+
+#define FOUND(A)                                                                                   \
+    {                                                                                              \
+        nst->saveptr = cp + (A) + 1;                                                               \
+        *strlen = len + A;                                                                         \
+        nst->instrlen -= A + 1;                                                                    \
+        return beginning;                                                                          \
+    }
+
+    /* Go across the string word by word: */
+    longword_ptr = (MAGIC_INT*) char_ptr;
+    for (;;) {
+        /*
+         * Get the current item and move to the next one. The XOR operator does the following thing:
+         * If the byte is separator, sets it to zero. Otherwise it is nonzero.
+         */
+        longword = *longword_ptr++;
+        longword_mask = longword ^ nst->separator_mask;
+
+        /* Check the end of string. If we don't have enough bytes for the next longword, return what
+         * we have: */
+        if (nst->instrlen < sizeof(longword)) {
+            /* The separator could be just before the end of the buffer: */
+            cp = (const unsigned char*) (longword_ptr - 1);
+            for (i = 0; i < nst->instrlen; i++) {
+                if (cp[i] == nst->separator) {
+                    /* Correct string length: */
+                    *strlen = len + i;
+
+                    /* If the separator is the last character in the buffer: */
+                    if (nst->instrlen == i + 1) {
+                        nst->saveptr = nullptr;
+                    } else {
+                        nst->saveptr = cp + i + 1;
+                        nst->instrlen -= i + 1;
+                    }
+                    return beginning;
+                }
+            }
+            /* Separator not found, so return the rest of buffer: */
+            *strlen = len + nst->instrlen;
+            nst->saveptr = nullptr;
+            return beginning;
+        }
+
+        /*
+         * Here we will try to find the separator:
+         * Add magic_bits to longword
+         *             |      Set those bits which were unchanged by the addition
+         *             |             |        Look at the hole bits. If some of them is unchanged,
+         *             |             |            |    most likely there is zero byte, ie. our
+         * separator. v             v            v */
+        if ((((longword_mask + MAGIC_BITS) ^ ~longword_mask) & MAGIC_BITS_NEG) != 0) {
+            /* Convert the integer back to the string: */
+            cp = (const unsigned char*) (longword_ptr - 1);
+
+            /* Find out which byte is the separator: */
+            if (cp[0] == nst->separator)
+                FOUND(0);
+            if (cp[1] == nst->separator)
+                FOUND(1);
+            if (cp[2] == nst->separator)
+                FOUND(2);
+            if (cp[3] == nst->separator)
+                FOUND(3);
+            if (sizeof(longword) > 4) {
+                if (cp[4] == nst->separator)
+                    FOUND(4);
+                if (cp[5] == nst->separator)
+                    FOUND(5);
+                if (cp[6] == nst->separator)
+                    FOUND(6);
+                if (cp[7] == nst->separator)
+                    FOUND(7);
+            }
+        }
+
+        /* Add the length: */
+        len += sizeof(longword);
+        nst->instrlen -= sizeof(longword);
+    }
 }
 
-void SIPPlugin::parser_field_uri(const unsigned char *line, int linelen, int skip, char *dst, unsigned int dstlen)
+void SIPPlugin::parser_field_value(
+    const unsigned char* line,
+    int linelen,
+    int skip,
+    char* dst,
+    unsigned int dstlen)
 {
-   parser_strtok_t pst;
-   unsigned int newlen;
-   unsigned int final_len;
-   uint32_t uri;
-   const unsigned char *start;
+    parser_strtok_t pst;
+    unsigned int newlen;
 
-   /* Skip leading characters: */
-   line += skip;
-   linelen -= skip;
+    /* Skip the leading characters: */
+    line += skip;
+    linelen -= skip;
 
-   /* Find the first colon, this could be probably a part of the SIP uri: */
-   start = nullptr;
-   final_len = 0;
-   line = parser_strtok(line, linelen, ':', &newlen, &pst);
-   while (line != nullptr && newlen > 0) {
-      /* Add the linelen to get the position of the first colon: */
-      line += newlen;
-      newlen = linelen - newlen;
-      /* The characters before colon must be sip or sips: */
-      uri = SIP_UCFOUR(*((uint32_t *) (line - SIP_URI_LEN)));
-      if (uri == SIP_URI) {
-         start = line - SIP_URI_LEN;
-         final_len = newlen + SIP_URI_LEN;
-         break;
-      } else if (uri == SIP_URIS) {
-         start = line - SIP_URIS_LEN;
-         final_len = newlen + SIP_URIS_LEN;
-         break;
-      }
+    /* Skip whitespaces: */
+    while (isalnum(*line) == 0 && linelen > 0) {
+        line++;
+        linelen--;
+    }
 
-      /* Not a sip uri - find the next colon: */
-      line = parser_strtok(nullptr, 0, ' ', &newlen, &pst);
-   }
+    /* Trim trailing whitespaces: */
+    while (isalnum(line[linelen - 1]) == 0 && linelen > 0) {
+        linelen--;
+    }
 
-   /* No URI found? Exit: */
-   if (start == nullptr) {
-      return;
-   }
+    /* Find the first field value: */
+    line = parser_strtok(line, linelen, ';', &newlen, &pst);
 
-   /* Now we have the beginning of the SIP uri. Find the end - >, ; or EOL: */
-   line = parser_strtok(start, final_len, '>', &newlen, &pst);
-   if (newlen < final_len) {
-      final_len = newlen;
-   } else {
-      /* No bracket found, try to find at least a semicolon: */
-      line = parser_strtok(start, final_len, ';', &newlen, &pst);
-      if (newlen < final_len) {
-         final_len = newlen;
-      } else {
-         /* Nor semicolon found. Strip the whitespaces from the end of line and use the whole line: */
-         while (isalpha(start[final_len - 1]) == 0 && final_len > 0) {
-            final_len--;
-         }
-      }
-   }
+    /* Trim to the length of the destination buffer: */
+    if (newlen > dstlen - 1) {
+        newlen = dstlen - 1;
+    }
 
-   /* Trim to the length of the destination buffer: */
-   if (final_len > dstlen - 1) {
-      final_len = dstlen - 1;
-   }
-
-   /* Copy the buffer: */
-   memcpy(dst, start, final_len);
-   dst[final_len] = 0;
+    /* Copy the buffer: */
+    memcpy(dst, line, newlen);
+    dst[newlen] = 0;
 }
 
-int SIPPlugin::parser_process_sip(const Packet &pkt, RecordExtSIP *sip_data)
+void SIPPlugin::parser_field_uri(
+    const unsigned char* line,
+    int linelen,
+    int skip,
+    char* dst,
+    unsigned int dstlen)
 {
-   const unsigned char *payload;
-   const unsigned char *line;
-   int caplen;
-   unsigned int line_len = 0;
-   int field_len;
-   parser_strtok_t line_parser;
-   uint32_t first_bytes4;
-   uint32_t first_bytes3;
-   uint32_t first_bytes2;
+    parser_strtok_t pst;
+    unsigned int newlen;
+    unsigned int final_len;
+    uint32_t uri;
+    const unsigned char* start;
 
-   /* Skip the packet headers: */
-   payload = (unsigned char *)pkt.payload;
-   caplen = pkt.payload_len;
+    /* Skip leading characters: */
+    line += skip;
+    linelen -= skip;
 
-   /* Grab the first line of the payload: */
-   line = parser_strtok(payload, caplen, '\n', &line_len, &line_parser);
+    /* Find the first colon, this could be probably a part of the SIP uri: */
+    start = nullptr;
+    final_len = 0;
+    line = parser_strtok(line, linelen, ':', &newlen, &pst);
+    while (line != nullptr && newlen > 0) {
+        /* Add the linelen to get the position of the first colon: */
+        line += newlen;
+        newlen = linelen - newlen;
+        /* The characters before colon must be sip or sips: */
+        uri = SIP_UCFOUR(*((uint32_t*) (line - SIP_URI_LEN)));
+        if (uri == SIP_URI) {
+            start = line - SIP_URI_LEN;
+            final_len = newlen + SIP_URI_LEN;
+            break;
+        } else if (uri == SIP_URIS) {
+            start = line - SIP_URIS_LEN;
+            final_len = newlen + SIP_URIS_LEN;
+            break;
+        }
 
+        /* Not a sip uri - find the next colon: */
+        line = parser_strtok(nullptr, 0, ' ', &newlen, &pst);
+    }
 
-   /* Get Request-URI for SIP requests from first line of the payload: */
-   if (sip_data->msg_type <= 10) {
-      requests++;
-      /* Note: First SIP request line has syntax: "Method SP Request-URI SP SIP-Version CRLF" (SP=single space) */
-      parser_strtok_t first_line_parser;
-      const unsigned char *line_token;
-      unsigned int line_token_len;
+    /* No URI found? Exit: */
+    if (start == nullptr) {
+        return;
+    }
 
-      /* Get Method part of request: */
-      line_token = parser_strtok(line, line_len, ' ', &line_token_len, &first_line_parser);
-      /* Get Request-URI part of request: */
-      line_token = parser_strtok(nullptr, 0, ' ', &line_token_len, &first_line_parser);
+    /* Now we have the beginning of the SIP uri. Find the end - >, ; or EOL: */
+    line = parser_strtok(start, final_len, '>', &newlen, &pst);
+    if (newlen < final_len) {
+        final_len = newlen;
+    } else {
+        /* No bracket found, try to find at least a semicolon: */
+        line = parser_strtok(start, final_len, ';', &newlen, &pst);
+        if (newlen < final_len) {
+            final_len = newlen;
+        } else {
+            /* Nor semicolon found. Strip the whitespaces from the end of line and use the whole
+             * line: */
+            while (isalpha(start[final_len - 1]) == 0 && final_len > 0) {
+                final_len--;
+            }
+        }
+    }
 
-      if (line_token != nullptr) {
-         /* Request-URI: */
-         parser_field_value(line_token, line_token_len, 0, sip_data->request_uri, sizeof(sip_data->request_uri));
-      } else {
-         /* Not found */
-         sip_data->request_uri[0] = 0;
-      }
-   } else {
-      responses++;
-      if (sip_data->msg_type == 99) {
-         parser_strtok_t first_line_parser;
-         const unsigned char *line_token;
-         unsigned int line_token_len;
-         line_token = parser_strtok(line, line_len, ' ', &line_token_len, &first_line_parser);
-         line_token = parser_strtok(nullptr, 0, ' ', &line_token_len, &first_line_parser);
-         sip_data->status_code = SIP_MSG_TYPE_UNDEFINED;
-         if (line_token) {
-            sip_data->status_code = atoi((const char *)line_token);
-         }
-      }
-   }
+    /* Trim to the length of the destination buffer: */
+    if (final_len > dstlen - 1) {
+        final_len = dstlen - 1;
+    }
 
-   total++;
-   /* Go to the next line. Divide the packet payload by line breaks and process them one by one: */
-   line = parser_strtok(nullptr, 0, ' ', &line_len, &line_parser);
-
-   /*
-    * Process all the remaining attributes:
-    */
-   while (line != nullptr && line_len > 1) {
-      /* Get first 4, 3 and 2 bytes and compare them with searched SIP fields: */
-      first_bytes4 = SIP_UCFOUR(*((uint32_t *) line));
-      first_bytes3 = SIP_UCTHREE(*((uint32_t *) line));
-      first_bytes2 = SIP_UCTWO(*((uint32_t *) line));
-
-      /* From: */
-      if (first_bytes4 == SIP_FROM4) {
-         parser_field_uri(line, line_len, 5, sip_data->calling_party, sizeof(sip_data->calling_party));
-      } else if (first_bytes2 == SIP_FROM2) {
-         parser_field_uri(line, line_len, 2, sip_data->calling_party, sizeof(sip_data->calling_party));
-      }
-
-      /* To: */
-      else if (first_bytes3 == SIP_TO3) {
-         parser_field_uri(line, line_len, 3, sip_data->called_party, sizeof(sip_data->called_party));
-      } else if (first_bytes2 == SIP_TO2) {
-         parser_field_uri(line, line_len, 2, sip_data->called_party, sizeof(sip_data->called_party));
-      }
-
-      /* Via: */
-      else if (first_bytes4 == SIP_VIA4) {
-         /* Via fields can be present more times. Include all and separate them by semicolons: */
-         if (sip_data->via[0] == 0) {
-            parser_field_value(line, line_len, 4, sip_data->via, sizeof(sip_data->via));
-         } else {
-            field_len = strlen(sip_data->via);
-            sip_data->via[field_len++] = ';';
-            parser_field_value(line, line_len, 4, sip_data->via + field_len, sizeof(sip_data->via) - field_len);
-         }
-      } else if (first_bytes2 == SIP_VIA2) {
-         if (sip_data->via[0] == 0) {
-            parser_field_value(line, line_len, 2, sip_data->via, sizeof(sip_data->via));
-         } else {
-            field_len = strlen(sip_data->via);
-            sip_data->via[field_len++] = ';';
-            parser_field_value(line, line_len, 2, sip_data->via + field_len, sizeof(sip_data->via) - field_len);
-         }
-      }
-
-      /* Call-ID: */
-      else if (first_bytes4 == SIP_CALLID4) {
-         parser_field_value(line, line_len, 8, sip_data->call_id, sizeof(sip_data->call_id));
-      } else if (first_bytes2 == SIP_CALLID2) {
-         parser_field_value(line, line_len, 2, sip_data->call_id, sizeof(sip_data->call_id));
-      }
-
-      /* User-Agent: */
-      else if (first_bytes4 == SIP_USERAGENT4) {
-         parser_field_value(line, line_len, 11, sip_data->user_agent, sizeof(sip_data->user_agent));
-      }
-
-      /* CSeq: */
-      else if (first_bytes4 == SIP_CSEQ4) {
-
-         /* Save CSeq: */
-         parser_field_value(line, line_len, 5, sip_data->cseq, sizeof(sip_data->cseq));
-      }
-
-      /* Go to the next line: */
-      line = parser_strtok(nullptr, 0, ' ', &line_len, &line_parser);
-   }
-
-   return 0;
+    /* Copy the buffer: */
+    memcpy(dst, start, final_len);
+    dst[final_len] = 0;
 }
 
+int SIPPlugin::parser_process_sip(const Packet& pkt, RecordExtSIP* sip_data)
+{
+    const unsigned char* payload;
+    const unsigned char* line;
+    int caplen;
+    unsigned int line_len = 0;
+    int field_len;
+    parser_strtok_t line_parser;
+    uint32_t first_bytes4;
+    uint32_t first_bytes3;
+    uint32_t first_bytes2;
+
+    /* Skip the packet headers: */
+    payload = (unsigned char*) pkt.payload;
+    caplen = pkt.payload_len;
+
+    /* Grab the first line of the payload: */
+    line = parser_strtok(payload, caplen, '\n', &line_len, &line_parser);
+
+    /* Get Request-URI for SIP requests from first line of the payload: */
+    if (sip_data->msg_type <= 10) {
+        requests++;
+        /* Note: First SIP request line has syntax: "Method SP Request-URI SP SIP-Version CRLF"
+         * (SP=single space) */
+        parser_strtok_t first_line_parser;
+        const unsigned char* line_token;
+        unsigned int line_token_len;
+
+        /* Get Method part of request: */
+        line_token = parser_strtok(line, line_len, ' ', &line_token_len, &first_line_parser);
+        /* Get Request-URI part of request: */
+        line_token = parser_strtok(nullptr, 0, ' ', &line_token_len, &first_line_parser);
+
+        if (line_token != nullptr) {
+            /* Request-URI: */
+            parser_field_value(
+                line_token,
+                line_token_len,
+                0,
+                sip_data->request_uri,
+                sizeof(sip_data->request_uri));
+        } else {
+            /* Not found */
+            sip_data->request_uri[0] = 0;
+        }
+    } else {
+        responses++;
+        if (sip_data->msg_type == 99) {
+            parser_strtok_t first_line_parser;
+            const unsigned char* line_token;
+            unsigned int line_token_len;
+            line_token = parser_strtok(line, line_len, ' ', &line_token_len, &first_line_parser);
+            line_token = parser_strtok(nullptr, 0, ' ', &line_token_len, &first_line_parser);
+            sip_data->status_code = SIP_MSG_TYPE_UNDEFINED;
+            if (line_token) {
+                sip_data->status_code = atoi((const char*) line_token);
+            }
+        }
+    }
+
+    total++;
+    /* Go to the next line. Divide the packet payload by line breaks and process them one by one: */
+    line = parser_strtok(nullptr, 0, ' ', &line_len, &line_parser);
+
+    /*
+     * Process all the remaining attributes:
+     */
+    while (line != nullptr && line_len > 1) {
+        /* Get first 4, 3 and 2 bytes and compare them with searched SIP fields: */
+        first_bytes4 = SIP_UCFOUR(*((uint32_t*) line));
+        first_bytes3 = SIP_UCTHREE(*((uint32_t*) line));
+        first_bytes2 = SIP_UCTWO(*((uint32_t*) line));
+
+        /* From: */
+        if (first_bytes4 == SIP_FROM4) {
+            parser_field_uri(
+                line,
+                line_len,
+                5,
+                sip_data->calling_party,
+                sizeof(sip_data->calling_party));
+        } else if (first_bytes2 == SIP_FROM2) {
+            parser_field_uri(
+                line,
+                line_len,
+                2,
+                sip_data->calling_party,
+                sizeof(sip_data->calling_party));
+        }
+
+        /* To: */
+        else if (first_bytes3 == SIP_TO3) {
+            parser_field_uri(
+                line,
+                line_len,
+                3,
+                sip_data->called_party,
+                sizeof(sip_data->called_party));
+        } else if (first_bytes2 == SIP_TO2) {
+            parser_field_uri(
+                line,
+                line_len,
+                2,
+                sip_data->called_party,
+                sizeof(sip_data->called_party));
+        }
+
+        /* Via: */
+        else if (first_bytes4 == SIP_VIA4) {
+            /* Via fields can be present more times. Include all and separate them by semicolons: */
+            if (sip_data->via[0] == 0) {
+                parser_field_value(line, line_len, 4, sip_data->via, sizeof(sip_data->via));
+            } else {
+                field_len = strlen(sip_data->via);
+                sip_data->via[field_len++] = ';';
+                parser_field_value(
+                    line,
+                    line_len,
+                    4,
+                    sip_data->via + field_len,
+                    sizeof(sip_data->via) - field_len);
+            }
+        } else if (first_bytes2 == SIP_VIA2) {
+            if (sip_data->via[0] == 0) {
+                parser_field_value(line, line_len, 2, sip_data->via, sizeof(sip_data->via));
+            } else {
+                field_len = strlen(sip_data->via);
+                sip_data->via[field_len++] = ';';
+                parser_field_value(
+                    line,
+                    line_len,
+                    2,
+                    sip_data->via + field_len,
+                    sizeof(sip_data->via) - field_len);
+            }
+        }
+
+        /* Call-ID: */
+        else if (first_bytes4 == SIP_CALLID4) {
+            parser_field_value(line, line_len, 8, sip_data->call_id, sizeof(sip_data->call_id));
+        } else if (first_bytes2 == SIP_CALLID2) {
+            parser_field_value(line, line_len, 2, sip_data->call_id, sizeof(sip_data->call_id));
+        }
+
+        /* User-Agent: */
+        else if (first_bytes4 == SIP_USERAGENT4) {
+            parser_field_value(
+                line,
+                line_len,
+                11,
+                sip_data->user_agent,
+                sizeof(sip_data->user_agent));
+        }
+
+        /* CSeq: */
+        else if (first_bytes4 == SIP_CSEQ4) {
+            /* Save CSeq: */
+            parser_field_value(line, line_len, 5, sip_data->cseq, sizeof(sip_data->cseq));
+        }
+
+        /* Go to the next line: */
+        line = parser_strtok(nullptr, 0, ' ', &line_len, &line_parser);
+    }
+
+    return 0;
 }
+
+} // namespace ipxp

--- a/process/sip.hpp
+++ b/process/sip.hpp
@@ -40,45 +40,45 @@
 #endif
 
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/process.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
-#define SIP_FIELD_LEN				128
+#define SIP_FIELD_LEN 128
 
-#define SIP_MSG_TYPE_INVALID     0
-#define SIP_MSG_TYPE_INVITE      1
-#define SIP_MSG_TYPE_ACK         2
-#define SIP_MSG_TYPE_CANCEL      3
-#define SIP_MSG_TYPE_BYE         4
-#define SIP_MSG_TYPE_REGISTER	   5
-#define SIP_MSG_TYPE_OPTIONS	   6
-#define SIP_MSG_TYPE_PUBLISH	   7
-#define SIP_MSG_TYPE_NOTIFY      8
-#define SIP_MSG_TYPE_INFO        9
-#define SIP_MSG_TYPE_SUBSCRIBE   10
-#define SIP_MSG_TYPE_STATUS      99
+#define SIP_MSG_TYPE_INVALID 0
+#define SIP_MSG_TYPE_INVITE 1
+#define SIP_MSG_TYPE_ACK 2
+#define SIP_MSG_TYPE_CANCEL 3
+#define SIP_MSG_TYPE_BYE 4
+#define SIP_MSG_TYPE_REGISTER 5
+#define SIP_MSG_TYPE_OPTIONS 6
+#define SIP_MSG_TYPE_PUBLISH 7
+#define SIP_MSG_TYPE_NOTIFY 8
+#define SIP_MSG_TYPE_INFO 9
+#define SIP_MSG_TYPE_SUBSCRIBE 10
+#define SIP_MSG_TYPE_STATUS 99
 
-#define SIP_MSG_TYPE_TRYING         100
-#define SIP_MSG_TYPE_DIAL_ESTABL	   101
-#define SIP_MSG_TYPE_RINGING  	   180
-#define SIP_MSG_TYPE_SESSION_PROGR  183
-#define SIP_MSG_TYPE_OK	            200
-#define SIP_MSG_TYPE_BAD_REQ        400
-#define SIP_MSG_TYPE_UNAUTHORIZED   401
-#define SIP_MSG_TYPE_FORBIDDEN      403
-#define SIP_MSG_TYPE_NOT_FOUND      404
-#define SIP_MSG_TYPE_PROXY_AUT_REQ  407
-#define SIP_MSG_TYPE_BUSY_HERE      486
-#define SIP_MSG_TYPE_REQ_CANCELED   487
-#define SIP_MSG_TYPE_INTERNAL_ERR   500
-#define SIP_MSG_TYPE_DECLINE        603
-#define SIP_MSG_TYPE_UNDEFINED      999
+#define SIP_MSG_TYPE_TRYING 100
+#define SIP_MSG_TYPE_DIAL_ESTABL 101
+#define SIP_MSG_TYPE_RINGING 180
+#define SIP_MSG_TYPE_SESSION_PROGR 183
+#define SIP_MSG_TYPE_OK 200
+#define SIP_MSG_TYPE_BAD_REQ 400
+#define SIP_MSG_TYPE_UNAUTHORIZED 401
+#define SIP_MSG_TYPE_FORBIDDEN 403
+#define SIP_MSG_TYPE_NOT_FOUND 404
+#define SIP_MSG_TYPE_PROXY_AUT_REQ 407
+#define SIP_MSG_TYPE_BUSY_HERE 486
+#define SIP_MSG_TYPE_REQ_CANCELED 487
+#define SIP_MSG_TYPE_INTERNAL_ERR 500
+#define SIP_MSG_TYPE_DECLINE 603
+#define SIP_MSG_TYPE_UNDEFINED 999
 
 /* Mininum length of SIP message: */
-#define SIP_MIN_MSG_LEN     64
+#define SIP_MIN_MSG_LEN 64
 
 /*
  * SIP identification table - these are all patterns that must be contained
@@ -88,76 +88,76 @@ namespace ipxp {
 /* ** The first pattern test group: ** */
 /*                                     v    */
 #if BYTEORDER == 1234
-#  define SIP_INVITE		0x49564e49	/* IVNI */
+#define SIP_INVITE 0x49564e49 /* IVNI */
 #else
-#  define SIP_INVITE		0x494e5649	/* INVI */
+#define SIP_INVITE 0x494e5649 /* INVI */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_REGISTER		0x49474552	/* IGER */
+#define SIP_REGISTER 0x49474552 /* IGER */
 #else
-#  define SIP_REGISTER		0x52454749	/* REGI */
+#define SIP_REGISTER 0x52454749 /* REGI */
 #endif
 
 /*                                     vv   */
 #if BYTEORDER == 1234
-#  define SIP_NOTIFY		0x49544f4e	/* ITON */
+#define SIP_NOTIFY 0x49544f4e /* ITON */
 #else
-#  define SIP_NOTIFY		0x4e4f5449	/* NOTI */
+#define SIP_NOTIFY 0x4e4f5449 /* NOTI */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_OPTIONS		0x4954504f	/* ITPO */
+#define SIP_OPTIONS 0x4954504f /* ITPO */
 #else
-#  define SIP_OPTIONS		0x4f505449	/* OPTI */
+#define SIP_OPTIONS 0x4f505449 /* OPTI */
 #endif
 
 /*                                       v  */
 #if BYTEORDER == 1234
-#  define SIP_CANCEL		0x434e4143	/* CNAC */
+#define SIP_CANCEL 0x434e4143 /* CNAC */
 #else
-#  define SIP_CANCEL		0x43414e43	/* CANC */
+#define SIP_CANCEL 0x43414e43 /* CANC */
 #endif
 
 /*                                        v */
 #if BYTEORDER == 1234
-#  define SIP_INFO		0x4f464e49	/* OFNI */
+#define SIP_INFO 0x4f464e49 /* OFNI */
 #else
-#  define SIP_INFO		0x494e464f	/* INFO */
+#define SIP_INFO 0x494e464f /* INFO */
 #endif
 
 /* ** Test second pattern test group: ** */
 /*                                     v    */
 #if BYTEORDER == 1234
-#  define SIP_ACK		0x204b4341	/*  KCA */
+#define SIP_ACK 0x204b4341 /*  KCA */
 #else
-#  define SIP_ACK		0x41434b20	/*  ACK */
+#define SIP_ACK 0x41434b20 /*  ACK */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_BYE		0x20455942	/*  EYB */
+#define SIP_BYE 0x20455942 /*  EYB */
 #else
-#  define SIP_BYE		0x42594520	/*  BYE */
+#define SIP_BYE 0x42594520 /*  BYE */
 #endif
 
 /*                                      v   */
 #if BYTEORDER == 1234
-#  define SIP_PUBLISH		0x4c425550	/* LBUP */
+#define SIP_PUBLISH 0x4c425550 /* LBUP */
 #else
-#  define SIP_PUBLISH		0x5055424c	/* PUBL */
+#define SIP_PUBLISH 0x5055424c /* PUBL */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_SUBSCRIBE		0x53425553	/* SBUS */
+#define SIP_SUBSCRIBE 0x53425553 /* SBUS */
 #else
-#  define SIP_SUBSCRIBE		0x53554253	/* SUBS */
+#define SIP_SUBSCRIBE 0x53554253 /* SUBS */
 #endif
 
 /*                                       vv */
 #if BYTEORDER == 1234
-#  define SIP_REPLY	    	0x2f504953	/* /PIS */
+#define SIP_REPLY 0x2f504953 /* /PIS */
 #else
-#  define SIP_REPLY	    	0x5349502f	/* SIP/ */
+#define SIP_REPLY 0x5349502f /* SIP/ */
 #endif
 
 /* If one of the bytes in the tested packet equals to byte in the
@@ -165,40 +165,40 @@ namespace ipxp {
  * where used to make the test pattern.
  */
 #if BYTEORDER == 1234
-#  define SIP_TEST_1		0x49544149	/* ITAI */
+#define SIP_TEST_1 0x49544149 /* ITAI */
 #else
-#  define SIP_TEST_1		0x49415449	/* IATI */
+#define SIP_TEST_1 0x49415449 /* IATI */
 #endif
 
 #if BYTEORDER == 1234
-#define SIP_TEST_2		0x20424953	/*  BIS */
+#define SIP_TEST_2 0x20424953 /*  BIS */
 #else
-#define SIP_TEST_2		0x53494220	/* SIB  */
+#define SIP_TEST_2 0x53494220 /* SIB  */
 #endif
 
 /* MS SSDP notify header for detecting false SIP packets: */
 #if BYTEORDER == 1234
-#  define SIP_NOT_NOTIFY1	0x2a205946	/* * YF */
+#define SIP_NOT_NOTIFY1 0x2a205946 /* * YF */
 #else
-#  define SIP_NOT_NOTIFY1	0x4659202a	/* FY * */
+#define SIP_NOT_NOTIFY1 0x4659202a /* FY * */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_NOT_NOTIFY2	0x54544820	/* TTH  */
+#define SIP_NOT_NOTIFY2 0x54544820 /* TTH  */
 #else
-#  define SIP_NOT_NOTIFY2	0x20485454	/*  HTT */
+#define SIP_NOT_NOTIFY2 0x20485454 /*  HTT */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_NOT_OPTIONS1	0x20534e4f	/*  SNO */
+#define SIP_NOT_OPTIONS1 0x20534e4f /*  SNO */
 #else
-#  define SIP_NOT_OPTIONS1	0x4f4e5320	/* ONS  */
+#define SIP_NOT_OPTIONS1 0x4f4e5320 /* ONS  */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_NOT_OPTIONS2	0x3a706973	/* :sip */
+#define SIP_NOT_OPTIONS2 0x3a706973 /* :sip */
 #else
-#  define SIP_NOT_OPTIONS2	0x7369703a	/* pis: */
+#define SIP_NOT_OPTIONS2 0x7369703a /* pis: */
 #endif
 
 /*
@@ -207,91 +207,92 @@ namespace ipxp {
  */
 /* This macro converts low ASCII characters to upper case. Colon changes to 0x1a character: */
 #if BYTEORDER == 1234
-#  define SIP_UCFOUR(A)   ((A) & 0xdfdfdfdf)
-#  define SIP_UCTWO(A)    ((A) & 0x0000dfdf)
-#  define SIP_UCTHREE(A)  ((A) & 0x00dfdfdf)
+#define SIP_UCFOUR(A) ((A) &0xdfdfdfdf)
+#define SIP_UCTWO(A) ((A) &0x0000dfdf)
+#define SIP_UCTHREE(A) ((A) &0x00dfdfdf)
 #else
-#  define SIP_UCFOUR(A)   ((A) & 0xdfdfdfdf)
-#  define SIP_UCTWO(A)    ((A) & 0xdfdf0000)
-#  define SIP_UCTHREE(A)  ((A) & 0xdfdfdf00)
+#define SIP_UCFOUR(A) ((A) &0xdfdfdfdf)
+#define SIP_UCTWO(A) ((A) &0xdfdf0000)
+#define SIP_UCTHREE(A) ((A) &0xdfdfdf00)
 #endif
 
-/* Encoded SIP field names - long and short alternatives. The trailing number means the number of bytes to compare: */
+/* Encoded SIP field names - long and short alternatives. The trailing number means the number of
+ * bytes to compare: */
 #if BYTEORDER == 1234
-#  define SIP_VIA4        0x1a414956	/* :AIV */
+#define SIP_VIA4 0x1a414956 /* :AIV */
 #else
-#  define SIP_VIA4        0x5649411a	/* VIA: */
-#endif
-
-#if BYTEORDER == 1234
-#  define SIP_VIA2        0x00001a56	/*   :V */
-#else
-#  define SIP_VIA2        0x561a0000	/* V:   */
+#define SIP_VIA4 0x5649411a /* VIA: */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_FROM4       0x4d4f5246	/* MORF */
+#define SIP_VIA2 0x00001a56 /*   :V */
 #else
-#  define SIP_FROM4       0x46524f4d	/* FROM */
+#define SIP_VIA2 0x561a0000 /* V:   */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_FROM2       0x00001a46	/*   :F */
+#define SIP_FROM4 0x4d4f5246 /* MORF */
 #else
-#  define SIP_FROM2       0x461a0000	/* F:   */
+#define SIP_FROM4 0x46524f4d /* FROM */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_TO3         0x001a4f54	/*  :OT */
+#define SIP_FROM2 0x00001a46 /*   :F */
 #else
-#  define SIP_TO3         0x544f1a00	/* TO:  */
+#define SIP_FROM2 0x461a0000 /* F:   */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_TO2         0x00001a54	/*   :T */
+#define SIP_TO3 0x001a4f54 /*  :OT */
 #else
-#  define SIP_TO2         0x541a0000	/* T:   */
+#define SIP_TO3 0x544f1a00 /* TO:  */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_CALLID4     0x4c4c4143	/* LLAC */
+#define SIP_TO2 0x00001a54 /*   :T */
 #else
-#  define SIP_CALLID4     0x43414c4c	/* CALL */
+#define SIP_TO2 0x541a0000 /* T:   */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_CALLID2     0x00001a49	/*   :I */
+#define SIP_CALLID4 0x4c4c4143 /* LLAC */
 #else
-#  define SIP_CALLID2     0x491a0000	/* I:   */
+#define SIP_CALLID4 0x43414c4c /* CALL */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_CSEQ4       0x51455343	/* QESC */
+#define SIP_CALLID2 0x00001a49 /*   :I */
 #else
-#  define SIP_CSEQ4       0x43534551	/* CSEQ */
+#define SIP_CALLID2 0x491a0000 /* I:   */
 #endif
 
 #if BYTEORDER == 1234
-#  define SIP_USERAGENT4  0x52455355	/* RESU */
+#define SIP_CSEQ4 0x51455343 /* QESC */
 #else
-#  define SIP_USERAGENT4  0x55534552	/* USER */
+#define SIP_CSEQ4 0x43534551 /* CSEQ */
+#endif
+
+#if BYTEORDER == 1234
+#define SIP_USERAGENT4 0x52455355 /* RESU */
+#else
+#define SIP_USERAGENT4 0x55534552 /* USER */
 #endif
 
 /* Encoded SIP URI start: */
 #if BYTEORDER == 1234
-#  define SIP_URI         0x1a504953	/* :PIS */
+#define SIP_URI 0x1a504953 /* :PIS */
 #else
-#  define SIP_URI         0x5349501a	/* SIP: */
+#define SIP_URI 0x5349501a /* SIP: */
 #endif
 
-#define SIP_URI_LEN     3
+#define SIP_URI_LEN 3
 #if BYTEORDER == 1234
-#  define SIP_URIS        0x1a535049	/* :SPI */
+#define SIP_URIS 0x1a535049 /* :SPI */
 #else
-#  define SIP_URIS        0x4950531a	/* IPS: */
+#define SIP_URIS 0x4950531a /* IPS: */
 #endif
 
-#define SIP_URIS_LEN    4
+#define SIP_URIS_LEN 4
 
 /*
  * Bits 31, 24, 16, and 8 of this number are zero.  Call these bits
@@ -309,209 +310,219 @@ namespace ipxp {
  */
 
 #ifdef __amd64__
-#define MAGIC_INT       uint64_t
-#define MAGIC_BITS      0x7efefefe7efefeffL
-#define MAGIC_BITS_NEG  0x8101010181010100L
+#define MAGIC_INT uint64_t
+#define MAGIC_BITS 0x7efefefe7efefeffL
+#define MAGIC_BITS_NEG 0x8101010181010100L
 #else
-#define MAGIC_INT       uint32_t
-#define MAGIC_BITS      0x7efefeffL
-#define MAGIC_BITS_NEG  0x81010100L
+#define MAGIC_INT uint32_t
+#define MAGIC_BITS 0x7efefeffL
+#define MAGIC_BITS_NEG 0x81010100L
 #endif
 
-#define SIP_UNIREC_TEMPLATE  "SIP_MSG_TYPE,SIP_STATUS_CODE,SIP_CSEQ,SIP_CALLING_PARTY,SIP_CALLED_PARTY,SIP_CALL_ID,SIP_USER_AGENT,SIP_REQUEST_URI,SIP_VIA"
+#define SIP_UNIREC_TEMPLATE                                                                        \
+    "SIP_MSG_TYPE,SIP_STATUS_CODE,SIP_CSEQ,SIP_CALLING_PARTY,SIP_CALLED_PARTY,SIP_CALL_ID,SIP_"    \
+    "USER_AGENT,SIP_REQUEST_URI,SIP_VIA"
 
-UR_FIELDS (
-   uint16 SIP_MSG_TYPE,
-   uint16 SIP_STATUS_CODE,
-   string SIP_CSEQ,
-   string SIP_CALLING_PARTY,
-   string SIP_CALLED_PARTY,
-   string SIP_CALL_ID,
-   string SIP_USER_AGENT,
-   string SIP_REQUEST_URI,
-   string SIP_VIA
-)
+UR_FIELDS(
+    uint16 SIP_MSG_TYPE,
+    uint16 SIP_STATUS_CODE,
+    string SIP_CSEQ,
+    string SIP_CALLING_PARTY,
+    string SIP_CALLED_PARTY,
+    string SIP_CALL_ID,
+    string SIP_USER_AGENT,
+    string SIP_REQUEST_URI,
+    string SIP_VIA)
 
 struct parser_strtok_t {
-   parser_strtok_t()
-   {
-      separator_mask = 0;
-      saveptr = nullptr;
-      separator = 0;
-      instrlen = 0;
-   }
+    parser_strtok_t()
+    {
+        separator_mask = 0;
+        saveptr = nullptr;
+        separator = 0;
+        instrlen = 0;
+    }
 
-   MAGIC_INT separator_mask;
-   const unsigned char *saveptr;
-   char separator;
-   unsigned int instrlen;
+    MAGIC_INT separator_mask;
+    const unsigned char* saveptr;
+    char separator;
+    unsigned int instrlen;
 };
 
 struct RecordExtSIP : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t msg_type;                  /* SIP message code (register, invite) < 100 or SIP response status > 100 */
-   uint16_t status_code;
-   char call_id[SIP_FIELD_LEN];	      /* Call id. For sevice SIP traffic call id = 0 */
-   char calling_party[SIP_FIELD_LEN];	/* Calling party (ie. from) uri */
-   char called_party[SIP_FIELD_LEN];	/* Called party (ie. to) uri */
-   char via[SIP_FIELD_LEN];            /* Via field of SIP packet */
-   char user_agent[SIP_FIELD_LEN];     /* User-Agent field of SIP packet */
-   char cseq[SIP_FIELD_LEN];           /* CSeq field of SIP packet */
-   char request_uri[SIP_FIELD_LEN];    /* Request-URI of SIP request */
+    uint16_t msg_type; /* SIP message code (register, invite) < 100 or SIP response status > 100 */
+    uint16_t status_code;
+    char call_id[SIP_FIELD_LEN]; /* Call id. For sevice SIP traffic call id = 0 */
+    char calling_party[SIP_FIELD_LEN]; /* Calling party (ie. from) uri */
+    char called_party[SIP_FIELD_LEN]; /* Called party (ie. to) uri */
+    char via[SIP_FIELD_LEN]; /* Via field of SIP packet */
+    char user_agent[SIP_FIELD_LEN]; /* User-Agent field of SIP packet */
+    char cseq[SIP_FIELD_LEN]; /* CSeq field of SIP packet */
+    char request_uri[SIP_FIELD_LEN]; /* Request-URI of SIP request */
 
-   RecordExtSIP() : RecordExt(REGISTERED_ID)
-   {
-      msg_type = 0;
-      status_code = 0;
-      call_id[0] = 0;
-      calling_party[0] = 0;
-      called_party[0] = 0;
-      via[0] = 0;
-      user_agent[0] = 0;
-      cseq[0] = 0;
-      request_uri[0] = 0;
-   }
+    RecordExtSIP()
+        : RecordExt(REGISTERED_ID)
+    {
+        msg_type = 0;
+        status_code = 0;
+        call_id[0] = 0;
+        calling_party[0] = 0;
+        called_party[0] = 0;
+        via[0] = 0;
+        user_agent[0] = 0;
+        cseq[0] = 0;
+        request_uri[0] = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_SIP_MSG_TYPE, msg_type);
-      ur_set(tmplt, record, F_SIP_STATUS_CODE, status_code);
-      ur_set_string(tmplt, record, F_SIP_CSEQ, cseq);
-      ur_set_string(tmplt, record, F_SIP_CALLING_PARTY, calling_party);
-      ur_set_string(tmplt, record, F_SIP_CALLED_PARTY, called_party);
-      ur_set_string(tmplt, record, F_SIP_CALL_ID, call_id);
-      ur_set_string(tmplt, record, F_SIP_USER_AGENT, user_agent);
-      ur_set_string(tmplt, record, F_SIP_REQUEST_URI, request_uri);
-      ur_set_string(tmplt, record, F_SIP_VIA, via);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_SIP_MSG_TYPE, msg_type);
+        ur_set(tmplt, record, F_SIP_STATUS_CODE, status_code);
+        ur_set_string(tmplt, record, F_SIP_CSEQ, cseq);
+        ur_set_string(tmplt, record, F_SIP_CALLING_PARTY, calling_party);
+        ur_set_string(tmplt, record, F_SIP_CALLED_PARTY, called_party);
+        ur_set_string(tmplt, record, F_SIP_CALL_ID, call_id);
+        ur_set_string(tmplt, record, F_SIP_USER_AGENT, user_agent);
+        ur_set_string(tmplt, record, F_SIP_REQUEST_URI, request_uri);
+        ur_set_string(tmplt, record, F_SIP_VIA, via);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return SIP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return SIP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length, total_length = 4;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length, total_length = 4;
 
-      length = strlen(cseq);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      *(uint16_t *) (buffer) = ntohs(msg_type);
-      *(uint16_t *) (buffer + 2) = ntohs(status_code);
+        length = strlen(cseq);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        *(uint16_t*) (buffer) = ntohs(msg_type);
+        *(uint16_t*) (buffer + 2) = ntohs(status_code);
 
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, cseq, length);
-      total_length += length + 1;
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, cseq, length);
+        total_length += length + 1;
 
-      length = strlen(calling_party);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, calling_party, length);
-      total_length += length + 1;
+        length = strlen(calling_party);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, calling_party, length);
+        total_length += length + 1;
 
-      length = strlen(called_party);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, called_party, length);
-      total_length += length + 1;
+        length = strlen(called_party);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, called_party, length);
+        total_length += length + 1;
 
-      length = strlen(call_id);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, call_id, length);
-      total_length += length + 1;
+        length = strlen(call_id);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, call_id, length);
+        total_length += length + 1;
 
-      length = strlen(user_agent);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, user_agent, length);
-      total_length += length + 1;
+        length = strlen(user_agent);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, user_agent, length);
+        total_length += length + 1;
 
-      length = strlen(request_uri);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, request_uri, length);
-      total_length += length + 1;
+        length = strlen(request_uri);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, request_uri, length);
+        total_length += length + 1;
 
-      length = strlen(via);
-      if (total_length + length + 1 > size) {
-         return -1;
-      }
-      buffer[total_length] = length;
-      memcpy(buffer + total_length + 1, via, length);
-      total_length += length + 1;
+        length = strlen(via);
+        if (total_length + length + 1 > size) {
+            return -1;
+        }
+        buffer[total_length] = length;
+        memcpy(buffer + total_length + 1, via, length);
+        total_length += length + 1;
 
-      return total_length;
-   }
+        return total_length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_SIP_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_SIP_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
+    std::string get_text() const
+    {
+        std::ostringstream out;
 
-      out << "sipmsgtype=" << msg_type
-         << ",statuscode=" << status_code
-         << ",cseq=\"" << cseq << "\""
-         << ",callingparty=\"" << calling_party << "\""
-         << ",calledparty=\"" << called_party << "\""
-         << ",callid=\"" << call_id << "\""
-         << ",useragent=\"" << user_agent << "\""
-         << ",requri=\"" << request_uri << "\""
-         << ",via=\"" << via << "\"";
-      return out.str();
-   }
+        out << "sipmsgtype=" << msg_type << ",statuscode=" << status_code << ",cseq=\"" << cseq
+            << "\""
+            << ",callingparty=\"" << calling_party << "\""
+            << ",calledparty=\"" << called_party << "\""
+            << ",callid=\"" << call_id << "\""
+            << ",useragent=\"" << user_agent << "\""
+            << ",requri=\"" << request_uri << "\""
+            << ",via=\"" << via << "\"";
+        return out.str();
+    }
 };
 
 class SIPPlugin : public ProcessPlugin {
 public:
-   SIPPlugin();
-   ~SIPPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("sip", "Parse SIP traffic"); }
-   std::string get_name() const { return "sip"; }
-   RecordExt *get_ext() const { return new RecordExtSIP(); }
-   ProcessPlugin *copy();
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void finish(bool print_stats);
+    SIPPlugin();
+    ~SIPPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("sip", "Parse SIP traffic"); }
+    std::string get_name() const { return "sip"; }
+    RecordExt* get_ext() const { return new RecordExtSIP(); }
+    ProcessPlugin* copy();
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   uint16_t parse_msg_type(const Packet &pkt);
-   const unsigned char *parser_strtok(const unsigned char *str, unsigned int instrlen, char separator, unsigned int *strlen, parser_strtok_t *nst);
-   int parser_process_sip(const Packet &pkt, RecordExtSIP *sip_data);
-   void parser_field_uri(const unsigned char *line, int linelen, int skip, char *dst, unsigned int dstlen);
-   void parser_field_value(const unsigned char *line, int linelen, int skip, char *dst, unsigned int dstlen);
+    uint16_t parse_msg_type(const Packet& pkt);
+    const unsigned char* parser_strtok(
+        const unsigned char* str,
+        unsigned int instrlen,
+        char separator,
+        unsigned int* strlen,
+        parser_strtok_t* nst);
+    int parser_process_sip(const Packet& pkt, RecordExtSIP* sip_data);
+    void parser_field_uri(
+        const unsigned char* line,
+        int linelen,
+        int skip,
+        char* dst,
+        unsigned int dstlen);
+    void parser_field_value(
+        const unsigned char* line,
+        int linelen,
+        int skip,
+        char* dst,
+        unsigned int dstlen);
 
-   uint32_t requests;
-   uint32_t responses;
-   uint32_t total;
-   bool flow_flush;
+    uint32_t requests;
+    uint32_t responses;
+    uint32_t total;
+    bool flow_flush;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_SIP_HPP */

--- a/process/smtp.cpp
+++ b/process/smtp.cpp
@@ -26,9 +26,9 @@
  *
  */
 
-#include <iostream>
 #include <cstring>
 #include <ctype.h>
+#include <iostream>
 
 #include "common.hpp"
 #include "smtp.hpp"
@@ -39,73 +39,73 @@ int RecordExtSMTP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("smtp", [](){return new SMTPPlugin();});
-   register_plugin(&rec);
-   RecordExtSMTP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("smtp", []() { return new SMTPPlugin(); });
+    register_plugin(&rec);
+    RecordExtSMTP::REGISTERED_ID = register_extension();
 }
 
-SMTPPlugin::SMTPPlugin() : ext_ptr(nullptr), total(0), replies_cnt(0), commands_cnt(0)
+SMTPPlugin::SMTPPlugin()
+    : ext_ptr(nullptr)
+    , total(0)
+    , replies_cnt(0)
+    , commands_cnt(0)
 {
 }
 
 SMTPPlugin::~SMTPPlugin()
 {
-   close();
+    close();
 }
 
-void SMTPPlugin::init(const char *params)
+void SMTPPlugin::init(const char* params) {}
+
+void SMTPPlugin::close() {}
+
+ProcessPlugin* SMTPPlugin::copy()
 {
+    return new SMTPPlugin(*this);
 }
 
-void SMTPPlugin::close()
+int SMTPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
+    if (pkt.src_port == 25 || pkt.dst_port == 25) {
+        create_smtp_record(rec, pkt);
+    }
+
+    return 0;
 }
 
-ProcessPlugin *SMTPPlugin::copy()
+int SMTPPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   return new SMTPPlugin(*this);
+    if (pkt.src_port == 25 || pkt.dst_port == 25) {
+        RecordExt* ext = rec.get_extension(RecordExtSMTP::REGISTERED_ID);
+        if (ext == nullptr) {
+            create_smtp_record(rec, pkt);
+            return 0;
+        }
+        update_smtp_record(static_cast<RecordExtSMTP*>(ext), pkt);
+    }
+
+    return 0;
 }
 
-int SMTPPlugin::post_create(Flow &rec, const Packet &pkt)
+char* strncasestr(const char* str, size_t n, const char* substr)
 {
-   if (pkt.src_port == 25 || pkt.dst_port == 25) {
-      create_smtp_record(rec, pkt);
-   }
-
-   return 0;
-}
-
-int SMTPPlugin::pre_update(Flow &rec, Packet &pkt)
-{
-   if (pkt.src_port == 25 || pkt.dst_port == 25) {
-      RecordExt *ext = rec.get_extension(RecordExtSMTP::REGISTERED_ID);
-      if (ext == nullptr) {
-         create_smtp_record(rec, pkt);
-         return 0;
-      }
-      update_smtp_record(static_cast<RecordExtSMTP *>(ext), pkt);
-   }
-
-   return 0;
-}
-
-char *strncasestr(const char *str, size_t n, const char *substr)
-{
-   size_t i = 0;
-   size_t j = 0;
-   while (i < n && *str) {
-      if (tolower(*str) == tolower(substr[j])) {
-         j++;
-         if (!substr[j]) {
-            return (char *) str;
-         }
-      } else {
-         j = 0;
-      }
-      i++;
-      str++;
-   }
-   return nullptr;
+    size_t i = 0;
+    size_t j = 0;
+    while (i < n && *str) {
+        if (tolower(*str) == tolower(substr[j])) {
+            j++;
+            if (!substr[j]) {
+                return (char*) str;
+            }
+        } else {
+            j = 0;
+        }
+        i++;
+        str++;
+    }
+    return nullptr;
 }
 
 /**
@@ -116,118 +116,118 @@ char *strncasestr(const char *str, size_t n, const char *substr)
  * \param [out] rec Pointer to SMTP extension record.
  * \return True on success, false otherwise.
  */
-bool SMTPPlugin::parse_smtp_response(const char *data, int payload_len, RecordExtSMTP *rec)
+bool SMTPPlugin::parse_smtp_response(const char* data, int payload_len, RecordExtSMTP* rec)
 {
-   if (payload_len < 5 || !(data[3] == ' ' || data[3] == '-')) {
-      return false;
-   }
-   for (int i = 0; i < 3; i++) {
-      if (!isdigit(data[i])) {
-         return false;
-      }
-   }
+    if (payload_len < 5 || !(data[3] == ' ' || data[3] == '-')) {
+        return false;
+    }
+    for (int i = 0; i < 3; i++) {
+        if (!isdigit(data[i])) {
+            return false;
+        }
+    }
 
-   switch (atoi(data)) {
-      case 211:
-         rec->mail_code_flags |= SMTP_SC_211;
-         break;
-      case 214:
-         rec->mail_code_flags |= SMTP_SC_214;
-         break;
-      case 220:
-         rec->mail_code_flags |= SMTP_SC_220;
-         break;
-      case 221:
-         rec->mail_code_flags |= SMTP_SC_221;
-         break;
-      case 250:
-         rec->mail_code_flags |= SMTP_SC_250;
-         break;
-      case 251:
-         rec->mail_code_flags |= SMTP_SC_251;
-         break;
-      case 252:
-         rec->mail_code_flags |= SMTP_SC_252;
-         break;
-      case 354:
-         rec->mail_code_flags |= SMTP_SC_354;
-         break;
-      case 421:
-         rec->mail_code_flags |= SMTP_SC_421;
-         break;
-      case 450:
-         rec->mail_code_flags |= SMTP_SC_450;
-         break;
-      case 451:
-         rec->mail_code_flags |= SMTP_SC_451;
-         break;
-      case 452:
-         rec->mail_code_flags |= SMTP_SC_452;
-         break;
-      case 455:
-         rec->mail_code_flags |= SMTP_SC_455;
-         break;
-      case 500:
-         rec->mail_code_flags |= SMTP_SC_500;
-         break;
-      case 501:
-         rec->mail_code_flags |= SMTP_SC_501;
-         break;
-      case 502:
-         rec->mail_code_flags |= SMTP_SC_502;
-         break;
-      case 503:
-         rec->mail_code_flags |= SMTP_SC_503;
-         break;
-      case 504:
-         rec->mail_code_flags |= SMTP_SC_504;
-         break;
-      case 550:
-         rec->mail_code_flags |= SMTP_SC_550;
-         break;
-      case 551:
-         rec->mail_code_flags |= SMTP_SC_551;
-         break;
-      case 552:
-         rec->mail_code_flags |= SMTP_SC_552;
-         break;
-      case 553:
-         rec->mail_code_flags |= SMTP_SC_553;
-         break;
-      case 554:
-         rec->mail_code_flags |= SMTP_SC_554;
-         break;
-      case 555:
-         rec->mail_code_flags |= SMTP_SC_555;
-         break;
-      default:
-         rec->mail_code_flags |= SC_UNKNOWN;
-         break;
-   }
+    switch (atoi(data)) {
+    case 211:
+        rec->mail_code_flags |= SMTP_SC_211;
+        break;
+    case 214:
+        rec->mail_code_flags |= SMTP_SC_214;
+        break;
+    case 220:
+        rec->mail_code_flags |= SMTP_SC_220;
+        break;
+    case 221:
+        rec->mail_code_flags |= SMTP_SC_221;
+        break;
+    case 250:
+        rec->mail_code_flags |= SMTP_SC_250;
+        break;
+    case 251:
+        rec->mail_code_flags |= SMTP_SC_251;
+        break;
+    case 252:
+        rec->mail_code_flags |= SMTP_SC_252;
+        break;
+    case 354:
+        rec->mail_code_flags |= SMTP_SC_354;
+        break;
+    case 421:
+        rec->mail_code_flags |= SMTP_SC_421;
+        break;
+    case 450:
+        rec->mail_code_flags |= SMTP_SC_450;
+        break;
+    case 451:
+        rec->mail_code_flags |= SMTP_SC_451;
+        break;
+    case 452:
+        rec->mail_code_flags |= SMTP_SC_452;
+        break;
+    case 455:
+        rec->mail_code_flags |= SMTP_SC_455;
+        break;
+    case 500:
+        rec->mail_code_flags |= SMTP_SC_500;
+        break;
+    case 501:
+        rec->mail_code_flags |= SMTP_SC_501;
+        break;
+    case 502:
+        rec->mail_code_flags |= SMTP_SC_502;
+        break;
+    case 503:
+        rec->mail_code_flags |= SMTP_SC_503;
+        break;
+    case 504:
+        rec->mail_code_flags |= SMTP_SC_504;
+        break;
+    case 550:
+        rec->mail_code_flags |= SMTP_SC_550;
+        break;
+    case 551:
+        rec->mail_code_flags |= SMTP_SC_551;
+        break;
+    case 552:
+        rec->mail_code_flags |= SMTP_SC_552;
+        break;
+    case 553:
+        rec->mail_code_flags |= SMTP_SC_553;
+        break;
+    case 554:
+        rec->mail_code_flags |= SMTP_SC_554;
+        break;
+    case 555:
+        rec->mail_code_flags |= SMTP_SC_555;
+        break;
+    default:
+        rec->mail_code_flags |= SC_UNKNOWN;
+        break;
+    }
 
-   if (strncasestr(data, payload_len, "SPAM") != nullptr) {
-      rec->mail_code_flags |= SC_SPAM;
-   }
+    if (strncasestr(data, payload_len, "SPAM") != nullptr) {
+        rec->mail_code_flags |= SC_SPAM;
+    }
 
-   switch (data[0]) {
-      case '2':
-         rec->code_2xx_cnt++;
-         break;
-      case '3':
-         rec->code_3xx_cnt++;
-         break;
-      case '4':
-         rec->code_4xx_cnt++;
-         break;
-      case '5':
-         rec->code_5xx_cnt++;
-         break;
-      default:
-         return false;
-   }
+    switch (data[0]) {
+    case '2':
+        rec->code_2xx_cnt++;
+        break;
+    case '3':
+        rec->code_3xx_cnt++;
+        break;
+    case '4':
+        rec->code_4xx_cnt++;
+        break;
+    case '5':
+        rec->code_5xx_cnt++;
+        break;
+    default:
+        return false;
+    }
 
-   replies_cnt++;
-   return true;
+    replies_cnt++;
+    return true;
 }
 
 /**
@@ -236,14 +236,14 @@ bool SMTPPlugin::parse_smtp_response(const char *data, int payload_len, RecordEx
  * \param [in] data Pointer to data.
  * \return True on success, false otherwise.
  */
-bool SMTPPlugin::smtp_keyword(const char *data)
+bool SMTPPlugin::smtp_keyword(const char* data)
 {
-   for (int i = 0; data[i]; i++) {
-      if (!isupper(data[i])) {
-         return false;
-      }
-   }
-   return true;
+    for (int i = 0; data[i]; i++) {
+        if (!isupper(data[i])) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /**
@@ -254,164 +254,164 @@ bool SMTPPlugin::smtp_keyword(const char *data)
  * \param [out] rec Pointer to SMTP extension record.
  * \return True on success, false otherwise.
  */
-bool SMTPPlugin::parse_smtp_command(const char *data, int payload_len, RecordExtSMTP *rec)
+bool SMTPPlugin::parse_smtp_command(const char* data, int payload_len, RecordExtSMTP* rec)
 {
-   const char *begin, *end;
-   char buffer[32];
-   size_t len;
-   size_t remaining;
+    const char *begin, *end;
+    char buffer[32];
+    size_t len;
+    size_t remaining;
 
-   if (payload_len == 0) {
-      return false;
-   }
+    if (payload_len == 0) {
+        return false;
+    }
 
-   if (rec->data_transfer) {
-      if (payload_len != 3 || strcmp(data, ".\r\n")) {
-         return false;
-      }
-      rec->data_transfer = 0;
-      return true;
-   }
-
-   begin = data;
-   end = static_cast<const char *>(memchr(begin, '\r', payload_len));
-
-   len = end - begin;
-   if (end == nullptr) {
-      return false;
-   }
-   end = static_cast<const char *>(memchr(begin, ' ', payload_len));
-   if (end != nullptr) {
-      len = end - begin;
-   }
-   if (len >= sizeof(buffer)) {
-      return false;
-   }
-
-   memcpy(buffer, begin, len);
-   buffer[len] = 0;
-
-   if (!strcmp(buffer, "HELO") || !strcmp(buffer, "EHLO")) {
-      if (rec->domain[0] == 0 && end != nullptr) {
-         begin = end;
-         remaining = payload_len - (begin - data);
-         end = static_cast<const char *>(memchr(begin, '\r', remaining));
-         if (end != nullptr && begin != NULL) {
-            begin++;
-            len = end - begin;
-            if (len >= sizeof(rec->domain)) {
-               len = sizeof(rec->domain) - 1;
-            }
-
-            memcpy(rec->domain, begin, len);
-            rec->domain[len] = 0;
-         }
-      }
-      if (!strcmp(buffer, "HELO")) {
-         rec->command_flags |= SMTP_CMD_HELO;
-      } else {
-         rec->command_flags |= SMTP_CMD_EHLO;
-      }
-   } else if (!strcmp(buffer, "RCPT")) {
-      rec->mail_rcpt_cnt++;
-      if (rec->first_recipient[0] == 0 && end != nullptr) {
-         if (check_payload_len(payload_len, (end + 1) - data)) {
+    if (rec->data_transfer) {
+        if (payload_len != 3 || strcmp(data, ".\r\n")) {
             return false;
-         }
-         remaining = payload_len - ((end + 1) - data);
-         begin = static_cast<const char *>(memchr(end + 1, ':', remaining));
-         remaining = payload_len - (end - data);
-         end = static_cast<const char *>(memchr(end, '\r', remaining));
+        }
+        rec->data_transfer = 0;
+        return true;
+    }
 
-         if (end != nullptr && begin != NULL) {
-            begin++;
-            len = end - begin;
-            if (len >= sizeof(rec->first_recipient)) {
-               len = sizeof(rec->first_recipient) - 1;
+    begin = data;
+    end = static_cast<const char*>(memchr(begin, '\r', payload_len));
+
+    len = end - begin;
+    if (end == nullptr) {
+        return false;
+    }
+    end = static_cast<const char*>(memchr(begin, ' ', payload_len));
+    if (end != nullptr) {
+        len = end - begin;
+    }
+    if (len >= sizeof(buffer)) {
+        return false;
+    }
+
+    memcpy(buffer, begin, len);
+    buffer[len] = 0;
+
+    if (!strcmp(buffer, "HELO") || !strcmp(buffer, "EHLO")) {
+        if (rec->domain[0] == 0 && end != nullptr) {
+            begin = end;
+            remaining = payload_len - (begin - data);
+            end = static_cast<const char*>(memchr(begin, '\r', remaining));
+            if (end != nullptr && begin != NULL) {
+                begin++;
+                len = end - begin;
+                if (len >= sizeof(rec->domain)) {
+                    len = sizeof(rec->domain) - 1;
+                }
+
+                memcpy(rec->domain, begin, len);
+                rec->domain[len] = 0;
             }
-
-            memcpy(rec->first_recipient, begin, len);
-            rec->first_recipient[len] = 0;
-         }
-      }
-      rec->command_flags |= SMTP_CMD_RCPT;
-   } else if (!strcmp(buffer, "MAIL")) {
-      rec->mail_cmd_cnt++;
-      if (rec->first_sender[0] == 0 && end != nullptr) {
-         if (check_payload_len(payload_len, (end + 1) - data)) {
-            return false;
-         }
-         remaining = payload_len - ((end + 1) - data);
-         begin = static_cast<const char *>(memchr(end + 1, ':', remaining));
-         remaining = payload_len - (end - data);
-         end = static_cast<const char *>(memchr(end, '\r', remaining));
-
-         if (end != nullptr && begin != NULL) {
-            begin++;
-            len = end - begin;
-            if (len >= sizeof(rec->first_sender)) {
-               len = sizeof(rec->first_sender) - 1;
+        }
+        if (!strcmp(buffer, "HELO")) {
+            rec->command_flags |= SMTP_CMD_HELO;
+        } else {
+            rec->command_flags |= SMTP_CMD_EHLO;
+        }
+    } else if (!strcmp(buffer, "RCPT")) {
+        rec->mail_rcpt_cnt++;
+        if (rec->first_recipient[0] == 0 && end != nullptr) {
+            if (check_payload_len(payload_len, (end + 1) - data)) {
+                return false;
             }
+            remaining = payload_len - ((end + 1) - data);
+            begin = static_cast<const char*>(memchr(end + 1, ':', remaining));
+            remaining = payload_len - (end - data);
+            end = static_cast<const char*>(memchr(end, '\r', remaining));
 
-            memcpy(rec->first_sender, begin, len);
-            rec->first_sender[len] = 0;
-         }
-      }
-      rec->command_flags |= SMTP_CMD_MAIL;
-   } else if (!strcmp(buffer, "DATA")) {
-      rec->data_transfer = 1;
-      rec->command_flags |= SMTP_CMD_DATA;
-   } else if (!strcmp(buffer, "VRFY")) {
-      rec->command_flags |= SMTP_CMD_VRFY;
-   } else if (!strcmp(buffer, "EXPN")) {
-      rec->command_flags |= SMTP_CMD_EXPN;
-   } else if (!strcmp(buffer, "HELP")) {
-      rec->command_flags |= SMTP_CMD_HELP;
-   } else if (!strcmp(buffer, "NOOP")) {
-      rec->command_flags |= SMTP_CMD_NOOP;
-   } else if (!strcmp(buffer, "QUIT")) {
-      rec->command_flags |= SMTP_CMD_QUIT;
-   } else if (!smtp_keyword(buffer)) {
-      rec->command_flags |= CMD_UNKNOWN;
-   }
+            if (end != nullptr && begin != NULL) {
+                begin++;
+                len = end - begin;
+                if (len >= sizeof(rec->first_recipient)) {
+                    len = sizeof(rec->first_recipient) - 1;
+                }
 
-   commands_cnt++;
-   return true;
+                memcpy(rec->first_recipient, begin, len);
+                rec->first_recipient[len] = 0;
+            }
+        }
+        rec->command_flags |= SMTP_CMD_RCPT;
+    } else if (!strcmp(buffer, "MAIL")) {
+        rec->mail_cmd_cnt++;
+        if (rec->first_sender[0] == 0 && end != nullptr) {
+            if (check_payload_len(payload_len, (end + 1) - data)) {
+                return false;
+            }
+            remaining = payload_len - ((end + 1) - data);
+            begin = static_cast<const char*>(memchr(end + 1, ':', remaining));
+            remaining = payload_len - (end - data);
+            end = static_cast<const char*>(memchr(end, '\r', remaining));
+
+            if (end != nullptr && begin != NULL) {
+                begin++;
+                len = end - begin;
+                if (len >= sizeof(rec->first_sender)) {
+                    len = sizeof(rec->first_sender) - 1;
+                }
+
+                memcpy(rec->first_sender, begin, len);
+                rec->first_sender[len] = 0;
+            }
+        }
+        rec->command_flags |= SMTP_CMD_MAIL;
+    } else if (!strcmp(buffer, "DATA")) {
+        rec->data_transfer = 1;
+        rec->command_flags |= SMTP_CMD_DATA;
+    } else if (!strcmp(buffer, "VRFY")) {
+        rec->command_flags |= SMTP_CMD_VRFY;
+    } else if (!strcmp(buffer, "EXPN")) {
+        rec->command_flags |= SMTP_CMD_EXPN;
+    } else if (!strcmp(buffer, "HELP")) {
+        rec->command_flags |= SMTP_CMD_HELP;
+    } else if (!strcmp(buffer, "NOOP")) {
+        rec->command_flags |= SMTP_CMD_NOOP;
+    } else if (!strcmp(buffer, "QUIT")) {
+        rec->command_flags |= SMTP_CMD_QUIT;
+    } else if (!smtp_keyword(buffer)) {
+        rec->command_flags |= CMD_UNKNOWN;
+    }
+
+    commands_cnt++;
+    return true;
 }
 
-void SMTPPlugin::create_smtp_record(Flow &rec, const Packet &pkt)
+void SMTPPlugin::create_smtp_record(Flow& rec, const Packet& pkt)
 {
-   if (ext_ptr == nullptr) {
-      ext_ptr = new RecordExtSMTP();
-   }
+    if (ext_ptr == nullptr) {
+        ext_ptr = new RecordExtSMTP();
+    }
 
-   if (update_smtp_record(ext_ptr, pkt)) {
-      rec.add_extension(ext_ptr);
-      ext_ptr = nullptr;
-   }
+    if (update_smtp_record(ext_ptr, pkt)) {
+        rec.add_extension(ext_ptr);
+        ext_ptr = nullptr;
+    }
 }
 
-bool SMTPPlugin::update_smtp_record(RecordExtSMTP *ext, const Packet &pkt)
+bool SMTPPlugin::update_smtp_record(RecordExtSMTP* ext, const Packet& pkt)
 {
-   total++;
-   const char *payload = reinterpret_cast<const char *>(pkt.payload);
-   if (pkt.src_port == 25) {
-      return parse_smtp_response(payload, pkt.payload_len, ext);
-   } else if (pkt.dst_port == 25) {
-      return parse_smtp_command(payload, pkt.payload_len, ext);
-   }
+    total++;
+    const char* payload = reinterpret_cast<const char*>(pkt.payload);
+    if (pkt.src_port == 25) {
+        return parse_smtp_response(payload, pkt.payload_len, ext);
+    } else if (pkt.dst_port == 25) {
+        return parse_smtp_command(payload, pkt.payload_len, ext);
+    }
 
-   return false;
+    return false;
 }
 
 void SMTPPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "SMTP plugin stats:" << std::endl;
-      std::cout << "   Total SMTP packets: " << total << std::endl;
-      std::cout << "   Parsed SMTP replies: " << replies_cnt << std::endl;
-      std::cout << "   Parsed SMTP commands: " << commands_cnt << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "SMTP plugin stats:" << std::endl;
+        std::cout << "   Total SMTP packets: " << total << std::endl;
+        std::cout << "   Parsed SMTP replies: " << replies_cnt << std::endl;
+        std::cout << "   Parsed SMTP commands: " << commands_cnt << std::endl;
+    }
 }
 
-}
+} // namespace ipxp

--- a/process/smtp.hpp
+++ b/process/smtp.hpp
@@ -29,234 +29,225 @@
 #ifndef IPXP_PROCESS_SMTP_HPP
 #define IPXP_PROCESS_SMTP_HPP
 
-#include <string>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 /* Commands. */
-#define SMTP_CMD_EHLO      0x0001
-#define SMTP_CMD_HELO      0x0002
-#define SMTP_CMD_MAIL      0x0004
-#define SMTP_CMD_RCPT      0x0008
-#define SMTP_CMD_DATA      0x0010
-#define SMTP_CMD_RSET      0x0020
-#define SMTP_CMD_VRFY      0x0040
-#define SMTP_CMD_EXPN      0x0080
-#define SMTP_CMD_HELP      0x0100
-#define SMTP_CMD_NOOP      0x0200
-#define SMTP_CMD_QUIT      0x0400
-#define CMD_UNKNOWN        0x8000
+#define SMTP_CMD_EHLO 0x0001
+#define SMTP_CMD_HELO 0x0002
+#define SMTP_CMD_MAIL 0x0004
+#define SMTP_CMD_RCPT 0x0008
+#define SMTP_CMD_DATA 0x0010
+#define SMTP_CMD_RSET 0x0020
+#define SMTP_CMD_VRFY 0x0040
+#define SMTP_CMD_EXPN 0x0080
+#define SMTP_CMD_HELP 0x0100
+#define SMTP_CMD_NOOP 0x0200
+#define SMTP_CMD_QUIT 0x0400
+#define CMD_UNKNOWN 0x8000
 
 /* Status codes. */
-#define SMTP_SC_211        0x00000001
-#define SMTP_SC_214        0x00000002
-#define SMTP_SC_220        0x00000004
-#define SMTP_SC_221        0x00000008
-#define SMTP_SC_250        0x00000010
-#define SMTP_SC_251        0x00000020
-#define SMTP_SC_252        0x00000040
-#define SMTP_SC_354        0x00000080
-#define SMTP_SC_421        0x00000100
-#define SMTP_SC_450        0x00000200
-#define SMTP_SC_451        0x00000400
-#define SMTP_SC_452        0x00000800
-#define SMTP_SC_455        0x00001000
-#define SMTP_SC_500        0x00002000
-#define SMTP_SC_501        0x00004000
-#define SMTP_SC_502        0x00008000
-#define SMTP_SC_503        0x00010000
-#define SMTP_SC_504        0x00020000
-#define SMTP_SC_550        0x00040000
-#define SMTP_SC_551        0x00080000
-#define SMTP_SC_552        0x00100000
-#define SMTP_SC_553        0x00200000
-#define SMTP_SC_554        0x00400000
-#define SMTP_SC_555        0x00800000
-#define SC_SPAM            0x40000000 // indicates that answer contains SPAM keyword
-#define SC_UNKNOWN         0x80000000
+#define SMTP_SC_211 0x00000001
+#define SMTP_SC_214 0x00000002
+#define SMTP_SC_220 0x00000004
+#define SMTP_SC_221 0x00000008
+#define SMTP_SC_250 0x00000010
+#define SMTP_SC_251 0x00000020
+#define SMTP_SC_252 0x00000040
+#define SMTP_SC_354 0x00000080
+#define SMTP_SC_421 0x00000100
+#define SMTP_SC_450 0x00000200
+#define SMTP_SC_451 0x00000400
+#define SMTP_SC_452 0x00000800
+#define SMTP_SC_455 0x00001000
+#define SMTP_SC_500 0x00002000
+#define SMTP_SC_501 0x00004000
+#define SMTP_SC_502 0x00008000
+#define SMTP_SC_503 0x00010000
+#define SMTP_SC_504 0x00020000
+#define SMTP_SC_550 0x00040000
+#define SMTP_SC_551 0x00080000
+#define SMTP_SC_552 0x00100000
+#define SMTP_SC_553 0x00200000
+#define SMTP_SC_554 0x00400000
+#define SMTP_SC_555 0x00800000
+#define SC_SPAM 0x40000000 // indicates that answer contains SPAM keyword
+#define SC_UNKNOWN 0x80000000
 
-#define SMTP_UNIREC_TEMPLATE "SMTP_2XX_STAT_CODE_COUNT,SMTP_3XX_STAT_CODE_COUNT,SMTP_4XX_STAT_CODE_COUNT,SMTP_5XX_STAT_CODE_COUNT,SMTP_COMMAND_FLAGS,SMTP_MAIL_CMD_COUNT,SMTP_RCPT_CMD_COUNT,SMTP_STAT_CODE_FLAGS,SMTP_DOMAIN,SMTP_FIRST_RECIPIENT,SMTP_FIRST_SENDER"
+#define SMTP_UNIREC_TEMPLATE                                                                       \
+    "SMTP_2XX_STAT_CODE_COUNT,SMTP_3XX_STAT_CODE_COUNT,SMTP_4XX_STAT_CODE_COUNT,SMTP_5XX_STAT_"    \
+    "CODE_COUNT,SMTP_COMMAND_FLAGS,SMTP_MAIL_CMD_COUNT,SMTP_RCPT_CMD_COUNT,SMTP_STAT_CODE_FLAGS,"  \
+    "SMTP_DOMAIN,SMTP_FIRST_RECIPIENT,SMTP_FIRST_SENDER"
 
-UR_FIELDS (
-   uint32 SMTP_2XX_STAT_CODE_COUNT,
-   uint32 SMTP_3XX_STAT_CODE_COUNT,
-   uint32 SMTP_4XX_STAT_CODE_COUNT,
-   uint32 SMTP_5XX_STAT_CODE_COUNT,
-   uint32 SMTP_COMMAND_FLAGS,
-   uint32 SMTP_MAIL_CMD_COUNT,
-   uint32 SMTP_RCPT_CMD_COUNT,
-   uint32 SMTP_STAT_CODE_FLAGS,
-   string SMTP_DOMAIN,
-   string SMTP_FIRST_SENDER,
-   string SMTP_FIRST_RECIPIENT
-)
+UR_FIELDS(
+    uint32 SMTP_2XX_STAT_CODE_COUNT,
+    uint32 SMTP_3XX_STAT_CODE_COUNT,
+    uint32 SMTP_4XX_STAT_CODE_COUNT,
+    uint32 SMTP_5XX_STAT_CODE_COUNT,
+    uint32 SMTP_COMMAND_FLAGS,
+    uint32 SMTP_MAIL_CMD_COUNT,
+    uint32 SMTP_RCPT_CMD_COUNT,
+    uint32 SMTP_STAT_CODE_FLAGS,
+    string SMTP_DOMAIN,
+    string SMTP_FIRST_SENDER,
+    string SMTP_FIRST_RECIPIENT)
 
 /**
  * \brief Flow record extension header for storing parsed SMTP packets.
  */
 struct RecordExtSMTP : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint32_t code_2xx_cnt;
-   uint32_t code_3xx_cnt;
-   uint32_t code_4xx_cnt;
-   uint32_t code_5xx_cnt;
-   uint32_t command_flags;
-   uint32_t mail_cmd_cnt;
-   uint32_t mail_rcpt_cnt;
-   uint32_t mail_code_flags;
-   char domain[255];
-   char first_sender[255];
-   char first_recipient[255];
-   int data_transfer;
+    uint32_t code_2xx_cnt;
+    uint32_t code_3xx_cnt;
+    uint32_t code_4xx_cnt;
+    uint32_t code_5xx_cnt;
+    uint32_t command_flags;
+    uint32_t mail_cmd_cnt;
+    uint32_t mail_rcpt_cnt;
+    uint32_t mail_code_flags;
+    char domain[255];
+    char first_sender[255];
+    char first_recipient[255];
+    int data_transfer;
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtSMTP() : RecordExt(REGISTERED_ID)
-   {
-      code_2xx_cnt = 0;
-      code_3xx_cnt = 0;
-      code_4xx_cnt = 0;
-      code_5xx_cnt = 0;
-      command_flags = 0;
-      mail_cmd_cnt = 0;
-      mail_rcpt_cnt = 0;
-      mail_code_flags = 0;
-      domain[0] = 0;
-      first_sender[0] = 0;
-      first_recipient[0] = 0;
-      data_transfer = 0;
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtSMTP()
+        : RecordExt(REGISTERED_ID)
+    {
+        code_2xx_cnt = 0;
+        code_3xx_cnt = 0;
+        code_4xx_cnt = 0;
+        code_5xx_cnt = 0;
+        command_flags = 0;
+        mail_cmd_cnt = 0;
+        mail_rcpt_cnt = 0;
+        mail_code_flags = 0;
+        domain[0] = 0;
+        first_sender[0] = 0;
+        first_recipient[0] = 0;
+        data_transfer = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_SMTP_2XX_STAT_CODE_COUNT, code_2xx_cnt);
-      ur_set(tmplt, record, F_SMTP_3XX_STAT_CODE_COUNT, code_3xx_cnt);
-      ur_set(tmplt, record, F_SMTP_4XX_STAT_CODE_COUNT, code_4xx_cnt);
-      ur_set(tmplt, record, F_SMTP_5XX_STAT_CODE_COUNT, code_5xx_cnt);
-      ur_set(tmplt, record, F_SMTP_COMMAND_FLAGS, command_flags);
-      ur_set(tmplt, record, F_SMTP_MAIL_CMD_COUNT, mail_cmd_cnt);
-      ur_set(tmplt, record, F_SMTP_RCPT_CMD_COUNT, mail_rcpt_cnt);
-      ur_set(tmplt, record, F_SMTP_STAT_CODE_FLAGS, mail_code_flags);
-      ur_set_string(tmplt, record, F_SMTP_DOMAIN, domain);
-      ur_set_string(tmplt, record, F_SMTP_FIRST_SENDER, first_sender);
-      ur_set_string(tmplt, record, F_SMTP_FIRST_RECIPIENT, first_recipient);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_SMTP_2XX_STAT_CODE_COUNT, code_2xx_cnt);
+        ur_set(tmplt, record, F_SMTP_3XX_STAT_CODE_COUNT, code_3xx_cnt);
+        ur_set(tmplt, record, F_SMTP_4XX_STAT_CODE_COUNT, code_4xx_cnt);
+        ur_set(tmplt, record, F_SMTP_5XX_STAT_CODE_COUNT, code_5xx_cnt);
+        ur_set(tmplt, record, F_SMTP_COMMAND_FLAGS, command_flags);
+        ur_set(tmplt, record, F_SMTP_MAIL_CMD_COUNT, mail_cmd_cnt);
+        ur_set(tmplt, record, F_SMTP_RCPT_CMD_COUNT, mail_rcpt_cnt);
+        ur_set(tmplt, record, F_SMTP_STAT_CODE_FLAGS, mail_code_flags);
+        ur_set_string(tmplt, record, F_SMTP_DOMAIN, domain);
+        ur_set_string(tmplt, record, F_SMTP_FIRST_SENDER, first_sender);
+        ur_set_string(tmplt, record, F_SMTP_FIRST_RECIPIENT, first_recipient);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return SMTP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return SMTP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int domain_len = strlen(domain);
-      int sender_len = strlen(first_sender);
-      int recipient_len = strlen(first_recipient);
-      int length;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int domain_len = strlen(domain);
+        int sender_len = strlen(first_sender);
+        int recipient_len = strlen(first_recipient);
+        int length;
 
-      if (domain_len + sender_len + recipient_len + 35 > size) {
-         return -1;
-      }
+        if (domain_len + sender_len + recipient_len + 35 > size) {
+            return -1;
+        }
 
-      *(uint32_t *) (buffer) = ntohl(command_flags);
-      *(uint32_t *) (buffer + 4) = ntohl(mail_cmd_cnt);
-      *(uint32_t *) (buffer + 8) = ntohl(mail_rcpt_cnt);
-      *(uint32_t *) (buffer + 12) = ntohl(mail_code_flags);
-      *(uint32_t *) (buffer + 16) = ntohl(code_2xx_cnt);
-      *(uint32_t *) (buffer + 20) = ntohl(code_3xx_cnt);
-      *(uint32_t *) (buffer + 24) = ntohl(code_4xx_cnt);
-      *(uint32_t *) (buffer + 28) = ntohl(code_5xx_cnt);
+        *(uint32_t*) (buffer) = ntohl(command_flags);
+        *(uint32_t*) (buffer + 4) = ntohl(mail_cmd_cnt);
+        *(uint32_t*) (buffer + 8) = ntohl(mail_rcpt_cnt);
+        *(uint32_t*) (buffer + 12) = ntohl(mail_code_flags);
+        *(uint32_t*) (buffer + 16) = ntohl(code_2xx_cnt);
+        *(uint32_t*) (buffer + 20) = ntohl(code_3xx_cnt);
+        *(uint32_t*) (buffer + 24) = ntohl(code_4xx_cnt);
+        *(uint32_t*) (buffer + 28) = ntohl(code_5xx_cnt);
 
-      length = 32;
-      buffer[length++] = domain_len;
-      memcpy(buffer + length, domain, domain_len);
+        length = 32;
+        buffer[length++] = domain_len;
+        memcpy(buffer + length, domain, domain_len);
 
-      length += domain_len;
-      buffer[length++] = sender_len;
-      memcpy(buffer + length, first_sender, sender_len);
+        length += domain_len;
+        buffer[length++] = sender_len;
+        memcpy(buffer + length, first_sender, sender_len);
 
-      length += sender_len;
-      buffer[length++] = recipient_len;
-      memcpy(buffer + length, first_recipient, recipient_len);
+        length += sender_len;
+        buffer[length++] = recipient_len;
+        memcpy(buffer + length, first_recipient, recipient_len);
 
-      length += recipient_len;
+        length += recipient_len;
 
-      return length;
-   }
+        return length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_SMTP_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_SMTP_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "2xxcnt=" << code_2xx_cnt
-         << ",3xxcnt=" << code_3xx_cnt
-         << ",4xxcnt=" << code_4xx_cnt
-         << ",5xxcnt=" << code_5xx_cnt
-         << ",cmdflgs=" << command_flags
-         << ",mailcmdcnt=" << mail_cmd_cnt
-         << ",rcptcmdcnt=" << mail_rcpt_cnt
-         << ",codeflags=" << mail_code_flags
-         << ",domain=\"" << domain << "\""
-         << ",firstsender=\"" << first_sender << "\""
-         << ",firstrecipient=\"" << first_recipient << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "2xxcnt=" << code_2xx_cnt << ",3xxcnt=" << code_3xx_cnt << ",4xxcnt=" << code_4xx_cnt
+            << ",5xxcnt=" << code_5xx_cnt << ",cmdflgs=" << command_flags
+            << ",mailcmdcnt=" << mail_cmd_cnt << ",rcptcmdcnt=" << mail_rcpt_cnt
+            << ",codeflags=" << mail_code_flags << ",domain=\"" << domain << "\""
+            << ",firstsender=\"" << first_sender << "\""
+            << ",firstrecipient=\"" << first_recipient << "\"";
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing SMTP packets.
  */
-class SMTPPlugin : public ProcessPlugin
-{
+class SMTPPlugin : public ProcessPlugin {
 public:
-   SMTPPlugin();
-   ~SMTPPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("smtp", "Parse SMTP traffic"); }
-   std::string get_name() const { return "smtp"; }
-   RecordExt *get_ext() const { return new RecordExtSMTP(); }
-   ProcessPlugin *copy();
+    SMTPPlugin();
+    ~SMTPPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("smtp", "Parse SMTP traffic"); }
+    std::string get_name() const { return "smtp"; }
+    RecordExt* get_ext() const { return new RecordExtSMTP(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void finish(bool print_stats);
 
-   bool smtp_keyword(const char *data);
-   bool parse_smtp_response(const char *data, int payload_len, RecordExtSMTP *rec);
-   bool parse_smtp_command(const char *data, int payload_len, RecordExtSMTP *rec);
-   void create_smtp_record(Flow &rec, const Packet &pkt);
-   bool update_smtp_record(RecordExtSMTP *ext, const Packet &pkt);
+    bool smtp_keyword(const char* data);
+    bool parse_smtp_response(const char* data, int payload_len, RecordExtSMTP* rec);
+    bool parse_smtp_command(const char* data, int payload_len, RecordExtSMTP* rec);
+    void create_smtp_record(Flow& rec, const Packet& pkt);
+    bool update_smtp_record(RecordExtSMTP* ext, const Packet& pkt);
 
 private:
-   RecordExtSMTP *ext_ptr; /**< Pointer to allocated record extension. */
-   uint32_t total;         /**< Total number of SMTP packets seen. */
-   uint32_t replies_cnt;   /**< Total number of SMTP replies. */
-   uint32_t commands_cnt;  /**< Total number of SMTP commands. */
+    RecordExtSMTP* ext_ptr; /**< Pointer to allocated record extension. */
+    uint32_t total; /**< Total number of SMTP packets seen. */
+    uint32_t replies_cnt; /**< Total number of SMTP replies. */
+    uint32_t commands_cnt; /**< Total number of SMTP commands. */
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_SMTP_HPP */

--- a/process/ssadetector.cpp
+++ b/process/ssadetector.cpp
@@ -37,14 +37,14 @@ int RecordExtSSADetector::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("ssadetector", []() { return new SSADetectorPlugin(); });
-   register_plugin(&rec);
-   RecordExtSSADetector::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("ssadetector", []() { return new SSADetectorPlugin(); });
+    register_plugin(&rec);
+    RecordExtSSADetector::REGISTERED_ID = register_extension();
 }
 
 SSADetectorPlugin::SSADetectorPlugin()
 {
-   close();
+    close();
 }
 
 SSADetectorPlugin::~SSADetectorPlugin() {}
@@ -55,7 +55,7 @@ void SSADetectorPlugin::close() {}
 
 ProcessPlugin* SSADetectorPlugin::copy()
 {
-   return new SSADetectorPlugin(*this);
+    return new SSADetectorPlugin(*this);
 }
 
 inline void SSADetectorPlugin::transition_from_init(
@@ -64,7 +64,7 @@ inline void SSADetectorPlugin::transition_from_init(
     const timeval& ts,
     uint8_t dir)
 {
-   record->syn_table.update_entry(len, dir, ts);
+    record->syn_table.update_entry(len, dir, ts);
 }
 
 inline void SSADetectorPlugin::transition_from_syn(
@@ -73,10 +73,10 @@ inline void SSADetectorPlugin::transition_from_syn(
     const timeval& ts,
     uint8_t dir)
 {
-   bool can_transit = record->syn_table.check_range_for_presence(len, SYN_LOOKUP_WINDOW, !dir, ts);
-   if (can_transit) {
-      record->syn_ack_table.update_entry(len, dir, ts);
-   }
+    bool can_transit = record->syn_table.check_range_for_presence(len, SYN_LOOKUP_WINDOW, !dir, ts);
+    if (can_transit) {
+        record->syn_ack_table.update_entry(len, dir, ts);
+    }
 }
 
 inline bool SSADetectorPlugin::transition_from_syn_ack(
@@ -85,143 +85,142 @@ inline bool SSADetectorPlugin::transition_from_syn_ack(
     const timeval& ts,
     uint8_t dir)
 {
-   return record->syn_table.check_range_for_presence(len, SYN_ACK_LOOKUP_WINDOW, !dir, ts);
+    return record->syn_table.check_range_for_presence(len, SYN_ACK_LOOKUP_WINDOW, !dir, ts);
 }
 
 void SSADetectorPlugin::update_record(RecordExtSSADetector* record, const Packet& pkt)
 {
-   /**
-    * 0 - client -> server
-    * 1 - server -> client
-    */
-   uint8_t dir = pkt.source_pkt ? 0 : 1;
-   uint16_t len = pkt.payload_len;
-   timeval ts = pkt.ts;
+    /**
+     * 0 - client -> server
+     * 1 - server -> client
+     */
+    uint8_t dir = pkt.source_pkt ? 0 : 1;
+    uint16_t len = pkt.payload_len;
+    timeval ts = pkt.ts;
 
-   if (!(MIN_PKT_SIZE <= len && len <= MAX_PKT_SIZE)) {
-      return;
-   }
+    if (!(MIN_PKT_SIZE <= len && len <= MAX_PKT_SIZE)) {
+        return;
+    }
 
-   bool reached_end_state = transition_from_syn_ack(record, len, ts, dir);
+    bool reached_end_state = transition_from_syn_ack(record, len, ts, dir);
 
-   if (reached_end_state) {
-      record->reset();
-      if (record->syn_pkts_idx < SYN_RECORDS_NUM) {
-         record->syn_pkts[record->syn_pkts_idx] = len;
-         record->syn_pkts_idx += 1;
-      }
-      record->suspects += 1;
-      return;
-   }
+    if (reached_end_state) {
+        record->reset();
+        if (record->syn_pkts_idx < SYN_RECORDS_NUM) {
+            record->syn_pkts[record->syn_pkts_idx] = len;
+            record->syn_pkts_idx += 1;
+        }
+        record->suspects += 1;
+        return;
+    }
 
-   transition_from_syn(record, len, ts, dir);
-   transition_from_init(record, len, ts, dir);
+    transition_from_syn(record, len, ts, dir);
+    transition_from_init(record, len, ts, dir);
 }
-
 
 int SSADetectorPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   RecordExtSSADetector *record = nullptr;
-   if (rec.src_packets + rec.dst_packets < MIN_PKT_IN_FLOW) {
-      return 0;
-   }
+    RecordExtSSADetector* record = nullptr;
+    if (rec.src_packets + rec.dst_packets < MIN_PKT_IN_FLOW) {
+        return 0;
+    }
 
-   record = (RecordExtSSADetector *) rec.get_extension(RecordExtSSADetector::REGISTERED_ID);
-   if (record == nullptr) {
-      record = new RecordExtSSADetector();
-      rec.add_extension(record);   
-   }
-   
-   update_record(record, pkt);
-   return 0;
+    record = (RecordExtSSADetector*) rec.get_extension(RecordExtSSADetector::REGISTERED_ID);
+    if (record == nullptr) {
+        record = new RecordExtSSADetector();
+        rec.add_extension(record);
+    }
+
+    update_record(record, pkt);
+    return 0;
 }
 
 double classes_ratio(uint8_t* syn_pkts, uint8_t size)
 {
-   uint8_t unique_members = 0;
-   bool marked[size];
-   for (uint8_t i = 0; i < size; ++i)
-      marked[i] = false;
-   for (uint8_t i = 0; i < size; ++i) {
-      if (marked[i]) {
-         continue;
-      }
-      uint8_t akt_pkt_size = syn_pkts[i];
-      unique_members++;
-      marked[i] = true;
-      for (uint8_t j = i + 1; j < size; ++j) {
-         if (marked[j]) {
+    uint8_t unique_members = 0;
+    bool marked[size];
+    for (uint8_t i = 0; i < size; ++i)
+        marked[i] = false;
+    for (uint8_t i = 0; i < size; ++i) {
+        if (marked[i]) {
             continue;
-         }
-         if (syn_pkts[j] == akt_pkt_size) {
-            marked[j] = true;
-         }
-      }
-   }
+        }
+        uint8_t akt_pkt_size = syn_pkts[i];
+        unique_members++;
+        marked[i] = true;
+        for (uint8_t j = i + 1; j < size; ++j) {
+            if (marked[j]) {
+                continue;
+            }
+            if (syn_pkts[j] == akt_pkt_size) {
+                marked[j] = true;
+            }
+        }
+    }
 
-   return double(unique_members) / double(size);
+    return double(unique_members) / double(size);
 }
 
 void SSADetectorPlugin::pre_export(Flow& rec)
 {
-   // do not export for small packets flows
-   uint32_t packets = rec.src_packets + rec.dst_packets;
-   if (packets <= MIN_PKT_IN_FLOW) {
-      rec.remove_extension(RecordExtSSADetector::REGISTERED_ID);
-      return;
-   }
+    // do not export for small packets flows
+    uint32_t packets = rec.src_packets + rec.dst_packets;
+    if (packets <= MIN_PKT_IN_FLOW) {
+        rec.remove_extension(RecordExtSSADetector::REGISTERED_ID);
+        return;
+    }
 
-   RecordExtSSADetector* record
-       = (RecordExtSSADetector*) rec.get_extension(RecordExtSSADetector::REGISTERED_ID);
-   const auto& suspects = record->suspects;
-   if (suspects < MIN_NUM_SUSPECTS) {
-      return;
-   }
-   if (double(packets) / double(suspects) > MIN_SUSPECTS_RATIO) {
-      return;
-   }
-   if (suspects < LOW_NUM_SUSPECTS_THRESHOLD) {
-      if (classes_ratio(record->syn_pkts, record->syn_pkts_idx) > LOW_NUM_SUSPECTS_MAX_RATIO) {
-         return;
-      }
-   } else if (suspects < MID_NUM_SUSPECTS_THRESHOLD) {
-      if (classes_ratio(record->syn_pkts, record->syn_pkts_idx) > MID_NUM_SUSPECTS_MAX_RATIO) {
-         return;
-      }
-   } else {
-      if (classes_ratio(record->syn_pkts, record->syn_pkts_idx) > HIGH_NUM_SUSPECTS_MAX_RATIO) {
-         return;
-      }
-   }
+    RecordExtSSADetector* record
+        = (RecordExtSSADetector*) rec.get_extension(RecordExtSSADetector::REGISTERED_ID);
+    const auto& suspects = record->suspects;
+    if (suspects < MIN_NUM_SUSPECTS) {
+        return;
+    }
+    if (double(packets) / double(suspects) > MIN_SUSPECTS_RATIO) {
+        return;
+    }
+    if (suspects < LOW_NUM_SUSPECTS_THRESHOLD) {
+        if (classes_ratio(record->syn_pkts, record->syn_pkts_idx) > LOW_NUM_SUSPECTS_MAX_RATIO) {
+            return;
+        }
+    } else if (suspects < MID_NUM_SUSPECTS_THRESHOLD) {
+        if (classes_ratio(record->syn_pkts, record->syn_pkts_idx) > MID_NUM_SUSPECTS_MAX_RATIO) {
+            return;
+        }
+    } else {
+        if (classes_ratio(record->syn_pkts, record->syn_pkts_idx) > HIGH_NUM_SUSPECTS_MAX_RATIO) {
+            return;
+        }
+    }
 
-   record->possible_vpn = 1;
+    record->possible_vpn = 1;
 }
 
 //--------------------RecordExtSSADetector::pkt_entry-------------------------------
 void RecordExtSSADetector::pkt_entry::reset()
 {
-   ts_dir1.tv_sec = 0;
-   ts_dir1.tv_usec = 0;
-   ts_dir2.tv_sec = 0;
-   ts_dir2.tv_usec = 0;
+    ts_dir1.tv_sec = 0;
+    ts_dir1.tv_usec = 0;
+    ts_dir2.tv_sec = 0;
+    ts_dir2.tv_usec = 0;
 }
 
 timeval& RecordExtSSADetector::pkt_entry::get_time(dir_t dir)
 {
-   return (dir == 1) ? ts_dir1 : ts_dir2;
+    return (dir == 1) ? ts_dir1 : ts_dir2;
 }
 
 RecordExtSSADetector::pkt_entry::pkt_entry()
 {
-   reset();
+    reset();
 }
 
 //--------------------RecordExtSSADetector::pkt_table-------------------------------
 void RecordExtSSADetector::pkt_table::reset()
 {
-   for (int i = 0; i < PKT_TABLE_SIZE; ++i) {
-      table_[i].reset();
-   }
+    for (int i = 0; i < PKT_TABLE_SIZE; ++i) {
+        table_[i].reset();
+    }
 }
 
 bool RecordExtSSADetector::pkt_table::check_range_for_presence(
@@ -230,35 +229,35 @@ bool RecordExtSSADetector::pkt_table::check_range_for_presence(
     dir_t dir,
     const timeval& ts_to_compare)
 {
-   int8_t idx = get_idx_from_len(len);
-   for (int8_t i = std::max(idx - down_by, 0); i <= idx; ++i) {
-      if (entry_is_present(i, dir, ts_to_compare)) {
-         return true;
-      }
-   }
-   return false;
+    int8_t idx = get_idx_from_len(len);
+    for (int8_t i = std::max(idx - down_by, 0); i <= idx; ++i) {
+        if (entry_is_present(i, dir, ts_to_compare)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void RecordExtSSADetector::pkt_table::update_entry(uint16_t len, dir_t dir, timeval ts)
 {
-   int8_t idx = get_idx_from_len(len);
-   if (dir == 1) {
-      table_[idx].ts_dir1 = ts;
-   } else {
-      table_[idx].ts_dir2 = ts;
-   }
+    int8_t idx = get_idx_from_len(len);
+    if (dir == 1) {
+        table_[idx].ts_dir1 = ts;
+    } else {
+        table_[idx].ts_dir2 = ts;
+    }
 }
 
 bool RecordExtSSADetector::pkt_table::time_in_window(const timeval& ts_now, const timeval& ts_old)
 {
-   long diff_secs = ts_now.tv_sec - ts_old.tv_sec;
-   long diff_micro_secs = ts_now.tv_usec - ts_old.tv_usec;
+    long diff_secs = ts_now.tv_sec - ts_old.tv_sec;
+    long diff_micro_secs = ts_now.tv_usec - ts_old.tv_usec;
 
-   diff_micro_secs += diff_secs * 1000000;
-   if (diff_micro_secs > MAX_TIME_WINDOW) {
-      return false;
-   }
-   return true;
+    diff_micro_secs += diff_secs * 1000000;
+    if (diff_micro_secs > MAX_TIME_WINDOW) {
+        return false;
+    }
+    return true;
 }
 
 bool RecordExtSSADetector::pkt_table::entry_is_present(
@@ -266,16 +265,16 @@ bool RecordExtSSADetector::pkt_table::entry_is_present(
     dir_t dir,
     const timeval& ts_to_compare)
 {
-   timeval& ts = table_[idx].get_time(dir);
-   if (time_in_window(ts_to_compare, ts)) {
-      return true;
-   }
-   return false;
+    timeval& ts = table_[idx].get_time(dir);
+    if (time_in_window(ts_to_compare, ts)) {
+        return true;
+    }
+    return false;
 }
 
 int8_t RecordExtSSADetector::pkt_table::get_idx_from_len(uint16_t len)
 {
-   return std::max(int(len) - MIN_PKT_SIZE, 0);
+    return std::max(int(len) - MIN_PKT_SIZE, 0);
 }
 
 } // namespace ipxp

--- a/process/ssadetector.hpp
+++ b/process/ssadetector.hpp
@@ -74,118 +74,121 @@ using dir_t = uint8_t;
  * \brief Flow record extension header for storing parsed SSADETECTOR data.
  */
 struct RecordExtSSADetector : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   struct pkt_entry {
-      pkt_entry();
-      void reset();
-      timeval& get_time(dir_t dir);
+    struct pkt_entry {
+        pkt_entry();
+        void reset();
+        timeval& get_time(dir_t dir);
 
-      timeval ts_dir1;
-      timeval ts_dir2;
-   };
+        timeval ts_dir1;
+        timeval ts_dir2;
+    };
 
-   struct pkt_table {
-  public:
-      pkt_entry table_[PKT_TABLE_SIZE];
+    struct pkt_table {
+    public:
+        pkt_entry table_[PKT_TABLE_SIZE];
 
-      void reset();
+        void reset();
 
-      bool check_range_for_presence(
-          uint16_t len,
-          uint8_t down_by,
-          dir_t dir,
-          const timeval& ts_to_compare);
-      void update_entry(uint16_t len, dir_t dir, timeval ts);
+        bool check_range_for_presence(
+            uint16_t len,
+            uint8_t down_by,
+            dir_t dir,
+            const timeval& ts_to_compare);
+        void update_entry(uint16_t len, dir_t dir, timeval ts);
 
-  private:
-      static inline int8_t get_idx_from_len(uint16_t len);
-      static inline bool time_in_window(const timeval& ts_now, const timeval& ts_old);
-      inline bool entry_is_present(int8_t idx, dir_t dir, const timeval& ts_to_compare);
-   };
+    private:
+        static inline int8_t get_idx_from_len(uint16_t len);
+        static inline bool time_in_window(const timeval& ts_now, const timeval& ts_old);
+        inline bool entry_is_present(int8_t idx, dir_t dir, const timeval& ts_to_compare);
+    };
 
-   uint8_t possible_vpn {0}; // fidelity of this flow being vpn
-   uint64_t suspects {0};
-   uint8_t syn_pkts_idx {0};
-   uint8_t syn_pkts[SYN_RECORDS_NUM];
+    uint8_t possible_vpn {0}; // fidelity of this flow being vpn
+    uint64_t suspects {0};
+    uint8_t syn_pkts_idx {0};
+    uint8_t syn_pkts[SYN_RECORDS_NUM];
 
-   pkt_table syn_table {};
-   pkt_table syn_ack_table {};
+    pkt_table syn_table {};
+    pkt_table syn_ack_table {};
 
-   RecordExtSSADetector()
-       : RecordExt(REGISTERED_ID)
-   {
-   }
+    RecordExtSSADetector()
+        : RecordExt(REGISTERED_ID)
+    {
+    }
 
-   void reset()
-   {
-      syn_table.reset();
-      syn_ack_table.reset();
-   }
+    void reset()
+    {
+        syn_table.reset();
+        syn_ack_table.reset();
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t* tmplt, void* record)
-   {
-      ur_set(tmplt, record, F_SSA_CONF_LEVEL, possible_vpn);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_SSA_CONF_LEVEL, possible_vpn);
+    }
 
-   const char* get_unirec_tmplt() const { return SSADETECTOR_UNIREC_TEMPLATE; }
+    const char* get_unirec_tmplt() const { return SSADETECTOR_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t* buffer, int size)
-   {
-      if (size < 1) {
-         return -1;
-      }
-      buffer[0] = (uint8_t) possible_vpn;
-      return 1;
-   }
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        if (size < 1) {
+            return -1;
+        }
+        buffer[0] = (uint8_t) possible_vpn;
+        return 1;
+    }
 
-   const char** get_ipfix_tmplt() const
-   {
-      static const char* ipfix_template[] = {IPFIX_SSADETECTOR_TEMPLATE(IPFIX_FIELD_NAMES) NULL};
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_SSADETECTOR_TEMPLATE(IPFIX_FIELD_NAMES) NULL};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "SSA=" << (int) possible_vpn;
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "SSA=" << (int) possible_vpn;
+        return out.str();
+    }
 };
 
 /**
  * \brief Process plugin for parsing SSADETECTOR packets.
  */
 class SSADetectorPlugin : public ProcessPlugin {
-   public:
-   SSADetectorPlugin();
-   ~SSADetectorPlugin();
-   void init(const char* params);
-   void close();
-   OptionsParser* get_parser() const
-   {
-      return new OptionsParser(
-          "SSADetector",
-          "Check traffic for SYN-SYNACK-ACK sequence to find possible network tunnels.");
-   }
-   std::string get_name() const { return "SSADetector"; }
-   RecordExt* get_ext() const { return new RecordExtSSADetector(); }
-   ProcessPlugin* copy();
+public:
+    SSADetectorPlugin();
+    ~SSADetectorPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser(
+            "SSADetector",
+            "Check traffic for SYN-SYNACK-ACK sequence to find possible network tunnels.");
+    }
+    std::string get_name() const { return "SSADetector"; }
+    RecordExt* get_ext() const { return new RecordExtSSADetector(); }
+    ProcessPlugin* copy();
 
-   int post_update(Flow& rec, const Packet& pkt);
-   void pre_export(Flow& rec);
-   void update_record(RecordExtSSADetector* record, const Packet& pkt);
-   static inline void
-   transition_from_init(RecordExtSSADetector* record, uint16_t len, const timeval& ts, uint8_t dir);
-   static inline void
-   transition_from_syn(RecordExtSSADetector* record, uint16_t len, const timeval& ts, uint8_t dir);
-   static inline bool transition_from_syn_ack(
-       RecordExtSSADetector* record,
-       uint16_t len,
-       const timeval& ts,
-       uint8_t dir);
+    int post_update(Flow& rec, const Packet& pkt);
+    void pre_export(Flow& rec);
+    void update_record(RecordExtSSADetector* record, const Packet& pkt);
+    static inline void transition_from_init(
+        RecordExtSSADetector* record,
+        uint16_t len,
+        const timeval& ts,
+        uint8_t dir);
+    static inline void
+    transition_from_syn(RecordExtSSADetector* record, uint16_t len, const timeval& ts, uint8_t dir);
+    static inline bool transition_from_syn_ack(
+        RecordExtSSADetector* record,
+        uint16_t len,
+        const timeval& ts,
+        uint8_t dir);
 };
 
 } // namespace ipxp

--- a/process/ssdp.cpp
+++ b/process/ssdp.cpp
@@ -37,9 +37,9 @@ int RecordExtSSDP::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("ssdp", [](){return new SSDPPlugin();});
-   register_plugin(&rec);
-   RecordExtSSDP::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("ssdp", []() { return new SSDPPlugin(); });
+    register_plugin(&rec);
+    RecordExtSSDP::REGISTERED_ID = register_extension();
 }
 
 // #define DEBUG_SSDP
@@ -51,73 +51,60 @@ __attribute__((constructor)) static void register_this_plugin()
 #define SSDP_DEBUG_MSG(format, ...)
 #endif
 
-enum header_types {
-   LOCATION,
-   NT,
-   ST,
-   SERVER,
-   USER_AGENT,
-   NONE
-};
+enum header_types { LOCATION, NT, ST, SERVER, USER_AGENT, NONE };
 
-const char *headers[] = {
-   "location",
-   "nt",
-   "st",
-   "server",
-   "user-agent"
-};
+const char* headers[] = {"location", "nt", "st", "server", "user-agent"};
 
-SSDPPlugin::SSDPPlugin() : record(nullptr), notifies(0), searches(0), total(0)
+SSDPPlugin::SSDPPlugin()
+    : record(nullptr)
+    , notifies(0)
+    , searches(0)
+    , total(0)
 {
 }
 
 SSDPPlugin::~SSDPPlugin()
 {
-   close();
+    close();
 }
 
-void SSDPPlugin::init(const char *params)
+void SSDPPlugin::init(const char* params) {}
+
+void SSDPPlugin::close() {}
+
+ProcessPlugin* SSDPPlugin::copy()
 {
+    return new SSDPPlugin(*this);
 }
 
-void SSDPPlugin::close()
+int SSDPPlugin::post_create(Flow& rec, const Packet& pkt)
 {
+    if (pkt.dst_port == 1900) {
+        record = new RecordExtSSDP();
+        rec.add_extension(record);
+        record = nullptr;
+
+        parse_ssdp_message(rec, pkt);
+    }
+    return 0;
 }
 
-ProcessPlugin *SSDPPlugin::copy()
+int SSDPPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   return new SSDPPlugin(*this);
-}
-
-int SSDPPlugin::post_create(Flow &rec, const Packet &pkt)
-{
-   if (pkt.dst_port == 1900) {
-      record = new RecordExtSSDP();
-      rec.add_extension(record);
-      record = nullptr;
-
-      parse_ssdp_message(rec, pkt);
-   }
-   return 0;
-}
-
-int SSDPPlugin::pre_update(Flow &rec, Packet &pkt)
-{
-   if (pkt.dst_port == 1900) {
-      parse_ssdp_message(rec, pkt);
-   }
-   return 0;
+    if (pkt.dst_port == 1900) {
+        parse_ssdp_message(rec, pkt);
+    }
+    return 0;
 }
 
 void SSDPPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "SSDP plugin stats:" << std::endl;
-      std::cout << "   Parsed SSDP M-Searches: " << searches << std::endl;
-      std::cout << "   Parsed SSDP Notifies: " << notifies << std::endl;
-      std::cout << "   Total SSDP packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "SSDP plugin stats:" << std::endl;
+        std::cout << "   Parsed SSDP M-Searches: " << searches << std::endl;
+        std::cout << "   Parsed SSDP Notifies: " << notifies << std::endl;
+        std::cout << "   Total SSDP packets processed: " << total << std::endl;
+    }
 }
 
 /**
@@ -127,33 +114,33 @@ void SSDPPlugin::finish(bool print_stats)
  * \param [in] ip_version IP version of the Location url being parsed.
  * \return Parsed port number on success, 0 otherwise.
  */
-uint16_t SSDPPlugin::parse_loc_port(const char *data, unsigned data_len, uint8_t ip_version)
+uint16_t SSDPPlugin::parse_loc_port(const char* data, unsigned data_len, uint8_t ip_version)
 {
-   uint16_t port;
-   char *end_ptr = nullptr;
-   const void *data_mem = static_cast<const void *>(data);
+    uint16_t port;
+    char* end_ptr = nullptr;
+    const void* data_mem = static_cast<const void*>(data);
 
-   if (ip_version == IP::v6) {
-      data_mem = memchr(data_mem, ']', data_len);
-   } else {
-      data_mem = memchr(data_mem, '.', data_len);
-   }
-   if (data_mem == nullptr) {
-       return 0;
-   }
-   data_mem = memchr(data_mem, ':', data_len);
+    if (ip_version == IP::v6) {
+        data_mem = memchr(data_mem, ']', data_len);
+    } else {
+        data_mem = memchr(data_mem, '.', data_len);
+    }
+    if (data_mem == nullptr) {
+        return 0;
+    }
+    data_mem = memchr(data_mem, ':', data_len);
 
-   if (data_mem == nullptr) {
-      return 0;
-   }
-   data = static_cast<const char *>(data_mem);
-   data++;
+    if (data_mem == nullptr) {
+        return 0;
+    }
+    data = static_cast<const char*>(data_mem);
+    data++;
 
-   port = strtol(data, &end_ptr, 0);
-   if (data != end_ptr) {
-      return port;
-   }
-   return 0;
+    port = strtol(data, &end_ptr, 0);
+    if (data != end_ptr) {
+        return port;
+    }
+    return 0;
 }
 
 /**
@@ -164,16 +151,16 @@ uint16_t SSDPPlugin::parse_loc_port(const char *data, unsigned data_len, uint8_t
  * \param [in] len Lenght of the desired header.
  * \return True if the header is found, otherwise false.
  */
-bool SSDPPlugin::get_header_val(const char **data, const char *header, const int len)
+bool SSDPPlugin::get_header_val(const char** data, const char* header, const int len)
 {
-   if (strncasecmp(*data, header, len) == 0 && (*data)[len] == ':') {
-      (*data) += len + 1;
-      while (isspace(**data)) {
-         (*data)++;
-      };
-      return true;
-   }
-   return false;
+    if (strncasecmp(*data, header, len) == 0 && (*data)[len] == ':') {
+        (*data) += len + 1;
+        while (isspace(**data)) {
+            (*data)++;
+        };
+        return true;
+    }
+    return false;
 }
 
 /**
@@ -183,60 +170,63 @@ bool SSDPPlugin::get_header_val(const char **data, const char *header, const int
  * \param [in] payload_len Lenght of payload data
  * \param [in] conf Struct containing parser configuration.
  */
-void SSDPPlugin::parse_headers(const uint8_t *data, size_t payload_len, header_parser_conf conf)
+void SSDPPlugin::parse_headers(const uint8_t* data, size_t payload_len, header_parser_conf conf)
 {
-   const char *ptr = (const char *)(data);
-   const char *old_ptr = ptr;
-   size_t len = 0;
+    const char* ptr = (const char*) (data);
+    const char* old_ptr = ptr;
+    size_t len = 0;
 
-   while (*ptr != '\0' && len <= payload_len) {
-      if (*ptr == '\n' && *(ptr - 1) == '\r') {
-         for (unsigned j = 0, i = 0; j < conf.select_cnt; j++) {
-            i = conf.select[j];
-            if (get_header_val(&old_ptr, conf.headers[i], strlen(conf.headers[i]))) {
-               switch ((header_types) i) {
-               case ST:
-                  if (get_header_val(&old_ptr, "urn", strlen("urn"))) {
-                     SSDP_DEBUG_MSG("%s\n", old_ptr);
-                     append_value(conf.ext->st, SSDP_URN_LEN, old_ptr, ptr-old_ptr);
-                  }
-                  break;
-               case NT:
-                  if (get_header_val(&old_ptr, "urn", strlen("urn"))) {
-                     SSDP_DEBUG_MSG("%s\n", old_ptr);
-                     append_value(conf.ext->nt, SSDP_URN_LEN, old_ptr, ptr-old_ptr);
-                  }
-                  break;
-               case LOCATION:
-                  {
-                     uint16_t port = parse_loc_port(old_ptr, ptr-old_ptr,conf.ip_version);
+    while (*ptr != '\0' && len <= payload_len) {
+        if (*ptr == '\n' && *(ptr - 1) == '\r') {
+            for (unsigned j = 0, i = 0; j < conf.select_cnt; j++) {
+                i = conf.select[j];
+                if (get_header_val(&old_ptr, conf.headers[i], strlen(conf.headers[i]))) {
+                    switch ((header_types) i) {
+                    case ST:
+                        if (get_header_val(&old_ptr, "urn", strlen("urn"))) {
+                            SSDP_DEBUG_MSG("%s\n", old_ptr);
+                            append_value(conf.ext->st, SSDP_URN_LEN, old_ptr, ptr - old_ptr);
+                        }
+                        break;
+                    case NT:
+                        if (get_header_val(&old_ptr, "urn", strlen("urn"))) {
+                            SSDP_DEBUG_MSG("%s\n", old_ptr);
+                            append_value(conf.ext->nt, SSDP_URN_LEN, old_ptr, ptr - old_ptr);
+                        }
+                        break;
+                    case LOCATION: {
+                        uint16_t port = parse_loc_port(old_ptr, ptr - old_ptr, conf.ip_version);
 
-                     if (port > 0) {
-                        SSDP_DEBUG_MSG("%d <- %d\n", conf.ext->port, port);
-                        conf.ext->port = port;
-                     }
-                     break;
-                  }
-               case USER_AGENT:
-                  SSDP_DEBUG_MSG("%s\n", old_ptr);
-                  append_value(conf.ext->user_agent, SSDP_USER_AGENT_LEN, old_ptr, ptr-old_ptr);
-                  break;
-               case SERVER:
-                  SSDP_DEBUG_MSG("%s\n", old_ptr);
-                  append_value(conf.ext->server, SSDP_SERVER_LEN, old_ptr, ptr-old_ptr);
-                  break;
-               default:
-                  break;
-               }
-               break;
+                        if (port > 0) {
+                            SSDP_DEBUG_MSG("%d <- %d\n", conf.ext->port, port);
+                            conf.ext->port = port;
+                        }
+                        break;
+                    }
+                    case USER_AGENT:
+                        SSDP_DEBUG_MSG("%s\n", old_ptr);
+                        append_value(
+                            conf.ext->user_agent,
+                            SSDP_USER_AGENT_LEN,
+                            old_ptr,
+                            ptr - old_ptr);
+                        break;
+                    case SERVER:
+                        SSDP_DEBUG_MSG("%s\n", old_ptr);
+                        append_value(conf.ext->server, SSDP_SERVER_LEN, old_ptr, ptr - old_ptr);
+                        break;
+                    default:
+                        break;
+                    }
+                    break;
+                }
             }
-         }
-         old_ptr = ptr + 1;
-      }
-      ptr++;
-      len++;
-   }
-   return;
+            old_ptr = ptr + 1;
+        }
+        ptr++;
+        len++;
+    }
+    return;
 }
 
 /**
@@ -248,23 +238,27 @@ void SSDPPlugin::parse_headers(const uint8_t *data, size_t payload_len, header_p
  * \param [in] entry_max Maximum length if the entry.
  * \param [in] value String containing the new entry.
  */
-void SSDPPlugin::append_value(char *curr_entry, unsigned entry_max, const char *value, unsigned value_len)
+void SSDPPlugin::append_value(
+    char* curr_entry,
+    unsigned entry_max,
+    const char* value,
+    unsigned value_len)
 {
-   if (strlen(curr_entry) + value_len + 1 < entry_max) {
-      // return if value already in curr_entry
-      for (unsigned i = 0; i < strlen(curr_entry) - value_len; i++) {
-          if (strlen(curr_entry) < value_len) {
-              break;
-          }
-          if (strncmp(&curr_entry[i], value, value_len) == 0) {
-              return;
-          }
-      }
+    if (strlen(curr_entry) + value_len + 1 < entry_max) {
+        // return if value already in curr_entry
+        for (unsigned i = 0; i < strlen(curr_entry) - value_len; i++) {
+            if (strlen(curr_entry) < value_len) {
+                break;
+            }
+            if (strncmp(&curr_entry[i], value, value_len) == 0) {
+                return;
+            }
+        }
 
-      SSDP_DEBUG_MSG("New entry\n");
-      strncat(curr_entry, value, value_len);
-      strcat(curr_entry, ";");
-   }
+        SSDP_DEBUG_MSG("New entry\n");
+        strncat(curr_entry, value, value_len);
+        strcat(curr_entry, ";");
+    }
 }
 
 /**
@@ -275,31 +269,30 @@ void SSDPPlugin::append_value(char *curr_entry, unsigned entry_max, const char *
  * \param [in, out] rec Flow record containing basic flow data.
  * \param [in] pkt Packet struct containing packet data.
  */
-void SSDPPlugin::parse_ssdp_message(Flow &rec, const Packet &pkt)
+void SSDPPlugin::parse_ssdp_message(Flow& rec, const Packet& pkt)
 {
-   header_parser_conf parse_conf = {
-      headers,
-      rec.ip_version,
-      static_cast<RecordExtSSDP *>(rec.get_extension(RecordExtSSDP::REGISTERED_ID))
-   };
+    header_parser_conf parse_conf
+        = {headers,
+           rec.ip_version,
+           static_cast<RecordExtSSDP*>(rec.get_extension(RecordExtSSDP::REGISTERED_ID))};
 
-   total++;
-   if (pkt.payload[0] == 'N') {
-      notifies++;
-      SSDP_DEBUG_MSG("Notify #%d\n", notifies);
-      int notify_headers[] = { NT, LOCATION, SERVER };
-      parse_conf.select = notify_headers;
-      parse_conf.select_cnt = sizeof(notify_headers) / sizeof(notify_headers[0]);
-      parse_headers(pkt.payload, pkt.payload_len, parse_conf);
-   } else if (pkt.payload[0] == 'M') {
-      searches++;
-      SSDP_DEBUG_MSG("M-search #%d\n", searches);
-      int search_headers[] = { ST, USER_AGENT };
-      parse_conf.select = search_headers;
-      parse_conf.select_cnt = sizeof(search_headers) / sizeof(search_headers[0]);
-      parse_headers(pkt.payload, pkt.payload_len, parse_conf);
-   }
-   SSDP_DEBUG_MSG("\n");
+    total++;
+    if (pkt.payload[0] == 'N') {
+        notifies++;
+        SSDP_DEBUG_MSG("Notify #%d\n", notifies);
+        int notify_headers[] = {NT, LOCATION, SERVER};
+        parse_conf.select = notify_headers;
+        parse_conf.select_cnt = sizeof(notify_headers) / sizeof(notify_headers[0]);
+        parse_headers(pkt.payload, pkt.payload_len, parse_conf);
+    } else if (pkt.payload[0] == 'M') {
+        searches++;
+        SSDP_DEBUG_MSG("M-search #%d\n", searches);
+        int search_headers[] = {ST, USER_AGENT};
+        parse_conf.select = search_headers;
+        parse_conf.select_cnt = sizeof(search_headers) / sizeof(search_headers[0]);
+        parse_headers(pkt.payload, pkt.payload_len, parse_conf);
+    }
+    SSDP_DEBUG_MSG("\n");
 }
 
-}
+} // namespace ipxp

--- a/process/ssdp.hpp
+++ b/process/ssdp.hpp
@@ -29,18 +29,18 @@
 #ifndef IPXP_PROCESS_SSDP_HPP
 #define IPXP_PROCESS_SSDP_HPP
 
-#include <string>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
 #include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
@@ -50,164 +50,156 @@ namespace ipxp {
 
 #define SSDP_UNIREC_TEMPLATE "SSDP_LOCATION_PORT,SSDP_NT,SSDP_SERVER,SSDP_ST,SSDP_USER_AGENT"
 
-UR_FIELDS (
-   uint16 SSDP_LOCATION_PORT,
-   string SSDP_NT,
-   string SSDP_SERVER,
-   string SSDP_ST,
-   string SSDP_USER_AGENT
-)
+UR_FIELDS(
+    uint16 SSDP_LOCATION_PORT,
+    string SSDP_NT,
+    string SSDP_SERVER,
+    string SSDP_ST,
+    string SSDP_USER_AGENT)
 
 /**
  * \brief Flow record extension header for storing parsed SSDP packets.
  */
 struct RecordExtSSDP : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t port;
-   char nt[SSDP_URN_LEN];
-   char st[SSDP_URN_LEN];
-   char server[SSDP_SERVER_LEN];
-   char user_agent[SSDP_USER_AGENT_LEN];
+    uint16_t port;
+    char nt[SSDP_URN_LEN];
+    char st[SSDP_URN_LEN];
+    char server[SSDP_SERVER_LEN];
+    char user_agent[SSDP_USER_AGENT_LEN];
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtSSDP() : RecordExt(REGISTERED_ID)
-   {
-      port = 0;
-      nt[0] = 0;
-      st[0] = 0;
-      server[0] = 0;
-      user_agent[0]= 0;
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtSSDP()
+        : RecordExt(REGISTERED_ID)
+    {
+        port = 0;
+        nt[0] = 0;
+        st[0] = 0;
+        server[0] = 0;
+        user_agent[0] = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_SSDP_LOCATION_PORT, port);
-      ur_set_string(tmplt, record, F_SSDP_NT, nt);
-      ur_set_string(tmplt, record, F_SSDP_SERVER, server);
-      ur_set_string(tmplt, record, F_SSDP_ST, st);
-      ur_set_string(tmplt, record, F_SSDP_USER_AGENT, user_agent);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_SSDP_LOCATION_PORT, port);
+        ur_set_string(tmplt, record, F_SSDP_NT, nt);
+        ur_set_string(tmplt, record, F_SSDP_SERVER, server);
+        ur_set_string(tmplt, record, F_SSDP_ST, st);
+        ur_set_string(tmplt, record, F_SSDP_USER_AGENT, user_agent);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return SSDP_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return SSDP_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int length = 2;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int length = 2;
 
-      int nt_len = strlen(nt);
-      int server_len = strlen(server);
-      int st_len = strlen(st);
-      int user_agent_len = strlen(user_agent);
+        int nt_len = strlen(nt);
+        int server_len = strlen(server);
+        int st_len = strlen(st);
+        int user_agent_len = strlen(user_agent);
 
-      if (length + nt_len + server_len + st_len + user_agent_len + 8 > size) {
-         return -1;
-      }
+        if (length + nt_len + server_len + st_len + user_agent_len + 8 > size) {
+            return -1;
+        }
 
-      *(uint16_t *) (buffer) = ntohs(port);
+        *(uint16_t*) (buffer) = ntohs(port);
 
-      if (nt_len >= 255) {
-         buffer[length++] = 255;
-         *(uint16_t *)(buffer + length) = ntohs(nt_len);
-         length += sizeof(uint16_t);
-      } else {
-         buffer[length++] = nt_len;
-      }
-      memcpy(buffer + length, nt, nt_len);
-      length += nt_len;
+        if (nt_len >= 255) {
+            buffer[length++] = 255;
+            *(uint16_t*) (buffer + length) = ntohs(nt_len);
+            length += sizeof(uint16_t);
+        } else {
+            buffer[length++] = nt_len;
+        }
+        memcpy(buffer + length, nt, nt_len);
+        length += nt_len;
 
-      buffer[length++] = server_len;
-      memcpy(buffer + length, server, server_len);
-      length += server_len;
+        buffer[length++] = server_len;
+        memcpy(buffer + length, server, server_len);
+        length += server_len;
 
-      if (st_len >= 255) {
-         buffer[length++] = 255;
-         *(uint16_t *)(buffer + length) = ntohs(st_len);
-         length += sizeof(uint16_t);
-      } else {
-         buffer[length++] = st_len;
-      }
-      memcpy(buffer + length, st, st_len);
-      length += st_len;
+        if (st_len >= 255) {
+            buffer[length++] = 255;
+            *(uint16_t*) (buffer + length) = ntohs(st_len);
+            length += sizeof(uint16_t);
+        } else {
+            buffer[length++] = st_len;
+        }
+        memcpy(buffer + length, st, st_len);
+        length += st_len;
 
-      buffer[length++] = user_agent_len;
-      memcpy(buffer + length, user_agent, user_agent_len);
-      length += user_agent_len;
+        buffer[length++] = user_agent_len;
+        memcpy(buffer + length, user_agent, user_agent_len);
+        length += user_agent_len;
 
-      return length;
-   }
+        return length;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_SSDP_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_SSDP_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "ssdpport=" << port
-         << ",nt=\"" << nt << "\""
-         << ",server=\"" << server << "\""
-         << ",st=\"" << st << "\""
-         << ",useragent=\"" << user_agent << "\"";
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "ssdpport=" << port << ",nt=\"" << nt << "\""
+            << ",server=\"" << server << "\""
+            << ",st=\"" << st << "\""
+            << ",useragent=\"" << user_agent << "\"";
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing SSDP packets.
  */
-class SSDPPlugin : public ProcessPlugin
-{
+class SSDPPlugin : public ProcessPlugin {
 public:
-   SSDPPlugin();
-   ~SSDPPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("ssdp", "Parse SSDP traffic"); }
-   std::string get_name() const { return "ssdp"; }
-   RecordExt *get_ext() const { return new RecordExtSSDP(); }
-   ProcessPlugin *copy();
+    SSDPPlugin();
+    ~SSDPPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("ssdp", "Parse SSDP traffic"); }
+    std::string get_name() const { return "ssdp"; }
+    RecordExt* get_ext() const { return new RecordExtSSDP(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void finish(bool print_stats);
 
-   /**
-    * \brief Struct passed to parse_headers function.
-    */
-   struct header_parser_conf {
-      const char **headers;   /**< Pointer to array of header strings. */
-      uint8_t ip_version;     /**< IP version of source IP address. */
-      RecordExtSSDP *ext;     /**< Pointer to allocated record exitension. */
-      unsigned select_cnt;    /**< Number of selected headers. */
-      int *select;            /**< Array of selected header indices. */
-   };
+    /**
+     * \brief Struct passed to parse_headers function.
+     */
+    struct header_parser_conf {
+        const char** headers; /**< Pointer to array of header strings. */
+        uint8_t ip_version; /**< IP version of source IP address. */
+        RecordExtSSDP* ext; /**< Pointer to allocated record exitension. */
+        unsigned select_cnt; /**< Number of selected headers. */
+        int* select; /**< Array of selected header indices. */
+    };
 
 private:
-   RecordExtSSDP *record;  /**< Pointer to allocated record extension */
-   uint32_t notifies;      /**< Total number of parsed SSDP notifies. */
-   uint32_t searches;      /**< Total number of parsed SSDP m-searches. */
-   uint32_t total;         /**< Total number of parsed SSDP packets. */
+    RecordExtSSDP* record; /**< Pointer to allocated record extension */
+    uint32_t notifies; /**< Total number of parsed SSDP notifies. */
+    uint32_t searches; /**< Total number of parsed SSDP m-searches. */
+    uint32_t total; /**< Total number of parsed SSDP packets. */
 
-   uint16_t parse_loc_port(const char *data, unsigned data_len, uint8_t ip_version);
-   bool get_header_val(const char **data, const char *header, const int len);
-   void parse_headers(const uint8_t *data, size_t payload_len, header_parser_conf conf);
-   void parse_ssdp_message(Flow &rec, const Packet &pkt);
-   void append_value(char *curr_entry, unsigned entry_max, const char *value, unsigned value_len);
+    uint16_t parse_loc_port(const char* data, unsigned data_len, uint8_t ip_version);
+    bool get_header_val(const char** data, const char* header, const int len);
+    void parse_headers(const uint8_t* data, size_t payload_len, header_parser_conf conf);
+    void parse_ssdp_message(Flow& rec, const Packet& pkt);
+    void append_value(char* curr_entry, unsigned entry_max, const char* value, unsigned value_len);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_SSDP_HPP */

--- a/process/stats.cpp
+++ b/process/stats.cpp
@@ -30,114 +30,119 @@
  */
 #include "stats.hpp"
 
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <sys/time.h>
 
 namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("stats", [](){return new StatsPlugin();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("stats", []() { return new StatsPlugin(); });
+    register_plugin(&rec);
 }
 
-StatsPlugin::StatsPlugin() :
-   m_packets(0), m_new_flows(0), m_cache_hits(0), m_flows_in_cache(0), m_init_ts(true),
-   m_interval({STATS_PRINT_INTERVAL, 0}), m_last_ts({0}), m_out(&std::cout)
+StatsPlugin::StatsPlugin()
+    : m_packets(0)
+    , m_new_flows(0)
+    , m_cache_hits(0)
+    , m_flows_in_cache(0)
+    , m_init_ts(true)
+    , m_interval({STATS_PRINT_INTERVAL, 0})
+    , m_last_ts({0})
+    , m_out(&std::cout)
 {
 }
 
 StatsPlugin::~StatsPlugin()
 {
-   close();
+    close();
 }
 
-void StatsPlugin::init(const char *params)
+void StatsPlugin::init(const char* params)
 {
-   StatsOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    StatsOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   m_interval = {parser.m_interval, 0};
-   if (parser.m_out == "stdout") {
-      m_out = &std::cout;
-   } else if (parser.m_out == "stderr") {
-      m_out = &std::cerr;
-   } else {
-      throw PluginError("Unknown argument " + parser.m_out);
-   }
-   print_header();
+    m_interval = {parser.m_interval, 0};
+    if (parser.m_out == "stdout") {
+        m_out = &std::cout;
+    } else if (parser.m_out == "stderr") {
+        m_out = &std::cerr;
+    } else {
+        throw PluginError("Unknown argument " + parser.m_out);
+    }
+    print_header();
 }
 
-void StatsPlugin::close()
+void StatsPlugin::close() {}
+
+ProcessPlugin* StatsPlugin::copy()
 {
+    return new StatsPlugin(*this);
 }
 
-ProcessPlugin *StatsPlugin::copy()
+int StatsPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   return new StatsPlugin(*this);
+    m_packets += 1;
+    m_new_flows += 1;
+    m_flows_in_cache += 1;
+    check_timestamp(pkt);
+    return 0;
 }
 
-int StatsPlugin::post_create(Flow &rec, const Packet &pkt)
+int StatsPlugin::post_update(Flow& rec, const Packet& pkt)
 {
-   m_packets += 1;
-   m_new_flows += 1;
-   m_flows_in_cache += 1;
-   check_timestamp(pkt);
-   return 0;
+    m_packets += 1;
+    m_cache_hits += 1;
+    check_timestamp(pkt);
+    return 0;
 }
 
-int StatsPlugin::post_update(Flow &rec, const Packet &pkt)
+void StatsPlugin::pre_export(Flow& rec)
 {
-   m_packets += 1;
-   m_cache_hits += 1;
-   check_timestamp(pkt);
-   return 0;
-}
-
-void StatsPlugin::pre_export(Flow &rec)
-{
-   m_flows_in_cache -= 1;
+    m_flows_in_cache -= 1;
 }
 
 void StatsPlugin::finish(bool print_stats)
 {
-   print_line(m_last_ts);
+    print_line(m_last_ts);
 }
 
-void StatsPlugin::check_timestamp(const Packet &pkt)
+void StatsPlugin::check_timestamp(const Packet& pkt)
 {
-   if (m_init_ts) {
-      m_init_ts = false;
-      m_last_ts = pkt.ts;
-      return;
-   }
+    if (m_init_ts) {
+        m_init_ts = false;
+        m_last_ts = pkt.ts;
+        return;
+    }
 
-   struct timeval tmp;
-   timeradd(&m_last_ts, &m_interval, &tmp);
+    struct timeval tmp;
+    timeradd(&m_last_ts, &m_interval, &tmp);
 
-   if (timercmp(&pkt.ts, &tmp, >)) {
-      print_line(m_last_ts);
-      timeradd(&m_last_ts, &m_interval, &m_last_ts);
-      m_packets = 0;
-      m_new_flows = 0;
-      m_cache_hits = 0;
-   }
+    if (timercmp(&pkt.ts, &tmp, >)) {
+        print_line(m_last_ts);
+        timeradd(&m_last_ts, &m_interval, &m_last_ts);
+        m_packets = 0;
+        m_new_flows = 0;
+        m_cache_hits = 0;
+    }
 }
 
 void StatsPlugin::print_header() const
 {
-   *m_out << "#timestamp packets hits newflows incache" << std::endl;
+    *m_out << "#timestamp packets hits newflows incache" << std::endl;
 }
 
-void StatsPlugin::print_line(const struct timeval &ts) const
+void StatsPlugin::print_line(const struct timeval& ts) const
 {
-   *m_out << ts.tv_sec << "." << ts.tv_usec << " ";
-   *m_out << m_packets << " " << m_cache_hits << " " << m_new_flows << " " << m_flows_in_cache << std::endl;
+    *m_out << ts.tv_sec << "." << ts.tv_usec << " ";
+    *m_out << m_packets << " " << m_cache_hits << " " << m_new_flows << " " << m_flows_in_cache
+           << std::endl;
 }
 
-}
+} // namespace ipxp

--- a/process/stats.hpp
+++ b/process/stats.hpp
@@ -36,61 +36,81 @@
 #include <string>
 #include <sys/time.h>
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/options.hpp>
+#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
 #define STATS_PRINT_INTERVAL 1
 
-class StatsOptParser : public OptionsParser
-{
+class StatsOptParser : public OptionsParser {
 public:
-   uint32_t m_interval;
-   std::string m_out;
+    uint32_t m_interval;
+    std::string m_out;
 
-   StatsOptParser() : OptionsParser("stats", "Print storage plugin statistics"), m_interval(STATS_PRINT_INTERVAL), m_out("stdout")
-   {
-      register_option("i", "interval", "SECS", "Print interval in seconds",
-         [this](const char *arg){try {m_interval = str2num<decltype(m_interval)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("o", "out", "DESC", "Print statistics to stdout or stderr",
-         [this](const char *arg){m_out = arg ; return m_out != "stdout" && m_out != "stderr";}, OptionFlags::RequiredArgument);
-   }
+    StatsOptParser()
+        : OptionsParser("stats", "Print storage plugin statistics")
+        , m_interval(STATS_PRINT_INTERVAL)
+        , m_out("stdout")
+    {
+        register_option(
+            "i",
+            "interval",
+            "SECS",
+            "Print interval in seconds",
+            [this](const char* arg) {
+                try {
+                    m_interval = str2num<decltype(m_interval)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "o",
+            "out",
+            "DESC",
+            "Print statistics to stdout or stderr",
+            [this](const char* arg) {
+                m_out = arg;
+                return m_out != "stdout" && m_out != "stderr";
+            },
+            OptionFlags::RequiredArgument);
+    }
 };
 
-class StatsPlugin : public ProcessPlugin
-{
+class StatsPlugin : public ProcessPlugin {
 public:
-   StatsPlugin();
-   ~StatsPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new StatsOptParser(); }
-   std::string get_name() const { return "stats"; }
-   ProcessPlugin *copy();
+    StatsPlugin();
+    ~StatsPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new StatsOptParser(); }
+    std::string get_name() const { return "stats"; }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int post_update(Flow &rec, const Packet &pkt);
-   void pre_export(Flow &rec);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int post_update(Flow& rec, const Packet& pkt);
+    void pre_export(Flow& rec);
+    void finish(bool print_stats);
 
 private:
-   uint64_t m_packets;
-   uint64_t m_new_flows;
-   uint64_t m_cache_hits;
-   uint64_t m_flows_in_cache;
+    uint64_t m_packets;
+    uint64_t m_new_flows;
+    uint64_t m_cache_hits;
+    uint64_t m_flows_in_cache;
 
-   bool m_init_ts;
-   struct timeval m_interval;
-   struct timeval m_last_ts;
-   std::ostream *m_out;
+    bool m_init_ts;
+    struct timeval m_interval;
+    struct timeval m_last_ts;
+    std::ostream* m_out;
 
-   void check_timestamp(const Packet &pkt);
-   void print_header() const;
-   void print_line(const struct timeval &ts) const;
+    void check_timestamp(const Packet& pkt);
+    void print_header() const;
+    void print_line(const struct timeval& ts) const;
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_STATS_HPP */

--- a/process/tls.cpp
+++ b/process/tls.cpp
@@ -12,215 +12,216 @@
  * \date 2018-2022
  */
 
-
 #include <iostream>
 #include <sstream>
 
 #include <stdio.h>
 
-#include "tls.hpp"
 #include "md5.hpp"
+#include "tls.hpp"
 
 namespace ipxp {
 int RecordExtTLS::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("tls", [](){
-         return new TLSPlugin();
-      });
+    static PluginRecord rec = PluginRecord("tls", []() { return new TLSPlugin(); });
 
-   register_plugin(&rec);
-   RecordExtTLS::REGISTERED_ID = register_extension();
+    register_plugin(&rec);
+    RecordExtTLS::REGISTERED_ID = register_extension();
 }
 
 // Print debug message if debugging is allowed.
 #ifdef DEBUG_TLS
-# define DEBUG_MSG(format, ...) fprintf(stderr, format, ## __VA_ARGS__)
+#define DEBUG_MSG(format, ...) fprintf(stderr, format, ##__VA_ARGS__)
 #else
-# define DEBUG_MSG(format, ...)
+#define DEBUG_MSG(format, ...)
 #endif
 
 // Process code if debugging is allowed.
 #ifdef DEBUG_TLS
-# define DEBUG_CODE(code) code
+#define DEBUG_CODE(code) code
 #else
-# define DEBUG_CODE(code)
+#define DEBUG_CODE(code)
 #endif
 
-TLSPlugin::TLSPlugin() : ext_ptr(nullptr), parsed_sni(0), flow_flush(false)
-{ }
+TLSPlugin::TLSPlugin()
+    : ext_ptr(nullptr)
+    , parsed_sni(0)
+    , flow_flush(false)
+{
+}
 
 TLSPlugin::~TLSPlugin()
 {
-   close();
+    close();
 }
 
-void TLSPlugin::init(const char *params)
-{ }
+void TLSPlugin::init(const char* params) {}
 
 void TLSPlugin::close()
 {
-   if (ext_ptr != nullptr) {
-      delete ext_ptr;
-      ext_ptr = nullptr;
-   }
+    if (ext_ptr != nullptr) {
+        delete ext_ptr;
+        ext_ptr = nullptr;
+    }
 }
 
-ProcessPlugin *TLSPlugin::copy()
+ProcessPlugin* TLSPlugin::copy()
 {
-   return new TLSPlugin(*this);
+    return new TLSPlugin(*this);
 }
 
-int TLSPlugin::post_create(Flow &rec, const Packet &pkt)
+int TLSPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   add_tls_record(rec, pkt);
-   return 0;
+    add_tls_record(rec, pkt);
+    return 0;
 }
 
-int TLSPlugin::pre_update(Flow &rec, Packet &pkt)
+int TLSPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   RecordExtTLS *ext = static_cast<RecordExtTLS *>(rec.get_extension(RecordExtTLS::REGISTERED_ID));
+    RecordExtTLS* ext = static_cast<RecordExtTLS*>(rec.get_extension(RecordExtTLS::REGISTERED_ID));
 
-   if (ext != nullptr) {
-      if (ext->server_hello_parsed == false) {
-         // Add ALPN from server packet
-         parse_tls(pkt.payload, pkt.payload_len, ext);
-      }
-      return 0;
-   }
-   add_tls_record(rec, pkt);
+    if (ext != nullptr) {
+        if (ext->server_hello_parsed == false) {
+            // Add ALPN from server packet
+            parse_tls(pkt.payload, pkt.payload_len, ext);
+        }
+        return 0;
+    }
+    add_tls_record(rec, pkt);
 
-   return 0;
+    return 0;
 }
 
-bool TLSPlugin::obtain_tls_data(TLSData &payload, RecordExtTLS *rec, std::string &ja3, uint8_t hs_type)
+bool TLSPlugin::obtain_tls_data(
+    TLSData& payload,
+    RecordExtTLS* rec,
+    std::string& ja3,
+    uint8_t hs_type)
 {
-   std::string ecliptic_curves;
-   std::string ec_point_formats;
+    std::string ecliptic_curves;
+    std::string ec_point_formats;
 
+    while (payload.start + sizeof(tls_ext) <= payload.end) {
+        tls_ext* ext = (tls_ext*) payload.start;
+        uint16_t length = ntohs(ext->length);
+        uint16_t type = ntohs(ext->type);
 
-   while (payload.start + sizeof(tls_ext) <= payload.end) {
-      tls_ext *ext    = (tls_ext *) payload.start;
-      uint16_t length = ntohs(ext->length);
-      uint16_t type   = ntohs(ext->type);
+        payload.start += sizeof(tls_ext);
+        if (payload.start + length > payload.end) {
+            break;
+        }
 
-      payload.start += sizeof(tls_ext);
-      if (payload.start + length > payload.end) {
-         break;
-      }
+        if (hs_type == TLS_HANDSHAKE_CLIENT_HELLO) {
+            if (type == TLS_EXT_SERVER_NAME) {
+                tls_parser.tls_get_server_name(payload, rec->sni, sizeof(rec->sni));
+            } else if (type == TLS_EXT_ECLIPTIC_CURVES) {
+                ecliptic_curves = tls_parser.tls_get_ja3_ecpliptic_curves(payload);
+            } else if (type == TLS_EXT_EC_POINT_FORMATS) {
+                ec_point_formats = tls_parser.tls_get_ja3_ec_point_formats(payload);
+            }
+        } else if (hs_type == TLS_HANDSHAKE_SERVER_HELLO) {
+            rec->server_hello_parsed = true;
+            if (type == TLS_EXT_ALPN) {
+                tls_parser.tls_get_alpn(payload, rec->alpn, BUFF_SIZE);
+                // not sure, but probably don`t return yet, as
+                // this is not only field we want to parse
+                // return true;
+            } else if (type == TLS_EXT_SUPPORTED_VER) {
+                tls_parser.tls_get_supp_ver(payload, rec->version);
+            }
+        }
+        payload.start += length;
+        if (!tls_parser.tls_is_grease_value(type)) {
+            ja3 += std::to_string(type);
 
-      if (hs_type == TLS_HANDSHAKE_CLIENT_HELLO) {
-         if (type == TLS_EXT_SERVER_NAME) {
-            tls_parser.tls_get_server_name(payload, rec->sni, sizeof(rec->sni));
-         } else if (type == TLS_EXT_ECLIPTIC_CURVES) {
-            ecliptic_curves = tls_parser.tls_get_ja3_ecpliptic_curves(payload);
-         } else if (type == TLS_EXT_EC_POINT_FORMATS) {
-            ec_point_formats = tls_parser.tls_get_ja3_ec_point_formats(payload);
-         }
-      } else if (hs_type == TLS_HANDSHAKE_SERVER_HELLO) {
-         rec->server_hello_parsed = true;
-         if (type == TLS_EXT_ALPN) {
-            tls_parser.tls_get_alpn(payload, rec->alpn, BUFF_SIZE);
-            // not sure, but probably don`t return yet, as 
-            // this is not only field we want to parse
-            //return true;
-         } else if (type == TLS_EXT_SUPPORTED_VER){
-            tls_parser.tls_get_supp_ver(payload, rec->version);
-         }
-      }
-      payload.start += length;
-      if (!tls_parser.tls_is_grease_value(type)) {
-         ja3 += std::to_string(type);
-
-         if (payload.start + sizeof(tls_ext) <= payload.end) {
-            ja3 += '-';
-         }
-      }
-   }
-   if (hs_type == TLS_HANDSHAKE_SERVER_HELLO) {
-      return false;
-   }
-   ja3 += ',' + ecliptic_curves + ',' + ec_point_formats;
-   md5_get_bin(ja3, rec->ja3_hash_bin);
-   return true;
+            if (payload.start + sizeof(tls_ext) <= payload.end) {
+                ja3 += '-';
+            }
+        }
+    }
+    if (hs_type == TLS_HANDSHAKE_SERVER_HELLO) {
+        return false;
+    }
+    ja3 += ',' + ecliptic_curves + ',' + ec_point_formats;
+    md5_get_bin(ja3, rec->ja3_hash_bin);
+    return true;
 } // TLSPlugin::obtain_tls_data
 
-bool TLSPlugin::parse_tls(const uint8_t *data, uint16_t payload_len, RecordExtTLS *rec)
+bool TLSPlugin::parse_tls(const uint8_t* data, uint16_t payload_len, RecordExtTLS* rec)
 {
-   TLSData payload = {
-      payload.start = data,
-      payload.end   = data + payload_len,
-      payload.obejcts_parsed = 0,
-   };
-   std::string ja3;
+    TLSData payload = {
+        payload.start = data,
+        payload.end = data + payload_len,
+        payload.obejcts_parsed = 0,
+    };
+    std::string ja3;
 
+    if (!tls_parser.tls_check_rec(payload)) {
+        return false;
+    }
+    if (!tls_parser.tls_check_handshake(payload)) {
+        return false;
+    }
+    tls_handshake tls_hs = tls_parser.tls_get_handshake();
 
-   if (!tls_parser.tls_check_rec(payload)) {
-      return false;
-   }
-   if (!tls_parser.tls_check_handshake(payload)) {
-      return false;
-   }
-   tls_handshake tls_hs = tls_parser.tls_get_handshake();
+    rec->version = (rec->version == 0)
+        ? (((uint16_t) tls_hs.version.major << 8) | tls_hs.version.minor)
+        : rec->version;
+    ja3 += std::to_string((uint16_t) tls_hs.version.version) + ',';
 
-   rec->version = (rec->version == 0)?(((uint16_t) tls_hs.version.major << 8) | tls_hs.version.minor) : rec->version;
-   ja3 += std::to_string((uint16_t) tls_hs.version.version) + ',';
+    if (!tls_parser.tls_skip_random(payload)) {
+        return false;
+    }
+    if (!tls_parser.tls_skip_sessid(payload)) {
+        return false;
+    }
 
-   if (!tls_parser.tls_skip_random(payload)) {
-      return false;
-   }
-   if (!tls_parser.tls_skip_sessid(payload)) {
-      return false;
-   }
-
-   if (tls_hs.type == TLS_HANDSHAKE_CLIENT_HELLO) {
-      if (!tls_parser.tls_get_ja3_cipher_suites(ja3, payload)) {
-         return false;
-      }
-      if (!tls_parser.tls_skip_compression_met(payload)) {
-         return false;
-      }
-   } else if (tls_hs.type == TLS_HANDSHAKE_SERVER_HELLO) {
-      payload.start += 2; // Skip cipher suite
-      payload.start += 1; // Skip compression method
-   } else   {
-      return false;
-   }
-   if (!tls_parser.tls_check_ext_len(payload)) {
-      return false;
-   }
-   if (!obtain_tls_data(payload, rec, ja3, tls_hs.type)) {
-      return false;
-   }
-   parsed_sni = payload.obejcts_parsed;
-   return payload.obejcts_parsed != 0 || !ja3.empty();
+    if (tls_hs.type == TLS_HANDSHAKE_CLIENT_HELLO) {
+        if (!tls_parser.tls_get_ja3_cipher_suites(ja3, payload)) {
+            return false;
+        }
+        if (!tls_parser.tls_skip_compression_met(payload)) {
+            return false;
+        }
+    } else if (tls_hs.type == TLS_HANDSHAKE_SERVER_HELLO) {
+        payload.start += 2; // Skip cipher suite
+        payload.start += 1; // Skip compression method
+    } else {
+        return false;
+    }
+    if (!tls_parser.tls_check_ext_len(payload)) {
+        return false;
+    }
+    if (!obtain_tls_data(payload, rec, ja3, tls_hs.type)) {
+        return false;
+    }
+    parsed_sni = payload.obejcts_parsed;
+    return payload.obejcts_parsed != 0 || !ja3.empty();
 } // TLSPlugin::parse_sni
 
-void TLSPlugin::add_tls_record(Flow &rec, const Packet &pkt)
+void TLSPlugin::add_tls_record(Flow& rec, const Packet& pkt)
 {
-   if (ext_ptr == nullptr) {
-      ext_ptr = new RecordExtTLS();
-   }
+    if (ext_ptr == nullptr) {
+        ext_ptr = new RecordExtTLS();
+    }
 
-   if (parse_tls(pkt.payload, pkt.payload_len, ext_ptr)) {
-      DEBUG_CODE(for (int i = 0; i < 16; i++) {
-            DEBUG_MSG("%02x", ext_ptr->ja3_hash_bin[i]);
-         }
-      )
-      DEBUG_MSG("\n");
-      DEBUG_MSG("%s\n", ext_ptr->sni);
-      DEBUG_MSG("%s\n", ext_ptr->alpn);
-      rec.add_extension(ext_ptr);
-      ext_ptr = nullptr;
-   }
+    if (parse_tls(pkt.payload, pkt.payload_len, ext_ptr)) {
+        DEBUG_CODE(for (int i = 0; i < 16; i++) { DEBUG_MSG("%02x", ext_ptr->ja3_hash_bin[i]); })
+        DEBUG_MSG("\n");
+        DEBUG_MSG("%s\n", ext_ptr->sni);
+        DEBUG_MSG("%s\n", ext_ptr->alpn);
+        rec.add_extension(ext_ptr);
+        ext_ptr = nullptr;
+    }
 }
 
 void TLSPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "TLS plugin stats:" << std::endl;
-      std::cout << "   Parsed SNI: " << parsed_sni << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "TLS plugin stats:" << std::endl;
+        std::cout << "   Parsed SNI: " << parsed_sni << std::endl;
+    }
 }
-}
+} // namespace ipxp

--- a/process/tls.hpp
+++ b/process/tls.hpp
@@ -11,175 +11,164 @@
  * \date 2022
  */
 
-
 #ifndef IPXP_PROCESS_TLS_HPP
 #define IPXP_PROCESS_TLS_HPP
 
-#include <string>
-#include <cstring>
 #include <arpa/inet.h>
+#include <cstring>
+#include <string>
 
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 
 #ifdef WITH_NEMEA
-# include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/utils.hpp>
 #include <process/tls_parser.hpp>
-
 
 #define BUFF_SIZE 255
 
 namespace ipxp {
 #define TLS_UNIREC_TEMPLATE "TLS_SNI,TLS_JA3,TLS_ALPN,TLS_VERSION"
 
-UR_FIELDS(
-   string TLS_SNI,
-   string TLS_ALPN,
-   uint16 TLS_VERSION,
-   bytes TLS_JA3
-)
+UR_FIELDS(string TLS_SNI, string TLS_ALPN, uint16 TLS_VERSION, bytes TLS_JA3)
 
 /**
  * \brief Flow record extension header for storing parsed HTTPS packets.
  */
 struct RecordExtTLS : public RecordExt {
-   static int  REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint16_t    version;
-   char        alpn[BUFF_SIZE]  = { 0 };
-   char        sni[BUFF_SIZE]   = { 0 };
-   char        ja3_hash[33]     = { 0 };
-   uint8_t     ja3_hash_bin[16] = { 0 };
-   std::string ja3;
-   bool        server_hello_parsed;
+    uint16_t version;
+    char alpn[BUFF_SIZE] = {0};
+    char sni[BUFF_SIZE] = {0};
+    char ja3_hash[33] = {0};
+    uint8_t ja3_hash_bin[16] = {0};
+    std::string ja3;
+    bool server_hello_parsed;
 
-   /**
-    * \brief Constructor.
-    */
-   RecordExtTLS() : RecordExt(REGISTERED_ID), version(0)
-   {
-      alpn[0]     = 0;
-      sni[0]      = 0;
-      ja3_hash[0] = 0;
-      server_hello_parsed = false;
-   }
+    /**
+     * \brief Constructor.
+     */
+    RecordExtTLS()
+        : RecordExt(REGISTERED_ID)
+        , version(0)
+    {
+        alpn[0] = 0;
+        sni[0] = 0;
+        ja3_hash[0] = 0;
+        server_hello_parsed = false;
+    }
 
-   #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_TLS_VERSION, version);
-      ur_set_string(tmplt, record, F_TLS_SNI, sni);
-      ur_set_string(tmplt, record, F_TLS_ALPN, alpn);
-      ur_set_var(tmplt, record, F_TLS_JA3, ja3_hash_bin, 16);
-   }
+#ifdef WITH_NEMEA
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_TLS_VERSION, version);
+        ur_set_string(tmplt, record, F_TLS_SNI, sni);
+        ur_set_string(tmplt, record, F_TLS_ALPN, alpn);
+        ur_set_var(tmplt, record, F_TLS_JA3, ja3_hash_bin, 16);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return TLS_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return TLS_UNIREC_TEMPLATE; }
 
-   #endif // ifdef WITH_NEMEA
+#endif // ifdef WITH_NEMEA
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      uint16_t sni_len  = strlen(sni);
-      uint16_t alpn_len = strlen(alpn);
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        uint16_t sni_len = strlen(sni);
+        uint16_t alpn_len = strlen(alpn);
 
-      uint32_t pos = 0;
-      uint32_t req_buff_len = (sni_len + 3) + (alpn_len + 3) + (2) + (16 + 3); // (SNI) + (ALPN) + (VERSION) + (JA3)
+        uint32_t pos = 0;
+        uint32_t req_buff_len
+            = (sni_len + 3) + (alpn_len + 3) + (2) + (16 + 3); // (SNI) + (ALPN) + (VERSION) + (JA3)
 
-      if (req_buff_len > (uint32_t) size) {
-         return -1;
-      }
+        if (req_buff_len > (uint32_t) size) {
+            return -1;
+        }
 
-      *(uint16_t *) buffer = ntohs(version);
-      pos += 2;
+        *(uint16_t*) buffer = ntohs(version);
+        pos += 2;
 
-      pos += variable2ipfix_buffer(buffer + pos, (uint8_t *) sni, sni_len);
-      pos += variable2ipfix_buffer(buffer + pos, (uint8_t *) alpn, alpn_len);
+        pos += variable2ipfix_buffer(buffer + pos, (uint8_t*) sni, sni_len);
+        pos += variable2ipfix_buffer(buffer + pos, (uint8_t*) alpn, alpn_len);
 
-      buffer[pos++] = 16;
-      memcpy(buffer + pos, ja3_hash_bin, 16);
-      pos += 16;
+        buffer[pos++] = 16;
+        memcpy(buffer + pos, ja3_hash_bin, 16);
+        pos += 16;
 
-      return pos;
-   }
+        return pos;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_TLS_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_TLS_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_template;
-   }
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
+    std::string get_text() const
+    {
+        std::ostringstream out;
 
-      out << "tlssni=\"" << sni << "\""
-          << ",tlsalpn=\"" << alpn << "\""
-          << ",tlsversion=0x" << std::hex << std::setw(4) << std::setfill('0') << version
-          << ",tlsja3=";
-      for (int i = 0; i < 16; i++) {
-         out << std::hex << std::setw(2) << std::setfill('0') << (unsigned) ja3_hash_bin[i];
-      }
-      return out.str();
-   }
+        out << "tlssni=\"" << sni << "\""
+            << ",tlsalpn=\"" << alpn << "\""
+            << ",tlsversion=0x" << std::hex << std::setw(4) << std::setfill('0') << version
+            << ",tlsja3=";
+        for (int i = 0; i < 16; i++) {
+            out << std::hex << std::setw(2) << std::setfill('0') << (unsigned) ja3_hash_bin[i];
+        }
+        return out.str();
+    }
 };
-
 
 #define TLS_HANDSHAKE_CLIENT_HELLO 1
 #define TLS_HANDSHAKE_SERVER_HELLO 2
 
-
-#define TLS_EXT_SERVER_NAME      0
-#define TLS_EXT_ECLIPTIC_CURVES  10 // AKA supported_groups
+#define TLS_EXT_SERVER_NAME 0
+#define TLS_EXT_ECLIPTIC_CURVES 10 // AKA supported_groups
 #define TLS_EXT_EC_POINT_FORMATS 11
-#define TLS_EXT_ALPN             16
-#define TLS_EXT_SUPPORTED_VER    43
-
+#define TLS_EXT_ALPN 16
+#define TLS_EXT_SUPPORTED_VER 43
 
 /**
  * \brief Flow cache plugin for parsing HTTPS packets.
  */
-class TLSPlugin : public ProcessPlugin
-{
+class TLSPlugin : public ProcessPlugin {
 public:
-   TLSPlugin();
-   ~TLSPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("tls", "Parse SNI from TLS traffic"); }
+    TLSPlugin();
+    ~TLSPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const
+    {
+        return new OptionsParser("tls", "Parse SNI from TLS traffic");
+    }
 
-   std::string get_name() const { return "tls"; }
+    std::string get_name() const { return "tls"; }
 
-   RecordExtTLS *get_ext() const { return new RecordExtTLS(); }
+    RecordExtTLS* get_ext() const { return new RecordExtTLS(); }
 
-   ProcessPlugin *copy();
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void finish(bool print_stats);
 
 private:
-   void add_tls_record(Flow&, const Packet&);
-   bool parse_tls(const uint8_t *, uint16_t, RecordExtTLS *);
-   bool obtain_tls_data(TLSData&, RecordExtTLS *, std::string&, uint8_t);
+    void add_tls_record(Flow&, const Packet&);
+    bool parse_tls(const uint8_t*, uint16_t, RecordExtTLS*);
+    bool obtain_tls_data(TLSData&, RecordExtTLS*, std::string&, uint8_t);
 
-   RecordExtTLS *ext_ptr;
-   TLSParser tls_parser;
-   uint32_t parsed_sni;
-   bool flow_flush;
+    RecordExtTLS* ext_ptr;
+    TLSParser tls_parser;
+    uint32_t parsed_sni;
+    bool flow_flush;
 };
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_TLS_HPP */

--- a/process/tls_parser.cpp
+++ b/process/tls_parser.cpp
@@ -16,329 +16,329 @@
 namespace ipxp {
 TLSParser::TLSParser()
 {
-   tls_hs = NULL;
+    tls_hs = NULL;
 }
 
-uint64_t quic_get_variable_length(uint8_t *start, uint64_t &offset)
+uint64_t quic_get_variable_length(uint8_t* start, uint64_t& offset)
 {
-   // find out length of parameter field (and load parameter, then move offset) , defined in:
-   // https://www.rfc-editor.org/rfc/rfc9000.html#name-summary-of-integer-encoding
-   // this approach is used also in length field , and other QUIC defined fields.
-   uint64_t tmp = 0;
+    // find out length of parameter field (and load parameter, then move offset) , defined in:
+    // https://www.rfc-editor.org/rfc/rfc9000.html#name-summary-of-integer-encoding
+    // this approach is used also in length field , and other QUIC defined fields.
+    uint64_t tmp = 0;
 
-   uint8_t two_bits = *(start + offset) & 0xC0;
+    uint8_t two_bits = *(start + offset) & 0xC0;
 
-   switch (two_bits) {
-       case 0:
-          tmp     = *(start + offset) & 0x3F;
-          offset += sizeof(uint8_t);
-          return tmp;
+    switch (two_bits) {
+    case 0:
+        tmp = *(start + offset) & 0x3F;
+        offset += sizeof(uint8_t);
+        return tmp;
 
-       case 64:
-          tmp     = be16toh(*(uint16_t *) (start + offset)) & 0x3FFF;
-          offset += sizeof(uint16_t);
-          return tmp;
+    case 64:
+        tmp = be16toh(*(uint16_t*) (start + offset)) & 0x3FFF;
+        offset += sizeof(uint16_t);
+        return tmp;
 
-       case 128:
-          tmp     = be32toh(*(uint32_t *) (start + offset)) & 0x3FFFFFFF;
-          offset += sizeof(uint32_t);
-          return tmp;
+    case 128:
+        tmp = be32toh(*(uint32_t*) (start + offset)) & 0x3FFFFFFF;
+        offset += sizeof(uint32_t);
+        return tmp;
 
-       case 192:
-          tmp     = be64toh(*(uint64_t *) (start + offset)) & 0x3FFFFFFFFFFFFFFF;
-          offset += sizeof(uint64_t);
-          return tmp;
+    case 192:
+        tmp = be64toh(*(uint64_t*) (start + offset)) & 0x3FFFFFFFFFFFFFFF;
+        offset += sizeof(uint64_t);
+        return tmp;
 
-       default:
-          return 0;
-   }
+    default:
+        return 0;
+    }
 } // quic_get_variable_length
 
 bool TLSParser::tls_is_grease_value(uint16_t val)
 {
-   if (val != 0 && !(val & ~(0xFAFA)) && ((0x00FF & val) == (val >> 8))) {
-      return true;
-   }
-   return false;
+    if (val != 0 && !(val & ~(0xFAFA)) && ((0x00FF & val) == (val >> 8))) {
+        return true;
+    }
+    return false;
 }
 
-void TLSParser::tls_get_quic_user_agent(TLSData &data, char *buffer, size_t buffer_size)
+void TLSParser::tls_get_quic_user_agent(TLSData& data, char* buffer, size_t buffer_size)
 {
-   // compute end of quic_transport_parameters
-   const uint16_t quic_transport_params_len = ntohs(*(uint16_t *) data.start);
-   const uint8_t *quic_transport_params_end = data.start + quic_transport_params_len
-     + sizeof(quic_transport_params_len);
+    // compute end of quic_transport_parameters
+    const uint16_t quic_transport_params_len = ntohs(*(uint16_t*) data.start);
+    const uint8_t* quic_transport_params_end
+        = data.start + quic_transport_params_len + sizeof(quic_transport_params_len);
 
-   if (quic_transport_params_end > data.end) {
-      return;
-   }
+    if (quic_transport_params_end > data.end) {
+        return;
+    }
 
-   uint64_t offset = 0;
-   uint64_t param  = 0;
-   uint64_t length = 0;
+    uint64_t offset = 0;
+    uint64_t param = 0;
+    uint64_t length = 0;
 
-   while (data.start + offset < quic_transport_params_end) {
-      param  = quic_get_variable_length((uint8_t *) data.start, offset);
-      length = quic_get_variable_length((uint8_t *) data.start, offset);
-      if (param == TLS_EXT_GOOGLE_USER_AGENT) {
-         if (length + (size_t) 1 > buffer_size) {
-            length = buffer_size - 1;
-         }
-         memcpy(buffer, data.start + offset, length);
-         buffer[length] = 0;
-         data.obejcts_parsed++;
-      }
-      offset += length;
-   }
-   return;
+    while (data.start + offset < quic_transport_params_end) {
+        param = quic_get_variable_length((uint8_t*) data.start, offset);
+        length = quic_get_variable_length((uint8_t*) data.start, offset);
+        if (param == TLS_EXT_GOOGLE_USER_AGENT) {
+            if (length + (size_t) 1 > buffer_size) {
+                length = buffer_size - 1;
+            }
+            memcpy(buffer, data.start + offset, length);
+            buffer[length] = 0;
+            data.obejcts_parsed++;
+        }
+        offset += length;
+    }
+    return;
 }
 
-void TLSParser::tls_get_server_name(TLSData &data, char *buffer, size_t buffer_size)
+void TLSParser::tls_get_server_name(TLSData& data, char* buffer, size_t buffer_size)
 {
-   uint16_t list_len       = ntohs(*(uint16_t *) data.start);
-   uint16_t offset         = sizeof(list_len);
-   const uint8_t *list_end = data.start + list_len + offset;
-   size_t buff_offset      = 0;
+    uint16_t list_len = ntohs(*(uint16_t*) data.start);
+    uint16_t offset = sizeof(list_len);
+    const uint8_t* list_end = data.start + list_len + offset;
+    size_t buff_offset = 0;
 
-   if (list_end > data.end) {
-      // data.valid = false;
-      return;
-   }
+    if (list_end > data.end) {
+        // data.valid = false;
+        return;
+    }
 
-   while (data.start + sizeof(tls_ext_sni) + offset < list_end) {
-      tls_ext_sni *tmp_sni = (tls_ext_sni *) (data.start + offset);
-      uint16_t sni_len     = ntohs(tmp_sni->length);
+    while (data.start + sizeof(tls_ext_sni) + offset < list_end) {
+        tls_ext_sni* tmp_sni = (tls_ext_sni*) (data.start + offset);
+        uint16_t sni_len = ntohs(tmp_sni->length);
 
-      offset += sizeof(tls_ext_sni);
-      if (data.start + offset + sni_len > list_end) {
-         break;
-      }
-      if (sni_len + (size_t) 1 + buff_offset > buffer_size) {
-         sni_len = buffer_size - 1 - buff_offset;
-      }
-      memcpy(buffer + buff_offset, data.start + offset, sni_len);
+        offset += sizeof(tls_ext_sni);
+        if (data.start + offset + sni_len > list_end) {
+            break;
+        }
+        if (sni_len + (size_t) 1 + buff_offset > buffer_size) {
+            sni_len = buffer_size - 1 - buff_offset;
+        }
+        memcpy(buffer + buff_offset, data.start + offset, sni_len);
 
-      buff_offset += sni_len + 1;
-      buffer[buff_offset - 1] = 0;
-      data.obejcts_parsed++;
-      offset += ntohs(tmp_sni->length);
-   }
-   return;
+        buff_offset += sni_len + 1;
+        buffer[buff_offset - 1] = 0;
+        data.obejcts_parsed++;
+        offset += ntohs(tmp_sni->length);
+    }
+    return;
 }
 
-void TLSParser::tls_get_supp_ver(TLSData &data, uint16_t &version)
+void TLSParser::tls_get_supp_ver(TLSData& data, uint16_t& version)
 {
-   tls_version* ext_ver = (tls_version *) data.start;
-   version = ((uint16_t) ext_ver->major << 8) | ext_ver->minor;
-   return;
+    tls_version* ext_ver = (tls_version*) data.start;
+    version = ((uint16_t) ext_ver->major << 8) | ext_ver->minor;
+    return;
 }
 
-void TLSParser::tls_get_alpn(TLSData &data, char *buffer, size_t buffer_size)
+void TLSParser::tls_get_alpn(TLSData& data, char* buffer, size_t buffer_size)
 {
-   uint16_t list_len       = ntohs(*(uint16_t *) data.start);
-   uint16_t offset         = sizeof(list_len);
-   const uint8_t *list_end = data.start + list_len + offset;
+    uint16_t list_len = ntohs(*(uint16_t*) data.start);
+    uint16_t offset = sizeof(list_len);
+    const uint8_t* list_end = data.start + list_len + offset;
 
-   if (list_end > data.end) {
-      // data.valid = false;
-      return;
-   }
-   if (buffer[0] != 0) {
-      return;
-   }
+    if (list_end > data.end) {
+        // data.valid = false;
+        return;
+    }
+    if (buffer[0] != 0) {
+        return;
+    }
 
-   uint16_t alpn_written = 0;
+    uint16_t alpn_written = 0;
 
-   while (data.start + sizeof(uint8_t) + offset < list_end) {
-      uint8_t alpn_len        = *(uint8_t *) (data.start + offset);
-      const uint8_t *alpn_str = data.start + offset + sizeof(uint8_t);
+    while (data.start + sizeof(uint8_t) + offset < list_end) {
+        uint8_t alpn_len = *(uint8_t*) (data.start + offset);
+        const uint8_t* alpn_str = data.start + offset + sizeof(uint8_t);
 
-      offset += sizeof(uint8_t) + alpn_len;
-      if (data.start + offset > list_end) {
-         break;
-      }
-      if (alpn_written + alpn_len + (size_t) 2 >= buffer_size) {
-         break;
-      }
+        offset += sizeof(uint8_t) + alpn_len;
+        if (data.start + offset > list_end) {
+            break;
+        }
+        if (alpn_written + alpn_len + (size_t) 2 >= buffer_size) {
+            break;
+        }
 
-      if (alpn_written != 0) {
-         buffer[alpn_written++] = ';';
-      }
-      memcpy(buffer + alpn_written, alpn_str, alpn_len);
-      alpn_written        += alpn_len;
-      buffer[alpn_written] = 0;
-   }
-   return;
+        if (alpn_written != 0) {
+            buffer[alpn_written++] = ';';
+        }
+        memcpy(buffer + alpn_written, alpn_str, alpn_len);
+        alpn_written += alpn_len;
+        buffer[alpn_written] = 0;
+    }
+    return;
 } // TLSParser::tls_get_alpn
 
 tls_handshake TLSParser::tls_get_handshake()
 {
-   if (tls_hs != NULL) {
-      return *tls_hs;
-   }
-   return { };
+    if (tls_hs != NULL) {
+        return *tls_hs;
+    }
+    return {};
 }
 
-bool TLSParser::tls_check_handshake(TLSData & payload)
+bool TLSParser::tls_check_handshake(TLSData& payload)
 {
-   tls_hs = (tls_handshake *) payload.start;
-   const uint8_t tmp_hs_type = tls_hs->type;
+    tls_hs = (tls_handshake*) payload.start;
+    const uint8_t tmp_hs_type = tls_hs->type;
 
-   if (payload.start + sizeof(tls_handshake) > payload.end ||
-     !(tmp_hs_type == TLS_HANDSHAKE_CLIENT_HELLO || tmp_hs_type == TLS_HANDSHAKE_SERVER_HELLO)) {
-      return false;
-   }
-   if (payload.start + 44 > payload.end ||
-     tls_hs->version.major != 3 ||
-     tls_hs->version.minor < 1 ||
-     tls_hs->version.minor > 3) {
-      return false;
-   }
-   payload.start += sizeof(tls_handshake);
-   return true;
+    if (payload.start + sizeof(tls_handshake) > payload.end
+        || !(
+            tmp_hs_type == TLS_HANDSHAKE_CLIENT_HELLO
+            || tmp_hs_type == TLS_HANDSHAKE_SERVER_HELLO)) {
+        return false;
+    }
+    if (payload.start + 44 > payload.end || tls_hs->version.major != 3 || tls_hs->version.minor < 1
+        || tls_hs->version.minor > 3) {
+        return false;
+    }
+    payload.start += sizeof(tls_handshake);
+    return true;
 }
 
-bool TLSParser::tls_check_rec(TLSData & payload)
+bool TLSParser::tls_check_rec(TLSData& payload)
 {
-   tls_rec *tls = (tls_rec *) payload.start;
+    tls_rec* tls = (tls_rec*) payload.start;
 
-   if (payload.start + sizeof(tls_rec) > payload.end || !tls || tls->type != TLS_HANDSHAKE ||
-     tls->version.major != 3 || tls->version.minor > 3) {
-      return false;
-   }
-   payload.start += sizeof(tls_rec);
-   return true;
+    if (payload.start + sizeof(tls_rec) > payload.end || !tls || tls->type != TLS_HANDSHAKE
+        || tls->version.major != 3 || tls->version.minor > 3) {
+        return false;
+    }
+    payload.start += sizeof(tls_rec);
+    return true;
 }
 
 bool TLSParser::tls_skip_random(TLSData& payload)
 {
-   if (payload.start + 32 > payload.end) {
-      return false;
-   }
-   payload.start += 32;
-   return true;
+    if (payload.start + 32 > payload.end) {
+        return false;
+    }
+    payload.start += 32;
+    return true;
 }
 
 bool TLSParser::tls_skip_sessid(TLSData& payload)
 {
-   uint8_t sess_id_len = *(uint8_t *) payload.start;
+    uint8_t sess_id_len = *(uint8_t*) payload.start;
 
-   if (payload.start + sizeof(sess_id_len) + sess_id_len > payload.end) {
-      return false;
-   }
-   payload.start += sizeof(sess_id_len) + sess_id_len;
-   return true;
+    if (payload.start + sizeof(sess_id_len) + sess_id_len > payload.end) {
+        return false;
+    }
+    payload.start += sizeof(sess_id_len) + sess_id_len;
+    return true;
 }
 
 bool TLSParser::tls_skip_cipher_suites(TLSData& payload)
 {
-   uint16_t cipher_suite_len = ntohs(*(uint16_t *) payload.start);
+    uint16_t cipher_suite_len = ntohs(*(uint16_t*) payload.start);
 
-   if (payload.start + sizeof(cipher_suite_len) + +cipher_suite_len > payload.end) {
-      return false;
-   }
-   payload.start += sizeof(cipher_suite_len) + cipher_suite_len;
-   return true;
+    if (payload.start + sizeof(cipher_suite_len) + +cipher_suite_len > payload.end) {
+        return false;
+    }
+    payload.start += sizeof(cipher_suite_len) + cipher_suite_len;
+    return true;
 }
 
 bool TLSParser::tls_skip_compression_met(TLSData& payload)
 {
-   uint8_t compression_met_len = *(uint8_t *) payload.start;
+    uint8_t compression_met_len = *(uint8_t*) payload.start;
 
-   if (payload.start + sizeof(compression_met_len) + compression_met_len > payload.end) {
-      return false;
-   }
-   payload.start += sizeof(compression_met_len) + compression_met_len;
-   return true;
+    if (payload.start + sizeof(compression_met_len) + compression_met_len > payload.end) {
+        return false;
+    }
+    payload.start += sizeof(compression_met_len) + compression_met_len;
+    return true;
 }
 
 bool TLSParser::tls_check_ext_len(TLSData& payload)
 {
-   const uint8_t *ext_end = payload.start + ntohs(*(uint16_t *) payload.start) + sizeof(uint16_t);
+    const uint8_t* ext_end = payload.start + ntohs(*(uint16_t*) payload.start) + sizeof(uint16_t);
 
-   payload.start += 2;
-   if (ext_end > payload.end) {
-      return false;
-   }
-   if (ext_end <= payload.end) {
-      payload.end = ext_end;
-   }
-   return true;
+    payload.start += 2;
+    if (ext_end > payload.end) {
+        return false;
+    }
+    if (ext_end <= payload.end) {
+        payload.end = ext_end;
+    }
+    return true;
 }
 
-bool TLSParser::tls_get_ja3_cipher_suites(std::string &ja3, TLSData &data)
+bool TLSParser::tls_get_ja3_cipher_suites(std::string& ja3, TLSData& data)
 {
-   uint16_t cipher_suites_length = ntohs(*(uint16_t *) data.start);
-   uint16_t type_id = 0;
-   const uint8_t *section_end = data.start + cipher_suites_length;
+    uint16_t cipher_suites_length = ntohs(*(uint16_t*) data.start);
+    uint16_t type_id = 0;
+    const uint8_t* section_end = data.start + cipher_suites_length;
 
-   if (data.start + cipher_suites_length + 1 > data.end) {
-      // data.valid = false;
-      return false;
-   }
-   data.start += sizeof(cipher_suites_length);
+    if (data.start + cipher_suites_length + 1 > data.end) {
+        // data.valid = false;
+        return false;
+    }
+    data.start += sizeof(cipher_suites_length);
 
-   for (; data.start <= section_end; data.start += sizeof(uint16_t)) {
-      type_id = ntohs(*(uint16_t *) (data.start));
-      if (!tls_is_grease_value(type_id)) {
-         ja3 += std::to_string(type_id);
-         if (data.start < section_end) {
-            ja3 += '-';
-         }
-      }
-   }
-   ja3 += ',';
-   return true;
+    for (; data.start <= section_end; data.start += sizeof(uint16_t)) {
+        type_id = ntohs(*(uint16_t*) (data.start));
+        if (!tls_is_grease_value(type_id)) {
+            ja3 += std::to_string(type_id);
+            if (data.start < section_end) {
+                ja3 += '-';
+            }
+        }
+    }
+    ja3 += ',';
+    return true;
 }
 
-std::string TLSParser::tls_get_ja3_ecpliptic_curves(TLSData &data)
+std::string TLSParser::tls_get_ja3_ecpliptic_curves(TLSData& data)
 {
-   std::string collected_types;
-   uint16_t type_id        = 0;
-   uint16_t list_len       = ntohs(*(uint16_t *) data.start);
-   const uint8_t *list_end = data.start + list_len + sizeof(list_len);
-   uint16_t offset         = sizeof(list_len);
+    std::string collected_types;
+    uint16_t type_id = 0;
+    uint16_t list_len = ntohs(*(uint16_t*) data.start);
+    const uint8_t* list_end = data.start + list_len + sizeof(list_len);
+    uint16_t offset = sizeof(list_len);
 
-   if (list_end > data.end) {
-      // data.valid = false;
-      return "";
-   }
+    if (list_end > data.end) {
+        // data.valid = false;
+        return "";
+    }
 
-   while (data.start + sizeof(uint16_t) + offset <= list_end) {
-      type_id = ntohs(*(uint16_t *) (data.start + offset));
-      offset += sizeof(uint16_t);
-      if (!tls_is_grease_value(type_id)) {
-         collected_types += std::to_string(type_id);
+    while (data.start + sizeof(uint16_t) + offset <= list_end) {
+        type_id = ntohs(*(uint16_t*) (data.start + offset));
+        offset += sizeof(uint16_t);
+        if (!tls_is_grease_value(type_id)) {
+            collected_types += std::to_string(type_id);
 
-         if (data.start + sizeof(uint16_t) + offset <= list_end) {
-            collected_types += '-';
-         }
-      }
-   }
-   return collected_types;
+            if (data.start + sizeof(uint16_t) + offset <= list_end) {
+                collected_types += '-';
+            }
+        }
+    }
+    return collected_types;
 }
 
-std::string TLSParser::tls_get_ja3_ec_point_formats(TLSData &data)
+std::string TLSParser::tls_get_ja3_ec_point_formats(TLSData& data)
 {
-   std::string collected_formats;
-   uint8_t list_len        = *data.start;
-   uint16_t offset         = sizeof(list_len);
-   const uint8_t *list_end = data.start + list_len + offset;
-   uint8_t format;
+    std::string collected_formats;
+    uint8_t list_len = *data.start;
+    uint16_t offset = sizeof(list_len);
+    const uint8_t* list_end = data.start + list_len + offset;
+    uint8_t format;
 
-   if (list_end > data.end) {
-      // data.valid = false;
-      return "";
-   }
+    if (list_end > data.end) {
+        // data.valid = false;
+        return "";
+    }
 
-   while (data.start + sizeof(uint8_t) + offset <= list_end) {
-      format = *(data.start + offset);
-      collected_formats += std::to_string((int) format);
-      offset += sizeof(uint8_t);
-      if (data.start + sizeof(uint8_t) + offset <= list_end) {
-         collected_formats += '-';
-      }
-   }
-   return collected_formats;
+    while (data.start + sizeof(uint8_t) + offset <= list_end) {
+        format = *(data.start + offset);
+        collected_formats += std::to_string((int) format);
+        offset += sizeof(uint8_t);
+        if (data.start + sizeof(uint8_t) + offset <= list_end) {
+            collected_formats += '-';
+        }
+    }
+    return collected_formats;
 }
-}
+} // namespace ipxp

--- a/process/tls_parser.hpp
+++ b/process/tls_parser.hpp
@@ -10,94 +10,92 @@
  * \date 2022
  */
 
-
 #include <cstdint>
 #include <cstring>
 #include <ipfixprobe/process.hpp>
 
-#define TLS_HANDSHAKE_CLIENT_HELLO           1
-#define TLS_HANDSHAKE_SERVER_HELLO           2
-#define TLS_EXT_SERVER_NAME                  0
-#define TLS_EXT_ALPN                         16
+#define TLS_HANDSHAKE_CLIENT_HELLO 1
+#define TLS_HANDSHAKE_SERVER_HELLO 2
+#define TLS_EXT_SERVER_NAME 0
+#define TLS_EXT_ALPN 16
 // draf-33, draft-34 a rfc9001, have this value defined as 0x39 == 57
 #define TLS_EXT_QUIC_TRANSPORT_PARAMETERS_V1 0x39
 // draf-13 az draft-32 have this value defined as 0xffa5 == 65445
-#define TLS_EXT_QUIC_TRANSPORT_PARAMETERS    0xffa5
+#define TLS_EXT_QUIC_TRANSPORT_PARAMETERS 0xffa5
 // draf-02 az draft-12 have this value defined as 0x26 == 38
 #define TLS_EXT_QUIC_TRANSPORT_PARAMETERS_V2 0x26
-#define TLS_EXT_GOOGLE_USER_AGENT            0x3129
-
+#define TLS_EXT_GOOGLE_USER_AGENT 0x3129
 
 namespace ipxp {
 typedef struct TLSData {
-   const uint8_t *start;
-   const uint8_t *end;
-   int            obejcts_parsed;
+    const uint8_t* start;
+    const uint8_t* end;
+    int obejcts_parsed;
 } TLSData;
 
 struct __attribute__((packed)) tls_ext_sni {
-   uint8_t  type;
-   uint16_t length;
-   /* Hostname bytes... */
+    uint8_t type;
+    uint16_t length;
+    /* Hostname bytes... */
 };
 
 struct __attribute__((packed)) tls_ext {
-   uint16_t type;
-   uint16_t length;
-   /* Extension pecific data... */
+    uint16_t type;
+    uint16_t length;
+    /* Extension pecific data... */
 };
 
 union __attribute__((packed)) tls_version {
-   uint16_t version;
-   struct {
-      uint8_t major;
-      uint8_t minor;
-   };
+    uint16_t version;
+    struct {
+        uint8_t major;
+        uint8_t minor;
+    };
 };
 
 struct __attribute__((packed)) tls_handshake {
-   uint8_t     type;
-   uint8_t     length1; // length field is 3 bytes long...
-   uint16_t    length2;
-   tls_version version;
+    uint8_t type;
+    uint8_t length1; // length field is 3 bytes long...
+    uint16_t length2;
+    tls_version version;
 
-   /* Handshake data... */
+    /* Handshake data... */
 };
 
 #define TLS_HANDSHAKE 22
 struct __attribute__((packed)) tls_rec {
-   uint8_t     type;
-   tls_version version;
-   uint16_t    length;
-   /* Record data... */
+    uint8_t type;
+    tls_version version;
+    uint16_t length;
+    /* Record data... */
 };
 
-class TLSParser
-{
+class TLSParser {
 private:
-   tls_handshake *tls_hs;
+    tls_handshake* tls_hs;
+
 public:
-   TLSParser();
-   bool tls_skip_random(TLSData&);
-   bool tls_skip_sessid(TLSData&);
-   bool tls_skip_cipher_suites(TLSData&);
-   bool tls_skip_compression_met(TLSData&);
-   bool tls_check_ext_len(TLSData&);
-   bool tls_check_rec(TLSData&);
-   void tls_get_server_name(TLSData &, char *, size_t);
-   void tls_get_alpn(TLSData &, char *, size_t);
-   void tls_get_supp_ver(TLSData &, uint16_t &);
+    TLSParser();
+    bool tls_skip_random(TLSData&);
+    bool tls_skip_sessid(TLSData&);
+    bool tls_skip_cipher_suites(TLSData&);
+    bool tls_skip_compression_met(TLSData&);
+    bool tls_check_ext_len(TLSData&);
+    bool tls_check_rec(TLSData&);
+    void tls_get_server_name(TLSData&, char*, size_t);
+    void tls_get_alpn(TLSData&, char*, size_t);
+    void tls_get_supp_ver(TLSData&, uint16_t&);
 
-   void tls_get_quic_user_agent(TLSData &, char *, size_t);
-   bool tls_check_handshake(TLSData&);
-   bool tls_get_ja3_cipher_suites(std::string&, TLSData&);
+    void tls_get_quic_user_agent(TLSData&, char*, size_t);
+    bool tls_check_handshake(TLSData&);
+    bool tls_get_ja3_cipher_suites(std::string&, TLSData&);
 
-   bool tls_is_grease_value(uint16_t);
+    bool tls_is_grease_value(uint16_t);
 
-   tls_handshake tls_get_handshake();
-   uint8_t tls_get_hstype();
-   std::string tls_get_version_ja3();
-   std::string tls_get_ja3_ecpliptic_curves(TLSData &data);
-   std::string tls_get_ja3_ec_point_formats(TLSData &data);
+    tls_handshake tls_get_handshake();
+    uint8_t tls_get_hstype();
+    std::string tls_get_version_ja3();
+    std::string tls_get_ja3_ecpliptic_curves(TLSData& data);
+    std::string tls_get_ja3_ec_point_formats(TLSData& data);
 };
-}
+} // namespace ipxp

--- a/process/vlan.cpp
+++ b/process/vlan.cpp
@@ -36,23 +36,22 @@ int RecordExtVLAN::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("vlan", [](){return new VLANPlugin();});
-   register_plugin(&rec);
-   RecordExtVLAN::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("vlan", []() { return new VLANPlugin(); });
+    register_plugin(&rec);
+    RecordExtVLAN::REGISTERED_ID = register_extension();
 }
 
-ProcessPlugin *VLANPlugin::copy()
+ProcessPlugin* VLANPlugin::copy()
 {
-   return new VLANPlugin(*this);
+    return new VLANPlugin(*this);
 }
 
-int VLANPlugin::post_create(Flow &rec, const Packet &pkt)
+int VLANPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   auto ext = new RecordExtVLAN();
-   ext->vlan_id = pkt.vlan_id;
-   rec.add_extension(ext);
-   return 0;
+    auto ext = new RecordExtVLAN();
+    ext->vlan_id = pkt.vlan_id;
+    rec.add_extension(ext);
+    return 0;
 }
 
-}
-
+} // namespace ipxp

--- a/process/vlan.hpp
+++ b/process/vlan.hpp
@@ -32,94 +32,86 @@
 #include <cstring>
 
 #ifdef WITH_NEMEA
-  #include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 #include <cstdint>
-#include <string>
 #include <sstream>
+#include <string>
 
 namespace ipxp {
 
 #define VLAN_UNIREC_TEMPLATE "VLAN_ID"
 
-UR_FIELDS (
-   uint16 VLAN_ID
-)
+UR_FIELDS(uint16 VLAN_ID)
 
 /**
  * \brief Flow record extension header for storing parsed VLAN data.
  */
 struct RecordExtVLAN : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   // vlan id is in the host byte order
-   uint16_t vlan_id;
+    // vlan id is in the host byte order
+    uint16_t vlan_id;
 
-   RecordExtVLAN() : RecordExt(REGISTERED_ID), vlan_id(0)
-   {
-   }
+    RecordExtVLAN()
+        : RecordExt(REGISTERED_ID)
+        , vlan_id(0)
+    {
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_VLAN_ID, vlan_id);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_VLAN_ID, vlan_id);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return VLAN_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return VLAN_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      const int LEN = sizeof(vlan_id);
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        const int LEN = sizeof(vlan_id);
 
-      if (size < LEN) {
-         return -1;
-      }
+        if (size < LEN) {
+            return -1;
+        }
 
-      *reinterpret_cast<uint16_t *>(buffer) = htons(vlan_id);
-      return LEN;
-   }
+        *reinterpret_cast<uint16_t*>(buffer) = htons(vlan_id);
+        return LEN;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_template[] = {
-         IPFIX_VLAN_TEMPLATE(IPFIX_FIELD_NAMES)
-         NULL
-      };
-      return ipfix_template;
-   }
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_template[] = {IPFIX_VLAN_TEMPLATE(IPFIX_FIELD_NAMES) NULL};
+        return ipfix_template;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "vlan_id=\"" << vlan_id << '"';
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "vlan_id=\"" << vlan_id << '"';
+        return out.str();
+    }
 };
 
 /**
  * \brief Process plugin for parsing VLAN packets.
  */
-class VLANPlugin : public ProcessPlugin
-{
+class VLANPlugin : public ProcessPlugin {
 public:
-   OptionsParser *get_parser() const { return new OptionsParser("vlan", "Parse VLAN traffic"); }
-   std::string get_name() const { return "vlan"; }
-   RecordExt *get_ext() const { return new RecordExtVLAN(); }
-   ProcessPlugin *copy();
+    OptionsParser* get_parser() const { return new OptionsParser("vlan", "Parse VLAN traffic"); }
+    std::string get_name() const { return "vlan"; }
+    RecordExt* get_ext() const { return new RecordExtVLAN(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
+    int post_create(Flow& rec, const Packet& pkt);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_VLAN_HPP */
-

--- a/process/wg.cpp
+++ b/process/wg.cpp
@@ -26,8 +26,8 @@
  *
  */
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
 #include "wg.hpp"
 
@@ -37,183 +37,195 @@ int RecordExtWG::REGISTERED_ID = -1;
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("wg", [](){return new WGPlugin();});
-   register_plugin(&rec);
-   RecordExtWG::REGISTERED_ID = register_extension();
+    static PluginRecord rec = PluginRecord("wg", []() { return new WGPlugin(); });
+    register_plugin(&rec);
+    RecordExtWG::REGISTERED_ID = register_extension();
 }
 
-WGPlugin::WGPlugin() : preallocated_record(nullptr), flow_flush(false), total(0), identified(0)
+WGPlugin::WGPlugin()
+    : preallocated_record(nullptr)
+    , flow_flush(false)
+    , total(0)
+    , identified(0)
 {
 }
 
 WGPlugin::~WGPlugin()
 {
-   close();
+    close();
 }
 
-void WGPlugin::init(const char *params)
-{
-}
+void WGPlugin::init(const char* params) {}
 
 void WGPlugin::close()
 {
-   if (preallocated_record != nullptr) {
-      delete preallocated_record;
-      preallocated_record = nullptr;
-   }
+    if (preallocated_record != nullptr) {
+        delete preallocated_record;
+        preallocated_record = nullptr;
+    }
 }
 
-ProcessPlugin *WGPlugin::copy()
+ProcessPlugin* WGPlugin::copy()
 {
-   return new WGPlugin(*this);
+    return new WGPlugin(*this);
 }
 
-int WGPlugin::post_create(Flow &rec, const Packet &pkt)
+int WGPlugin::post_create(Flow& rec, const Packet& pkt)
 {
-   if (pkt.ip_proto == IPPROTO_UDP) {
-      add_ext_wg(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.source_pkt, rec);
-   }
+    if (pkt.ip_proto == IPPROTO_UDP) {
+        add_ext_wg(
+            reinterpret_cast<const char*>(pkt.payload),
+            pkt.payload_len,
+            pkt.source_pkt,
+            rec);
+    }
 
-   return 0;
+    return 0;
 }
 
-int WGPlugin::pre_update(Flow &rec, Packet &pkt)
+int WGPlugin::pre_update(Flow& rec, Packet& pkt)
 {
-   RecordExtWG *vpn_data = (RecordExtWG *) rec.get_extension(RecordExtWG::REGISTERED_ID);
-   if (vpn_data != nullptr && vpn_data->possible_wg) {
-      bool res = parse_wg(reinterpret_cast<const char *>(pkt.payload), pkt.payload_len, pkt.source_pkt, vpn_data);
-      // In case of new flow, flush
-      if (flow_flush) {
-         flow_flush = false;
-         return FLOW_FLUSH_WITH_REINSERT;
-      }
-      // In other cases, when WG was not detected
-      if (!res) {
-         vpn_data->possible_wg = 0;
-      }
-   }
+    RecordExtWG* vpn_data = (RecordExtWG*) rec.get_extension(RecordExtWG::REGISTERED_ID);
+    if (vpn_data != nullptr && vpn_data->possible_wg) {
+        bool res = parse_wg(
+            reinterpret_cast<const char*>(pkt.payload),
+            pkt.payload_len,
+            pkt.source_pkt,
+            vpn_data);
+        // In case of new flow, flush
+        if (flow_flush) {
+            flow_flush = false;
+            return FLOW_FLUSH_WITH_REINSERT;
+        }
+        // In other cases, when WG was not detected
+        if (!res) {
+            vpn_data->possible_wg = 0;
+        }
+    }
 
-   return 0;
+    return 0;
 }
 
-void WGPlugin::pre_export(Flow &rec)
-{
-}
+void WGPlugin::pre_export(Flow& rec) {}
 
 void WGPlugin::finish(bool print_stats)
 {
-   if (print_stats) {
-      std::cout << "WG plugin stats:" << std::endl;
-      std::cout << "   Identified WG packets: " << identified << std::endl;
-      std::cout << "   Total packets processed: " << total << std::endl;
-   }
+    if (print_stats) {
+        std::cout << "WG plugin stats:" << std::endl;
+        std::cout << "   Identified WG packets: " << identified << std::endl;
+        std::cout << "   Total packets processed: " << total << std::endl;
+    }
 }
 
-bool WGPlugin::parse_wg(const char *data, unsigned int payload_len, bool source_pkt, RecordExtWG *ext)
+bool WGPlugin::parse_wg(
+    const char* data,
+    unsigned int payload_len,
+    bool source_pkt,
+    RecordExtWG* ext)
 {
-   uint32_t cmp_peer;
-   uint32_t cmp_new_peer;
+    uint32_t cmp_peer;
+    uint32_t cmp_new_peer;
 
-   static const char dns_query_mask [4] = {0x00, 0x01, 0x00, 0x00};
+    static const char dns_query_mask[4] = {0x00, 0x01, 0x00, 0x00};
 
-   total++;
+    total++;
 
-   // The smallest message (according to specs) is the data message (0x04) with 16 header bytes
-   // and 16 bytes of (empty) data authentication.
-   // Anything below that is not a valid WireGuard message.
-   if (payload_len < WG_PACKETLEN_MIN_TRANSPORT_DATA) {
-      return false;
-   }
+    // The smallest message (according to specs) is the data message (0x04) with 16 header bytes
+    // and 16 bytes of (empty) data authentication.
+    // Anything below that is not a valid WireGuard message.
+    if (payload_len < WG_PACKETLEN_MIN_TRANSPORT_DATA) {
+        return false;
+    }
 
-   // Let's try to parse according to the first 4 bytes, and see if that is enough.
-   // The first byte is 0x01-0x04, the following three bytes are reserved (0x00).
-   uint8_t pkt_type = data[0];
-   if (pkt_type < WG_PACKETTYPE_INIT_TO_RESP || pkt_type > WG_PACKETTYPE_TRANSPORT_DATA) {
-      return false;
-   }
-   if (data[1] != 0x0 || data[2] != 0x0 || data[3] != 0x0) {
-      return false;
-   }
+    // Let's try to parse according to the first 4 bytes, and see if that is enough.
+    // The first byte is 0x01-0x04, the following three bytes are reserved (0x00).
+    uint8_t pkt_type = data[0];
+    if (pkt_type < WG_PACKETTYPE_INIT_TO_RESP || pkt_type > WG_PACKETTYPE_TRANSPORT_DATA) {
+        return false;
+    }
+    if (data[1] != 0x0 || data[2] != 0x0 || data[3] != 0x0) {
+        return false;
+    }
 
-   // Next, check the packet contents based on the message type.
-   switch (pkt_type) {
-      case WG_PACKETTYPE_INIT_TO_RESP:
-         if (payload_len != WG_PACKETLEN_INIT_TO_RESP) {
+    // Next, check the packet contents based on the message type.
+    switch (pkt_type) {
+    case WG_PACKETTYPE_INIT_TO_RESP:
+        if (payload_len != WG_PACKETLEN_INIT_TO_RESP) {
             return false;
-         }
+        }
 
-         // compare the current dst_peer and see if it matches the original source.
-         // If not, the flow flush may be needed to create a new flow.
-         cmp_peer = source_pkt ? ext->src_peer : ext->dst_peer;
-         memcpy(&cmp_new_peer, (data + 4), sizeof(uint32_t));
+        // compare the current dst_peer and see if it matches the original source.
+        // If not, the flow flush may be needed to create a new flow.
+        cmp_peer = source_pkt ? ext->src_peer : ext->dst_peer;
+        memcpy(&cmp_new_peer, (data + 4), sizeof(uint32_t));
 
-         if (cmp_peer != 0 && cmp_peer != cmp_new_peer) {
+        if (cmp_peer != 0 && cmp_peer != cmp_new_peer) {
             flow_flush = true;
             return false;
-         }
+        }
 
-         memcpy(source_pkt ? &(ext->src_peer) : &(ext->dst_peer), (data + 4), sizeof(uint32_t));
-         break;
+        memcpy(source_pkt ? &(ext->src_peer) : &(ext->dst_peer), (data + 4), sizeof(uint32_t));
+        break;
 
-      case WG_PACKETTYPE_RESP_TO_INIT:
-         if (payload_len != WG_PACKETLEN_RESP_TO_INIT) {
+    case WG_PACKETTYPE_RESP_TO_INIT:
+        if (payload_len != WG_PACKETLEN_RESP_TO_INIT) {
             return false;
-         }
+        }
 
-         memcpy(&(ext->src_peer), (data + 4), sizeof(uint32_t));
-         memcpy(&(ext->dst_peer), (data + 8), sizeof(uint32_t));
+        memcpy(&(ext->src_peer), (data + 4), sizeof(uint32_t));
+        memcpy(&(ext->dst_peer), (data + 8), sizeof(uint32_t));
 
-         // let's swap for the opposite direction
-         if (!source_pkt) {
+        // let's swap for the opposite direction
+        if (!source_pkt) {
             std::swap(ext->src_peer, ext->dst_peer);
-         }
-         break;
+        }
+        break;
 
-      case WG_PACKETTYPE_COOKIE_REPLY:
-         if (payload_len != WG_PACKETLEN_COOKIE_REPLY) {
+    case WG_PACKETTYPE_COOKIE_REPLY:
+        if (payload_len != WG_PACKETLEN_COOKIE_REPLY) {
             return false;
-         }
+        }
 
-         memcpy(source_pkt ? &(ext->dst_peer) : &(ext->src_peer), (data + 4), sizeof(uint32_t));
-         break;
+        memcpy(source_pkt ? &(ext->dst_peer) : &(ext->src_peer), (data + 4), sizeof(uint32_t));
+        break;
 
-      case WG_PACKETTYPE_TRANSPORT_DATA:
-         // Each packet of transport data is zero-padded to the multiple of 16 bytes in length.
-         if (payload_len < WG_PACKETLEN_MIN_TRANSPORT_DATA || (payload_len % 16) != 0) {
+    case WG_PACKETTYPE_TRANSPORT_DATA:
+        // Each packet of transport data is zero-padded to the multiple of 16 bytes in length.
+        if (payload_len < WG_PACKETLEN_MIN_TRANSPORT_DATA || (payload_len % 16) != 0) {
             return false;
-         }
+        }
 
-         memcpy(source_pkt ? &(ext->dst_peer) : &(ext->src_peer), (data + 4), sizeof(uint32_t));
-         break;
-   }
+        memcpy(source_pkt ? &(ext->dst_peer) : &(ext->src_peer), (data + 4), sizeof(uint32_t));
+        break;
+    }
 
-   // Possible misdetection
-   // - DNS request
-   //   Can happen when transaction ID is >= 1 and <= 4, the query is non-recursive
-   //   and other flags are zeros, too.
-   //   2B transaction ID, 2B flags, 2B questions count, 2B answers count
-   if (!memcmp((data + 4), dns_query_mask, sizeof(dns_query_mask))) {
-      ext->possible_wg = 1;
-   } else {
-      ext->possible_wg = 100;
-   }
-   identified++;
-   return true;
+    // Possible misdetection
+    // - DNS request
+    //   Can happen when transaction ID is >= 1 and <= 4, the query is non-recursive
+    //   and other flags are zeros, too.
+    //   2B transaction ID, 2B flags, 2B questions count, 2B answers count
+    if (!memcmp((data + 4), dns_query_mask, sizeof(dns_query_mask))) {
+        ext->possible_wg = 1;
+    } else {
+        ext->possible_wg = 100;
+    }
+    identified++;
+    return true;
 }
 
-int WGPlugin::add_ext_wg(const char *data, unsigned int payload_len, bool source_pkt, Flow &rec)
+int WGPlugin::add_ext_wg(const char* data, unsigned int payload_len, bool source_pkt, Flow& rec)
 {
-   if (preallocated_record == nullptr) {
-      preallocated_record = new RecordExtWG();
-   }
-   // try to parse WireGuard packet
-   if (!parse_wg(data, payload_len, source_pkt, preallocated_record)) {
-      return 0;
-   }
+    if (preallocated_record == nullptr) {
+        preallocated_record = new RecordExtWG();
+    }
+    // try to parse WireGuard packet
+    if (!parse_wg(data, payload_len, source_pkt, preallocated_record)) {
+        return 0;
+    }
 
-   rec.add_extension(preallocated_record);
-   preallocated_record = nullptr;
-   return 0;
+    rec.add_extension(preallocated_record);
+    preallocated_record = nullptr;
+    return 0;
 }
 
-}
+} // namespace ipxp

--- a/process/wg.hpp
+++ b/process/wg.hpp
@@ -29,146 +29,135 @@
 #ifndef IPXP_PROCESS_WG_HPP
 #define IPXP_PROCESS_WG_HPP
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #ifdef WITH_NEMEA
-  #include "fields.h"
+#include "fields.h"
 #endif
 
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/flowifc.hpp>
-#include <ipfixprobe/packet.hpp>
 #include <ipfixprobe/ipfix-elements.hpp>
+#include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 
 namespace ipxp {
 
 /**
  * \brief WireGuard packet types.
  */
-#define WG_PACKETTYPE_INIT_TO_RESP   0x01    /**< Initiator to Responder message **/
-#define WG_PACKETTYPE_RESP_TO_INIT   0x02    /**< Responder to Initiator message **/
-#define WG_PACKETTYPE_COOKIE_REPLY   0x03    /**< Cookie Reply (under load) message **/
-#define WG_PACKETTYPE_TRANSPORT_DATA 0x04    /**< Transport Data message **/
+#define WG_PACKETTYPE_INIT_TO_RESP 0x01 /**< Initiator to Responder message **/
+#define WG_PACKETTYPE_RESP_TO_INIT 0x02 /**< Responder to Initiator message **/
+#define WG_PACKETTYPE_COOKIE_REPLY 0x03 /**< Cookie Reply (under load) message **/
+#define WG_PACKETTYPE_TRANSPORT_DATA 0x04 /**< Transport Data message **/
 
 /**
  * \brief WireGuard UDP payload (minimum) lengths.
  */
-#define WG_PACKETLEN_INIT_TO_RESP        148
-#define WG_PACKETLEN_RESP_TO_INIT        92
-#define WG_PACKETLEN_COOKIE_REPLY        64
-#define WG_PACKETLEN_MIN_TRANSPORT_DATA  32
+#define WG_PACKETLEN_INIT_TO_RESP 148
+#define WG_PACKETLEN_RESP_TO_INIT 92
+#define WG_PACKETLEN_COOKIE_REPLY 64
+#define WG_PACKETLEN_MIN_TRANSPORT_DATA 32
 
 #define WG_UNIREC_TEMPLATE "WG_CONF_LEVEL,WG_SRC_PEER,WG_DST_PEER"
 
-UR_FIELDS (
-   uint8 WG_CONF_LEVEL,
-   uint32 WG_SRC_PEER,
-   uint32 WG_DST_PEER
-)
+UR_FIELDS(uint8 WG_CONF_LEVEL, uint32 WG_SRC_PEER, uint32 WG_DST_PEER)
 
 /**
  * \brief Flow record extension header for storing parsed WG packets.
  */
 struct RecordExtWG : public RecordExt {
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   uint8_t possible_wg;
-   uint32_t src_peer;
-   uint32_t dst_peer;
+    uint8_t possible_wg;
+    uint32_t src_peer;
+    uint32_t dst_peer;
 
-   RecordExtWG() : RecordExt(REGISTERED_ID)
-   {
-      possible_wg = 0;
-      src_peer = 0;
-      dst_peer = 0;
-   }
+    RecordExtWG()
+        : RecordExt(REGISTERED_ID)
+    {
+        possible_wg = 0;
+        src_peer = 0;
+        dst_peer = 0;
+    }
 
 #ifdef WITH_NEMEA
-   virtual void fill_unirec(ur_template_t *tmplt, void *record)
-   {
-      ur_set(tmplt, record, F_WG_CONF_LEVEL, possible_wg);
-      ur_set(tmplt, record, F_WG_SRC_PEER, src_peer);
-      ur_set(tmplt, record, F_WG_DST_PEER, dst_peer);
-   }
+    virtual void fill_unirec(ur_template_t* tmplt, void* record)
+    {
+        ur_set(tmplt, record, F_WG_CONF_LEVEL, possible_wg);
+        ur_set(tmplt, record, F_WG_SRC_PEER, src_peer);
+        ur_set(tmplt, record, F_WG_DST_PEER, dst_peer);
+    }
 
-   const char *get_unirec_tmplt() const
-   {
-      return WG_UNIREC_TEMPLATE;
-   }
+    const char* get_unirec_tmplt() const { return WG_UNIREC_TEMPLATE; }
 #endif
 
-   virtual int fill_ipfix(uint8_t *buffer, int size)
-   {
-      int requiredLen = 0;
+    virtual int fill_ipfix(uint8_t* buffer, int size)
+    {
+        int requiredLen = 0;
 
-      requiredLen += sizeof(possible_wg); // WG_CONF_LEVEL
-      requiredLen += sizeof(src_peer); // WG_SRC_PEER
-      requiredLen += sizeof(dst_peer); // WG_DST_PEER
+        requiredLen += sizeof(possible_wg); // WG_CONF_LEVEL
+        requiredLen += sizeof(src_peer); // WG_SRC_PEER
+        requiredLen += sizeof(dst_peer); // WG_DST_PEER
 
-      if (requiredLen > size) {
-         return -1;
-      }
+        if (requiredLen > size) {
+            return -1;
+        }
 
-      memcpy(buffer, &possible_wg, sizeof(possible_wg));
-      buffer += sizeof(possible_wg);
-      memcpy(buffer, &src_peer, sizeof(src_peer));
-      buffer += sizeof(src_peer);
-      memcpy(buffer, &dst_peer, sizeof(dst_peer));
-      buffer += sizeof(dst_peer);
+        memcpy(buffer, &possible_wg, sizeof(possible_wg));
+        buffer += sizeof(possible_wg);
+        memcpy(buffer, &src_peer, sizeof(src_peer));
+        buffer += sizeof(src_peer);
+        memcpy(buffer, &dst_peer, sizeof(dst_peer));
+        buffer += sizeof(dst_peer);
 
-      return requiredLen;
-   }
+        return requiredLen;
+    }
 
-   const char **get_ipfix_tmplt() const
-   {
-      static const char *ipfix_tmplt[] = {
-         IPFIX_WG_TEMPLATE(IPFIX_FIELD_NAMES)
-         nullptr
-      };
+    const char** get_ipfix_tmplt() const
+    {
+        static const char* ipfix_tmplt[] = {IPFIX_WG_TEMPLATE(IPFIX_FIELD_NAMES) nullptr};
 
-      return ipfix_tmplt;
-   }
+        return ipfix_tmplt;
+    }
 
-   std::string get_text() const
-   {
-      std::ostringstream out;
-      out << "wgconf=" << (uint16_t) possible_wg
-         << ",wgsrcpeer=" << src_peer
-         << ",wgdstpeer=" << dst_peer;
-      return out.str();
-   }
+    std::string get_text() const
+    {
+        std::ostringstream out;
+        out << "wgconf=" << (uint16_t) possible_wg << ",wgsrcpeer=" << src_peer
+            << ",wgdstpeer=" << dst_peer;
+        return out.str();
+    }
 };
 
 /**
  * \brief Flow cache plugin for parsing WG packets.
  */
-class WGPlugin : public ProcessPlugin
-{
+class WGPlugin : public ProcessPlugin {
 public:
-   WGPlugin();
-   ~WGPlugin();
-   void init(const char *params);
-   void close();
-   OptionsParser *get_parser() const { return new OptionsParser("wg", "Parse WireGuard traffic"); }
-   std::string get_name() const { return "wg"; }
-   RecordExt *get_ext() const { return new RecordExtWG(); }
-   ProcessPlugin *copy();
+    WGPlugin();
+    ~WGPlugin();
+    void init(const char* params);
+    void close();
+    OptionsParser* get_parser() const { return new OptionsParser("wg", "Parse WireGuard traffic"); }
+    std::string get_name() const { return "wg"; }
+    RecordExt* get_ext() const { return new RecordExtWG(); }
+    ProcessPlugin* copy();
 
-   int post_create(Flow &rec, const Packet &pkt);
-   int pre_update(Flow &rec, Packet &pkt);
-   void pre_export(Flow &rec);
-   void finish(bool print_stats);
+    int post_create(Flow& rec, const Packet& pkt);
+    int pre_update(Flow& rec, Packet& pkt);
+    void pre_export(Flow& rec);
+    void finish(bool print_stats);
 
 private:
-   RecordExtWG *preallocated_record;    /**< Preallocated instance of record to use */
-   bool flow_flush;        /**< Instructs the engine to create new flow, during pre_update. */
-   uint32_t total;         /**< Total number of processed packets. */
-   uint32_t identified;    /**< Total number of identified WireGuard packets. */
+    RecordExtWG* preallocated_record; /**< Preallocated instance of record to use */
+    bool flow_flush; /**< Instructs the engine to create new flow, during pre_update. */
+    uint32_t total; /**< Total number of processed packets. */
+    uint32_t identified; /**< Total number of identified WireGuard packets. */
 
-   bool parse_wg(const char *data, unsigned int payload_len, bool source_pkt, RecordExtWG *ext);
-   int add_ext_wg(const char *data, unsigned int payload_len, bool source_pkt, Flow &rec);
+    bool parse_wg(const char* data, unsigned int payload_len, bool source_pkt, RecordExtWG* ext);
+    int add_ext_wg(const char* data, unsigned int payload_len, bool source_pkt, Flow& rec);
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_PROCESS_WG_HPP */

--- a/stacktrace.cpp
+++ b/stacktrace.cpp
@@ -27,10 +27,10 @@
  */
 
 #include <config.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
@@ -39,156 +39,155 @@
 
 namespace ipxp {
 
-static void st_write(int fd, const char *buffer, size_t buflen)
+static void st_write(int fd, const char* buffer, size_t buflen)
 {
-   size_t total = 0;
-   while (total < buflen) {
-      ssize_t written = write(fd, buffer + total, buflen - total);
-      if (written < 0) {
-         return;
-      }
+    size_t total = 0;
+    while (total < buflen) {
+        ssize_t written = write(fd, buffer + total, buflen - total);
+        if (written < 0) {
+            return;
+        }
 
-      total += written;
-   }
+        total += written;
+    }
 }
 
-static void st_write_str(int fd, const char *str)
+static void st_write_str(int fd, const char* str)
 {
-   st_write(fd, str, strlen(str));
+    st_write(fd, str, strlen(str));
 }
 
-static void st_write_num(int fd, int num, int padding=0)
+static void st_write_num(int fd, int num, int padding = 0)
 {
-   char buf[22];
-   int idx = 0;
-   int tmp = num < 0 ? -num : num;
+    char buf[22];
+    int idx = 0;
+    int tmp = num < 0 ? -num : num;
 
-   if (num == 0) {
-      buf[idx++] = '0';
-   }
+    if (num == 0) {
+        buf[idx++] = '0';
+    }
 
-   while (tmp != 0) {
-      buf[idx++] = '0' + tmp % 10;
-      tmp /= 10;
-   }
-   if (num < 0) {
-      buf[idx++] = '-';
-   }
+    while (tmp != 0) {
+        buf[idx++] = '0' + tmp % 10;
+        tmp /= 10;
+    }
+    if (num < 0) {
+        buf[idx++] = '-';
+    }
 
-   for (int i = 0; i < idx / 2; i++) {
-      char tmp = buf[i];
-      buf[i] = buf[idx - i - 1];
-      buf[idx - i - 1] = tmp;
-   }
-   while (idx < padding) {
-         buf[idx++] = ' ';
-   }
-   buf[idx] = 0;
+    for (int i = 0; i < idx / 2; i++) {
+        char tmp = buf[i];
+        buf[i] = buf[idx - i - 1];
+        buf[idx - i - 1] = tmp;
+    }
+    while (idx < padding) {
+        buf[idx++] = ' ';
+    }
+    buf[idx] = 0;
 
-   st_write_str(fd, buf);
+    st_write_str(fd, buf);
 }
 
 static char nibble2hex(uint8_t num)
 {
-   if (num < 10) {
-      return '0' + num;
-   } else if (num < 16) {
-      return 'a' + num - 10;
-   }
-   return '?';
+    if (num < 10) {
+        return '0' + num;
+    } else if (num < 16) {
+        return 'a' + num - 10;
+    }
+    return '?';
 }
 
-static void st_write_num_hex(int fd, uint64_t num, size_t size, bool nopad=false)
+static void st_write_num_hex(int fd, uint64_t num, size_t size, bool nopad = false)
 {
-   char buf[19] = "0x";
-   bool nonzero_seen = false;
-   size_t idx = 2;
+    char buf[19] = "0x";
+    bool nonzero_seen = false;
+    size_t idx = 2;
 
-   for (int i = 0; i < (int) size; i++) {
-      uint8_t bits2shift = (size - i - 1) * size;
-      uint8_t byte = (num >> bits2shift) & 0xFF;
-      if (byte == 0 && nopad && !nonzero_seen) {
-         continue;
-      }
-      buf[idx]     = nibble2hex(byte >> 4);
-      buf[idx + 1] = nibble2hex(byte & 0x0F);
-      idx += 2;
-      nonzero_seen = true;
-   }
-   buf[idx] = 0;
-   st_write_str(fd, buf);
+    for (int i = 0; i < (int) size; i++) {
+        uint8_t bits2shift = (size - i - 1) * size;
+        uint8_t byte = (num >> bits2shift) & 0xFF;
+        if (byte == 0 && nopad && !nonzero_seen) {
+            continue;
+        }
+        buf[idx] = nibble2hex(byte >> 4);
+        buf[idx + 1] = nibble2hex(byte & 0x0F);
+        idx += 2;
+        nonzero_seen = true;
+    }
+    buf[idx] = 0;
+    st_write_str(fd, buf);
 }
 
-static void st_write_word(int fd, unw_word_t num, bool nopad=false)
+static void st_write_word(int fd, unw_word_t num, bool nopad = false)
 {
-   st_write_num_hex(fd, num, sizeof(num), nopad);
+    st_write_num_hex(fd, num, sizeof(num), nopad);
 }
 
 void st_dump(int fd, int sig)
 {
-   int framenum = 0;
-   unw_context_t ctx;
-   unw_cursor_t cursor;
+    int framenum = 0;
+    unw_context_t ctx;
+    unw_cursor_t cursor;
 
-   unw_getcontext(&ctx);
-   unw_init_local(&cursor, &ctx);
+    unw_getcontext(&ctx);
+    unw_init_local(&cursor, &ctx);
 
-   st_write_str(fd, "stacktrace dump of " PACKAGE_NAME " " PACKAGE_VERSION "\n");
-   st_write_str(fd, "uid: ");
-   st_write_num(fd, getuid());
-   st_write_str(fd, " pid: ");
-   st_write_num(fd, getpid());
+    st_write_str(fd, "stacktrace dump of " PACKAGE_NAME " " PACKAGE_VERSION "\n");
+    st_write_str(fd, "uid: ");
+    st_write_num(fd, getuid());
+    st_write_str(fd, " pid: ");
+    st_write_num(fd, getpid());
 #ifdef SYS_gettid
-   st_write_str(fd, " tid: ");
-   st_write_num(fd, syscall(SYS_gettid));
+    st_write_str(fd, " tid: ");
+    st_write_num(fd, syscall(SYS_gettid));
 #endif
-   st_write_str(fd, "\n");
+    st_write_str(fd, "\n");
 
-   st_write_str(fd, "received signal: ");
-   st_write_num(fd, sig);
-   st_write_str(fd, "\n");
+    st_write_str(fd, "received signal: ");
+    st_write_num(fd, sig);
+    st_write_str(fd, "\n");
 
+    while (unw_step(&cursor) > 0) {
+        unw_word_t offset;
+        unw_word_t pc;
+        unw_word_t sp;
 
-   while (unw_step(&cursor) > 0) {
-      unw_word_t offset;
-      unw_word_t pc;
-      unw_word_t sp;
+        st_write_str(fd, "#");
+        st_write_num(fd, framenum, 2);
+        st_write_str(fd, " ");
+        if (unw_get_reg(&cursor, UNW_REG_IP, &pc) == 0) {
+            if (pc == 0) {
+                break;
+            }
 
-      st_write_str(fd, "#");
-      st_write_num(fd, framenum, 2);
-      st_write_str(fd, " ");
-      if (unw_get_reg(&cursor, UNW_REG_IP, &pc) == 0) {
-         if (pc == 0) {
-            break;
-         }
+            st_write_word(fd, pc);
+        } else {
+            st_write_str(fd, "???");
+        }
+        st_write_str(fd, " ");
+        if (unw_get_reg(&cursor, UNW_REG_SP, &sp) == 0) {
+            st_write_word(fd, sp);
+        } else {
+            st_write_str(fd, "???");
+        }
 
-         st_write_word(fd, pc);
-      } else {
-         st_write_str(fd, "???");
-      }
-      st_write_str(fd, " ");
-      if (unw_get_reg(&cursor, UNW_REG_SP, &sp) == 0) {
-         st_write_word(fd, sp);
-      } else {
-         st_write_str(fd, "???");
-      }
+        framenum++;
+        st_write_str(fd, ": ");
 
-      framenum++;
-      st_write_str(fd, ": ");
-
-      char sym[256];
-      if (unw_get_proc_name(&cursor, sym, sizeof(sym), &offset) == 0) {
-         st_write_str(fd, sym);
-         st_write_str(fd, "+");
-         st_write_word(fd, offset, true);
-         if (unw_is_signal_frame(&cursor)) {
-            st_write_str(fd, " <-");
-         }
-         st_write_str(fd, "\n");
-      } else {
-         st_write_str(fd, "???\n");
-      }
-   }
+        char sym[256];
+        if (unw_get_proc_name(&cursor, sym, sizeof(sym), &offset) == 0) {
+            st_write_str(fd, sym);
+            st_write_str(fd, "+");
+            st_write_word(fd, offset, true);
+            if (unw_is_signal_frame(&cursor)) {
+                st_write_str(fd, " <-");
+            }
+            st_write_str(fd, "\n");
+        } else {
+            st_write_str(fd, "???\n");
+        }
+    }
 }
 
-}
+} // namespace ipxp

--- a/stacktrace.hpp
+++ b/stacktrace.hpp
@@ -33,5 +33,5 @@ namespace ipxp {
 
 void st_dump(int fd, int sig);
 
-}
+} // namespace ipxp
 #endif /* IPXP_STACKTRACE_HPP */

--- a/stats.cpp
+++ b/stats.cpp
@@ -1,8 +1,7 @@
 /**
  * \file stats.cpp
- * \brief Implementation of service IO functions, modified code from libtrap service ifc and trap_stats
- * \author Jiri Havranek <havranek@cesnet.cz>
- * \date 2021
+ * \brief Implementation of service IO functions, modified code from libtrap service ifc and
+ * trap_stats \author Jiri Havranek <havranek@cesnet.cz> \date 2021
  */
 /*
  * Copyright (C) 2021 CESNET
@@ -30,121 +29,121 @@
 #include <string>
 
 #include <string.h>
-#include <unistd.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
-#include <sys/socket.h>
+#include <unistd.h>
 
 #include "stats.hpp"
 
-namespace ipxp
+namespace ipxp {
+
+int connect_to_exporter(const char* path)
 {
+    int fd;
+    struct sockaddr_un addr;
 
-int connect_to_exporter(const char *path)
-{
-   int fd;
-   struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    snprintf(addr.sun_path, sizeof(addr.sun_path) - 1, "%s", path);
 
-   memset(&addr, 0, sizeof(addr));
-   addr.sun_family = AF_UNIX;
-   snprintf(addr.sun_path, sizeof(addr.sun_path) - 1, "%s", path);
-
-   fd = socket(AF_UNIX, SOCK_STREAM, 0);
-   if (fd != -1) {
-      if (connect(fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
-         perror("unable to connect");
-         close(fd);
-         return -1;
-      }
-   }
-   return fd;
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd != -1) {
+        if (connect(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
+            perror("unable to connect");
+            close(fd);
+            return -1;
+        }
+    }
+    return fd;
 }
 
-int create_stats_sock(const char *path)
+int create_stats_sock(const char* path)
 {
-   int fd;
-   struct sockaddr_un addr;
+    int fd;
+    struct sockaddr_un addr;
 
-   addr.sun_family = AF_UNIX;
-   snprintf(addr.sun_path, sizeof(addr.sun_path) - 1, "%s", path);
+    addr.sun_family = AF_UNIX;
+    snprintf(addr.sun_path, sizeof(addr.sun_path) - 1, "%s", path);
 
-   unlink(addr.sun_path);
-   fd = socket(AF_UNIX, SOCK_STREAM, 0);
-   if (fd != -1) {
-      if (bind(fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
-         perror("unable to bind socket");
-         close(fd);
-         return -1;
-      }
-      if (listen(fd, 1) == -1) {
-         perror("unable to listen on socket");
-         close(fd);
-         return -1;
-      }
-      if (chmod(addr.sun_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) == -1) {
-         perror("unable to set access rights");
-         close(fd);
-         return -1;
-      }
-   }
-   return fd;
+    unlink(addr.sun_path);
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd != -1) {
+        if (bind(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
+            perror("unable to bind socket");
+            close(fd);
+            return -1;
+        }
+        if (listen(fd, 1) == -1) {
+            perror("unable to listen on socket");
+            close(fd);
+            return -1;
+        }
+        if (chmod(addr.sun_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) == -1) {
+            perror("unable to set access rights");
+            close(fd);
+            return -1;
+        }
+    }
+    return fd;
 }
 
-int recv_data(int fd, uint32_t size, void *data)
+int recv_data(int fd, uint32_t size, void* data)
 {
-   size_t num_of_timeouts = 0;
-   size_t total_received = 0;
-   ssize_t last_received = 0;
+    size_t num_of_timeouts = 0;
+    size_t total_received = 0;
+    ssize_t last_received = 0;
 
-   while (total_received < size) {
-      last_received = recv(fd, (uint8_t *) data + total_received, size - total_received, MSG_DONTWAIT);
-      if (last_received == 0) {
-         return -1;
-      } else if (last_received == -1) {
-         if (errno == EAGAIN  || errno == EWOULDBLOCK) {
-            num_of_timeouts++;
-            if (num_of_timeouts > SERVICE_WAIT_MAX_TRY) {
-               return -1;
-            } else {
-               usleep(SERVICE_WAIT_BEFORE_TIMEOUT);
-               continue;
+    while (total_received < size) {
+        last_received
+            = recv(fd, (uint8_t*) data + total_received, size - total_received, MSG_DONTWAIT);
+        if (last_received == 0) {
+            return -1;
+        } else if (last_received == -1) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                num_of_timeouts++;
+                if (num_of_timeouts > SERVICE_WAIT_MAX_TRY) {
+                    return -1;
+                } else {
+                    usleep(SERVICE_WAIT_BEFORE_TIMEOUT);
+                    continue;
+                }
             }
-         }
-         return -1;
-      }
-      total_received += last_received;
-   }
-   return 0;
+            return -1;
+        }
+        total_received += last_received;
+    }
+    return 0;
 }
 
-int send_data(int fd, uint32_t size, void *data)
+int send_data(int fd, uint32_t size, void* data)
 {
-   size_t num_of_timeouts = 0;
-   size_t total_sent = 0;
-   ssize_t last_sent = 0;
+    size_t num_of_timeouts = 0;
+    size_t total_sent = 0;
+    ssize_t last_sent = 0;
 
-   while (total_sent < size) {
-      last_sent = send(fd, (uint8_t *) data + total_sent, size - total_sent, MSG_DONTWAIT);
-      if (last_sent == -1) {
-         if (errno == EAGAIN  || errno == EWOULDBLOCK) {
-            num_of_timeouts++;
-            if (num_of_timeouts > SERVICE_WAIT_MAX_TRY) {
-               return -1;
-            } else {
-               usleep(SERVICE_WAIT_BEFORE_TIMEOUT);
-               continue;
+    while (total_sent < size) {
+        last_sent = send(fd, (uint8_t*) data + total_sent, size - total_sent, MSG_DONTWAIT);
+        if (last_sent == -1) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                num_of_timeouts++;
+                if (num_of_timeouts > SERVICE_WAIT_MAX_TRY) {
+                    return -1;
+                } else {
+                    usleep(SERVICE_WAIT_BEFORE_TIMEOUT);
+                    continue;
+                }
             }
-         }
-         return -1;
-      }
-      total_sent += last_sent;
-   }
-   return 0;
+            return -1;
+        }
+        total_sent += last_sent;
+    }
+    return 0;
 }
 
-std::string create_sockpath(const char *id)
+std::string create_sockpath(const char* id)
 {
-   return DEFAULTSOCKETDIR "/ipfixprobe_" + std::string(id) + ".sock";
+    return DEFAULTSOCKETDIR "/ipfixprobe_" + std::string(id) + ".sock";
 }
 
-}
+} // namespace ipxp

--- a/stats.hpp
+++ b/stats.hpp
@@ -29,47 +29,47 @@
 #ifndef IPXP_STATS_HPP
 #define IPXP_STATS_HPP
 
-#define SERVICE_WAIT_BEFORE_TIMEOUT 250000  ///< Timeout after EAGAIN or EWOULDBLOCK errno returned from service send() and recv().
-#define SERVICE_WAIT_MAX_TRY 8  ///< A maximal count of repeated timeouts per each service recv() and send() function call.
+#define SERVICE_WAIT_BEFORE_TIMEOUT                                                                \
+    250000 ///< Timeout after EAGAIN or EWOULDBLOCK errno returned from service send() and recv().
+#define SERVICE_WAIT_MAX_TRY                                                                       \
+    8 ///< A maximal count of repeated timeouts per each service recv() and send() function call.
 
 #define MSG_MAGIC 0xBEEFFEEB
 
 #include <cstdint>
 #include <string>
 
-namespace ipxp
-{
+namespace ipxp {
 
 struct InputStats {
-   uint64_t packets;
-   uint64_t parsed;
-   uint64_t bytes;
-   uint64_t qtime;
-   uint64_t dropped;
+    uint64_t packets;
+    uint64_t parsed;
+    uint64_t bytes;
+    uint64_t qtime;
+    uint64_t dropped;
 };
 
 struct OutputStats {
-   uint64_t biflows;
-   uint64_t bytes;
-   uint64_t packets;
-   uint64_t dropped;
+    uint64_t biflows;
+    uint64_t bytes;
+    uint64_t packets;
+    uint64_t dropped;
 };
 
-typedef struct msg_header_s
-{
-   uint32_t magic;
-   uint16_t size;
-   uint16_t inputs;
-   uint16_t outputs;
+typedef struct msg_header_s {
+    uint32_t magic;
+    uint16_t size;
+    uint16_t inputs;
+    uint16_t outputs;
 
-   // followed by arrays of plugin stats
+    // followed by arrays of plugin stats
 } msg_header_t;
 
-int connect_to_exporter(const char *path);
-int create_stats_sock(const char *path);
-int recv_data(int sd, uint32_t size, void *data);
-int send_data(int sd, uint32_t size, void *data);
-std::string create_sockpath(const char *id);
+int connect_to_exporter(const char* path);
+int create_stats_sock(const char* path);
+int recv_data(int sd, uint32_t size, void* data);
+int send_data(int sd, uint32_t size, void* data);
+std::string create_sockpath(const char* id);
 
-}
+} // namespace ipxp
 #endif /* IPXP_STATS_HPP */

--- a/storage/cache.cpp
+++ b/storage/cache.cpp
@@ -31,520 +31,533 @@
  */
 
 #include <cstdlib>
-#include <iostream>
 #include <cstring>
+#include <iostream>
 #include <sys/time.h>
 
-#include <ipfixprobe/ring.h>
 #include "cache.hpp"
 #include "xxhash.h"
+#include <ipfixprobe/ring.h>
 
 namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("cache", [](){return new NHTFlowCache();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("cache", []() { return new NHTFlowCache(); });
+    register_plugin(&rec);
 }
 
 FlowRecord::FlowRecord()
 {
-   erase();
+    erase();
 };
 
 FlowRecord::~FlowRecord()
 {
-   erase();
+    erase();
 };
 
 void FlowRecord::erase()
 {
-   m_flow.remove_extensions();
-   m_hash = 0;
+    m_flow.remove_extensions();
+    m_hash = 0;
 
-   memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
-   memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
-   m_flow.ip_version = 0;
-   m_flow.ip_proto = 0;
-   memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
-   memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
-   m_flow.src_port = 0;
-   m_flow.dst_port = 0;
-   m_flow.src_packets = 0;
-   m_flow.dst_packets = 0;
-   m_flow.src_bytes = 0;
-   m_flow.dst_bytes = 0;
-   m_flow.src_tcp_flags = 0;
-   m_flow.dst_tcp_flags = 0;
+    memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
+    memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
+    m_flow.ip_version = 0;
+    m_flow.ip_proto = 0;
+    memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
+    memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
+    m_flow.src_port = 0;
+    m_flow.dst_port = 0;
+    m_flow.src_packets = 0;
+    m_flow.dst_packets = 0;
+    m_flow.src_bytes = 0;
+    m_flow.dst_bytes = 0;
+    m_flow.src_tcp_flags = 0;
+    m_flow.dst_tcp_flags = 0;
 }
 void FlowRecord::reuse()
 {
-   m_flow.remove_extensions();
-   m_flow.time_first = m_flow.time_last;
-   m_flow.src_packets = 0;
-   m_flow.dst_packets = 0;
-   m_flow.src_bytes = 0;
-   m_flow.dst_bytes = 0;
-   m_flow.src_tcp_flags = 0;
-   m_flow.dst_tcp_flags = 0;
+    m_flow.remove_extensions();
+    m_flow.time_first = m_flow.time_last;
+    m_flow.src_packets = 0;
+    m_flow.dst_packets = 0;
+    m_flow.src_bytes = 0;
+    m_flow.dst_bytes = 0;
+    m_flow.src_tcp_flags = 0;
+    m_flow.dst_tcp_flags = 0;
 }
 
 inline __attribute__((always_inline)) bool FlowRecord::is_empty() const
 {
-   return m_hash == 0;
+    return m_hash == 0;
 }
 
 inline __attribute__((always_inline)) bool FlowRecord::belongs(uint64_t hash) const
 {
-   return hash == m_hash;
+    return hash == m_hash;
 }
 
-void FlowRecord::create(const Packet &pkt, uint64_t hash)
+void FlowRecord::create(const Packet& pkt, uint64_t hash)
 {
-   m_flow.src_packets = 1;
+    m_flow.src_packets = 1;
 
-   m_hash = hash;
+    m_hash = hash;
 
-   m_flow.time_first = pkt.ts;
-   m_flow.time_last = pkt.ts;
-   m_flow.flow_hash = hash;
+    m_flow.time_first = pkt.ts;
+    m_flow.time_last = pkt.ts;
+    m_flow.flow_hash = hash;
 
-   memcpy(m_flow.src_mac, pkt.src_mac, 6);
-   memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
+    memcpy(m_flow.src_mac, pkt.src_mac, 6);
+    memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
 
-   if (pkt.ip_version == IP::v4) {
-      m_flow.ip_version = pkt.ip_version;
-      m_flow.ip_proto = pkt.ip_proto;
-      m_flow.src_ip.v4 = pkt.src_ip.v4;
-      m_flow.dst_ip.v4 = pkt.dst_ip.v4;
-      m_flow.src_bytes = pkt.ip_len;
-   } else if (pkt.ip_version == IP::v6) {
-      m_flow.ip_version = pkt.ip_version;
-      m_flow.ip_proto = pkt.ip_proto;
-      memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
-      memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
-      m_flow.src_bytes = pkt.ip_len;
-   }
+    if (pkt.ip_version == IP::v4) {
+        m_flow.ip_version = pkt.ip_version;
+        m_flow.ip_proto = pkt.ip_proto;
+        m_flow.src_ip.v4 = pkt.src_ip.v4;
+        m_flow.dst_ip.v4 = pkt.dst_ip.v4;
+        m_flow.src_bytes = pkt.ip_len;
+    } else if (pkt.ip_version == IP::v6) {
+        m_flow.ip_version = pkt.ip_version;
+        m_flow.ip_proto = pkt.ip_proto;
+        memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
+        memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
+        m_flow.src_bytes = pkt.ip_len;
+    }
 
-   if (pkt.ip_proto == IPPROTO_TCP) {
-      m_flow.src_port = pkt.src_port;
-      m_flow.dst_port = pkt.dst_port;
-      m_flow.src_tcp_flags = pkt.tcp_flags;
-   } else if (pkt.ip_proto == IPPROTO_UDP) {
-      m_flow.src_port = pkt.src_port;
-      m_flow.dst_port = pkt.dst_port;
-   } else if (pkt.ip_proto == IPPROTO_ICMP ||
-      pkt.ip_proto == IPPROTO_ICMPV6) {
-      m_flow.src_port = pkt.src_port;
-      m_flow.dst_port = pkt.dst_port;
-   }
+    if (pkt.ip_proto == IPPROTO_TCP) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+        m_flow.src_tcp_flags = pkt.tcp_flags;
+    } else if (pkt.ip_proto == IPPROTO_UDP) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+    } else if (pkt.ip_proto == IPPROTO_ICMP || pkt.ip_proto == IPPROTO_ICMPV6) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+    }
 }
 
-void FlowRecord::update(const Packet &pkt, bool src)
+void FlowRecord::update(const Packet& pkt, bool src)
 {
-   m_flow.time_last = pkt.ts;
-   if (src) {
-      m_flow.src_packets++;
-      m_flow.src_bytes += pkt.ip_len;
+    m_flow.time_last = pkt.ts;
+    if (src) {
+        m_flow.src_packets++;
+        m_flow.src_bytes += pkt.ip_len;
 
-      if (pkt.ip_proto == IPPROTO_TCP) {
-         m_flow.src_tcp_flags |= pkt.tcp_flags;
-      }
-   } else {
-      m_flow.dst_packets++;
-      m_flow.dst_bytes += pkt.ip_len;
+        if (pkt.ip_proto == IPPROTO_TCP) {
+            m_flow.src_tcp_flags |= pkt.tcp_flags;
+        }
+    } else {
+        m_flow.dst_packets++;
+        m_flow.dst_bytes += pkt.ip_len;
 
-      if (pkt.ip_proto == IPPROTO_TCP) {
-         m_flow.dst_tcp_flags |= pkt.tcp_flags;
-      }
-   }
+        if (pkt.ip_proto == IPPROTO_TCP) {
+            m_flow.dst_tcp_flags |= pkt.tcp_flags;
+        }
+    }
 }
 
-
-NHTFlowCache::NHTFlowCache() :
-   m_cache_size(0), m_line_size(0), m_line_mask(0), m_line_new_idx(0),
-   m_qsize(0), m_qidx(0), m_timeout_idx(0), m_active(0), m_inactive(0),
-   m_split_biflow(false), m_keylen(0), m_key(), m_key_inv(), m_flow_table(nullptr), m_flow_records(nullptr)
+NHTFlowCache::NHTFlowCache()
+    : m_cache_size(0)
+    , m_line_size(0)
+    , m_line_mask(0)
+    , m_line_new_idx(0)
+    , m_qsize(0)
+    , m_qidx(0)
+    , m_timeout_idx(0)
+    , m_active(0)
+    , m_inactive(0)
+    , m_split_biflow(false)
+    , m_keylen(0)
+    , m_key()
+    , m_key_inv()
+    , m_flow_table(nullptr)
+    , m_flow_records(nullptr)
 {
 }
 
 NHTFlowCache::~NHTFlowCache()
 {
-   close();
+    close();
 }
 
-void NHTFlowCache::init(const char *params)
+void NHTFlowCache::init(const char* params)
 {
-   CacheOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
+    CacheOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   m_cache_size = parser.m_cache_size;
-   m_line_size = parser.m_line_size;
-   m_active = parser.m_active;
-   m_inactive = parser.m_inactive;
-   m_qidx = 0;
-   m_timeout_idx = 0;
-   m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
-   m_line_new_idx = m_line_size / 2;
+    m_cache_size = parser.m_cache_size;
+    m_line_size = parser.m_line_size;
+    m_active = parser.m_active;
+    m_inactive = parser.m_inactive;
+    m_qidx = 0;
+    m_timeout_idx = 0;
+    m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
+    m_line_new_idx = m_line_size / 2;
 
-   if (m_export_queue == nullptr) {
-      throw PluginError("output queue must be set before init");
-   }
+    if (m_export_queue == nullptr) {
+        throw PluginError("output queue must be set before init");
+    }
 
-   if (m_line_size > m_cache_size) {
-      throw PluginError("flow cache line size must be greater or equal to cache size");
-   }
-   if (m_cache_size == 0) {
-      throw PluginError("flow cache won't properly work with 0 records");
-   }
+    if (m_line_size > m_cache_size) {
+        throw PluginError("flow cache line size must be greater or equal to cache size");
+    }
+    if (m_cache_size == 0) {
+        throw PluginError("flow cache won't properly work with 0 records");
+    }
 
-   try {
-      m_flow_table = new FlowRecord*[m_cache_size + m_qsize];
-      m_flow_records = new FlowRecord[m_cache_size + m_qsize];
-      for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
-         m_flow_table[i] = m_flow_records + i;
-      }
-   } catch (std::bad_alloc &e) {
-      throw PluginError("not enough memory for flow cache allocation");
-   }
+    try {
+        m_flow_table = new FlowRecord*[m_cache_size + m_qsize];
+        m_flow_records = new FlowRecord[m_cache_size + m_qsize];
+        for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
+            m_flow_table[i] = m_flow_records + i;
+        }
+    } catch (std::bad_alloc& e) {
+        throw PluginError("not enough memory for flow cache allocation");
+    }
 
-   m_split_biflow = parser.m_split_biflow;
+    m_split_biflow = parser.m_split_biflow;
 
 #ifdef FLOW_CACHE_STATS
-   m_empty = 0;
-   m_not_empty = 0;
-   m_hits = 0;
-   m_expired = 0;
-   m_flushed = 0;
-   m_lookups = 0;
-   m_lookups2 = 0;
+    m_empty = 0;
+    m_not_empty = 0;
+    m_hits = 0;
+    m_expired = 0;
+    m_flushed = 0;
+    m_lookups = 0;
+    m_lookups2 = 0;
 #endif /* FLOW_CACHE_STATS */
 }
 
 void NHTFlowCache::close()
 {
-   if (m_flow_records != nullptr) {
-      delete [] m_flow_records;
-      m_flow_records = nullptr;
-   }
-   if (m_flow_table != nullptr) {
-      delete [] m_flow_table;
-      m_flow_table = nullptr;
-   }
+    if (m_flow_records != nullptr) {
+        delete[] m_flow_records;
+        m_flow_records = nullptr;
+    }
+    if (m_flow_table != nullptr) {
+        delete[] m_flow_table;
+        m_flow_table = nullptr;
+    }
 }
 
-void NHTFlowCache::set_queue(ipx_ring_t *queue)
+void NHTFlowCache::set_queue(ipx_ring_t* queue)
 {
-   m_export_queue = queue;
-   m_qsize = ipx_ring_size(queue);
+    m_export_queue = queue;
+    m_qsize = ipx_ring_size(queue);
 }
 
 void NHTFlowCache::export_flow(size_t index)
 {
-   ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
-   std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
-   m_flow_table[index]->erase();
-   m_qidx = (m_qidx + 1) % m_qsize;
+    ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
+    std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
+    m_flow_table[index]->erase();
+    m_qidx = (m_qidx + 1) % m_qsize;
 }
 
 void NHTFlowCache::finish()
 {
-   for (decltype(m_cache_size) i = 0; i < m_cache_size; i++) {
-      if (!m_flow_table[i]->is_empty()) {
-         plugins_pre_export(m_flow_table[i]->m_flow);
-         m_flow_table[i]->m_flow.end_reason = FLOW_END_FORCED;
-         export_flow(i);
+    for (decltype(m_cache_size) i = 0; i < m_cache_size; i++) {
+        if (!m_flow_table[i]->is_empty()) {
+            plugins_pre_export(m_flow_table[i]->m_flow);
+            m_flow_table[i]->m_flow.end_reason = FLOW_END_FORCED;
+            export_flow(i);
 #ifdef FLOW_CACHE_STATS
-         m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-      }
-   }
+        }
+    }
 }
 
-void NHTFlowCache::flush(Packet &pkt, size_t flow_index, int ret, bool source_flow)
+void NHTFlowCache::flush(Packet& pkt, size_t flow_index, int ret, bool source_flow)
 {
 #ifdef FLOW_CACHE_STATS
-   m_flushed++;
+    m_flushed++;
 #endif /* FLOW_CACHE_STATS */
 
-   if (ret == FLOW_FLUSH_WITH_REINSERT) {
-      FlowRecord *flow = m_flow_table[flow_index];
-      flow->m_flow.end_reason = FLOW_END_FORCED;
-      ipx_ring_push(m_export_queue, &flow->m_flow);
+    if (ret == FLOW_FLUSH_WITH_REINSERT) {
+        FlowRecord* flow = m_flow_table[flow_index];
+        flow->m_flow.end_reason = FLOW_END_FORCED;
+        ipx_ring_push(m_export_queue, &flow->m_flow);
 
-      std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
+        std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
 
-      flow = m_flow_table[flow_index];
-      flow->m_flow.remove_extensions();
-      *flow = *m_flow_table[m_cache_size + m_qidx];
-      m_qidx = (m_qidx + 1) % m_qsize;
+        flow = m_flow_table[flow_index];
+        flow->m_flow.remove_extensions();
+        *flow = *m_flow_table[m_cache_size + m_qidx];
+        m_qidx = (m_qidx + 1) % m_qsize;
 
-      flow->m_flow.m_exts = nullptr;
-      flow->reuse(); // Clean counters, set time first to last
-      flow->update(pkt, source_flow); // Set new counters from packet
+        flow->m_flow.m_exts = nullptr;
+        flow->reuse(); // Clean counters, set time first to last
+        flow->update(pkt, source_flow); // Set new counters from packet
 
-      ret = plugins_post_create(flow->m_flow, pkt);
-      if (ret & FLOW_FLUSH) {
-         flush(pkt, flow_index, ret, source_flow);
-      }
-   } else {
-      m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
-      export_flow(flow_index);
-   }
+        ret = plugins_post_create(flow->m_flow, pkt);
+        if (ret & FLOW_FLUSH) {
+            flush(pkt, flow_index, ret, source_flow);
+        }
+    } else {
+        m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
+        export_flow(flow_index);
+    }
 }
 
-int NHTFlowCache::put_pkt(Packet &pkt)
+int NHTFlowCache::put_pkt(Packet& pkt)
 {
-   int ret = plugins_pre_create(pkt);
+    int ret = plugins_pre_create(pkt);
 
-   if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key and NHTFlowCache::m_keylen
-      return 0;
-   }
+    if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key
+                                 // and NHTFlowCache::m_keylen
+        return 0;
+    }
 
-   uint64_t hashval = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
+    uint64_t hashval
+        = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
 
-   FlowRecord *flow; /* Pointer to flow we will be working with. */
-   bool found = false;
-   bool source_flow = true;
-   uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
-   uint32_t flow_index = 0;
-   uint32_t next_line = line_index + m_line_size;
+    FlowRecord* flow; /* Pointer to flow we will be working with. */
+    bool found = false;
+    bool source_flow = true;
+    uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
+    uint32_t flow_index = 0;
+    uint32_t next_line = line_index + m_line_size;
 
-   /* Find existing flow record in flow cache. */
-   for (flow_index = line_index; flow_index < next_line; flow_index++) {
-      if (m_flow_table[flow_index]->belongs(hashval)) {
-         found = true;
-         break;
-      }
-   }
-
-   /* Find inversed flow. */
-   if (!found && !m_split_biflow) {
-      uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
-      uint64_t line_index_inv = hashval_inv & m_line_mask;
-      uint64_t next_line_inv = line_index_inv + m_line_size;
-      for (flow_index = line_index_inv; flow_index < next_line_inv; flow_index++) {
-         if (m_flow_table[flow_index]->belongs(hashval_inv)) {
-            found = true;
-            source_flow = false;
-            hashval = hashval_inv;
-            line_index = line_index_inv;
-            break;
-         }
-      }
-   }
-
-   if (found) {
-      /* Existing flow record was found, put flow record at the first index of flow line. */
-#ifdef FLOW_CACHE_STATS
-      m_lookups += (flow_index - line_index + 1);
-      m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
-#endif /* FLOW_CACHE_STATS */
-
-      flow = m_flow_table[flow_index];
-      for (decltype(flow_index) j = flow_index; j > line_index; j--) {
-         m_flow_table[j] = m_flow_table[j - 1];
-      }
-
-      m_flow_table[line_index] = flow;
-      flow_index = line_index;
-#ifdef FLOW_CACHE_STATS
-      m_hits++;
-#endif /* FLOW_CACHE_STATS */
-   } else {
-      /* Existing flow record was not found. Find free place in flow line. */
-      for (flow_index = line_index; flow_index < next_line; flow_index++) {
-         if (m_flow_table[flow_index]->is_empty()) {
+    /* Find existing flow record in flow cache. */
+    for (flow_index = line_index; flow_index < next_line; flow_index++) {
+        if (m_flow_table[flow_index]->belongs(hashval)) {
             found = true;
             break;
-         }
-      }
-      if (!found) {
-         /* If free place was not found (flow line is full), find
-          * record which will be replaced by new record. */
-         flow_index = next_line - 1;
+        }
+    }
 
-         // Export flow
-         plugins_pre_export(m_flow_table[flow_index]->m_flow);
-         m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_NO_RES;
-         export_flow(flow_index);
+    /* Find inversed flow. */
+    if (!found && !m_split_biflow) {
+        uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
+        uint64_t line_index_inv = hashval_inv & m_line_mask;
+        uint64_t next_line_inv = line_index_inv + m_line_size;
+        for (flow_index = line_index_inv; flow_index < next_line_inv; flow_index++) {
+            if (m_flow_table[flow_index]->belongs(hashval_inv)) {
+                found = true;
+                source_flow = false;
+                hashval = hashval_inv;
+                line_index = line_index_inv;
+                break;
+            }
+        }
+    }
 
+    if (found) {
+        /* Existing flow record was found, put flow record at the first index of flow line. */
 #ifdef FLOW_CACHE_STATS
-         m_expired++;
+        m_lookups += (flow_index - line_index + 1);
+        m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
 #endif /* FLOW_CACHE_STATS */
-         uint32_t flow_new_index = line_index + m_line_new_idx;
-         flow = m_flow_table[flow_index];
-         for (decltype(flow_index) j = flow_index; j > flow_new_index; j--) {
+
+        flow = m_flow_table[flow_index];
+        for (decltype(flow_index) j = flow_index; j > line_index; j--) {
             m_flow_table[j] = m_flow_table[j - 1];
-         }
-         flow_index = flow_new_index;
-         m_flow_table[flow_new_index] = flow;
+        }
+
+        m_flow_table[line_index] = flow;
+        flow_index = line_index;
 #ifdef FLOW_CACHE_STATS
-         m_not_empty++;
-      } else {
-         m_empty++;
+        m_hits++;
 #endif /* FLOW_CACHE_STATS */
-      }
-   }
+    } else {
+        /* Existing flow record was not found. Find free place in flow line. */
+        for (flow_index = line_index; flow_index < next_line; flow_index++) {
+            if (m_flow_table[flow_index]->is_empty()) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            /* If free place was not found (flow line is full), find
+             * record which will be replaced by new record. */
+            flow_index = next_line - 1;
 
-   pkt.source_pkt = source_flow;
-   flow = m_flow_table[flow_index];
+            // Export flow
+            plugins_pre_export(m_flow_table[flow_index]->m_flow);
+            m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_NO_RES;
+            export_flow(flow_index);
 
-   uint8_t flw_flags = source_flow ? flow->m_flow.src_tcp_flags : flow->m_flow.dst_tcp_flags;
-   if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
-      // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
-      m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
-      export_flow(flow_index);
-      put_pkt(pkt);
-      return 0;
-   }
-
-   if (flow->is_empty()) {
-      flow->create(pkt, hashval);
-      ret = plugins_post_create(flow->m_flow, pkt);
-
-      if (ret & FLOW_FLUSH) {
-         export_flow(flow_index);
 #ifdef FLOW_CACHE_STATS
-         m_flushed++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-      }
-   } else {
-      /* Check if flow record is expired (inactive timeout). */
-      if (pkt.ts.tv_sec - flow->m_flow.time_last.tv_sec >= m_inactive) {
-         m_flow_table[flow_index]->m_flow.end_reason = get_export_reason(flow->m_flow);
-         plugins_pre_export(flow->m_flow);
-         export_flow(flow_index);
-   #ifdef FLOW_CACHE_STATS
-         m_expired++;
-   #endif /* FLOW_CACHE_STATS */
-         return put_pkt(pkt);
-      }
-
-      /* Check if flow record is expired (active timeout). */
-      if (pkt.ts.tv_sec - flow->m_flow.time_first.tv_sec >= m_active) {
-         m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_ACTIVE;
-         plugins_pre_export(flow->m_flow);
-         export_flow(flow_index);
+            uint32_t flow_new_index = line_index + m_line_new_idx;
+            flow = m_flow_table[flow_index];
+            for (decltype(flow_index) j = flow_index; j > flow_new_index; j--) {
+                m_flow_table[j] = m_flow_table[j - 1];
+            }
+            flow_index = flow_new_index;
+            m_flow_table[flow_new_index] = flow;
 #ifdef FLOW_CACHE_STATS
-         m_expired++;
+            m_not_empty++;
+        } else {
+            m_empty++;
 #endif /* FLOW_CACHE_STATS */
-         return put_pkt(pkt);
-      }
+        }
+    }
 
-      ret = plugins_pre_update(flow->m_flow, pkt);
-      if (ret & FLOW_FLUSH) {
-         flush(pkt, flow_index, ret, source_flow);
-         return 0;
-      } else {
-         flow->update(pkt, source_flow);
-         ret = plugins_post_update(flow->m_flow, pkt);
+    pkt.source_pkt = source_flow;
+    flow = m_flow_table[flow_index];
 
-         if (ret & FLOW_FLUSH) {
+    uint8_t flw_flags = source_flow ? flow->m_flow.src_tcp_flags : flow->m_flow.dst_tcp_flags;
+    if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
+        // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
+        m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
+        export_flow(flow_index);
+        put_pkt(pkt);
+        return 0;
+    }
+
+    if (flow->is_empty()) {
+        flow->create(pkt, hashval);
+        ret = plugins_post_create(flow->m_flow, pkt);
+
+        if (ret & FLOW_FLUSH) {
+            export_flow(flow_index);
+#ifdef FLOW_CACHE_STATS
+            m_flushed++;
+#endif /* FLOW_CACHE_STATS */
+        }
+    } else {
+        /* Check if flow record is expired (inactive timeout). */
+        if (pkt.ts.tv_sec - flow->m_flow.time_last.tv_sec >= m_inactive) {
+            m_flow_table[flow_index]->m_flow.end_reason = get_export_reason(flow->m_flow);
+            plugins_pre_export(flow->m_flow);
+            export_flow(flow_index);
+#ifdef FLOW_CACHE_STATS
+            m_expired++;
+#endif /* FLOW_CACHE_STATS */
+            return put_pkt(pkt);
+        }
+
+        /* Check if flow record is expired (active timeout). */
+        if (pkt.ts.tv_sec - flow->m_flow.time_first.tv_sec >= m_active) {
+            m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_ACTIVE;
+            plugins_pre_export(flow->m_flow);
+            export_flow(flow_index);
+#ifdef FLOW_CACHE_STATS
+            m_expired++;
+#endif /* FLOW_CACHE_STATS */
+            return put_pkt(pkt);
+        }
+
+        ret = plugins_pre_update(flow->m_flow, pkt);
+        if (ret & FLOW_FLUSH) {
             flush(pkt, flow_index, ret, source_flow);
             return 0;
-         }
-      }
-   }
+        } else {
+            flow->update(pkt, source_flow);
+            ret = plugins_post_update(flow->m_flow, pkt);
 
-   export_expired(pkt.ts.tv_sec);
-   return 0;
+            if (ret & FLOW_FLUSH) {
+                flush(pkt, flow_index, ret, source_flow);
+                return 0;
+            }
+        }
+    }
+
+    export_expired(pkt.ts.tv_sec);
+    return 0;
 }
 
-uint8_t NHTFlowCache::get_export_reason(Flow &flow)
+uint8_t NHTFlowCache::get_export_reason(Flow& flow)
 {
-   if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
-      // When FIN or RST is set, TCP connection ended naturally
-      return FLOW_END_EOF;
-   } else {
-      return FLOW_END_INACTIVE;
-   }
+    if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
+        // When FIN or RST is set, TCP connection ended naturally
+        return FLOW_END_EOF;
+    } else {
+        return FLOW_END_INACTIVE;
+    }
 }
 
 void NHTFlowCache::export_expired(time_t ts)
 {
-   for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
-      if (!m_flow_table[i]->is_empty() && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
-         m_flow_table[i]->m_flow.end_reason = get_export_reason(m_flow_table[i]->m_flow);
-         plugins_pre_export(m_flow_table[i]->m_flow);
-         export_flow(i);
+    for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
+        if (!m_flow_table[i]->is_empty()
+            && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
+            m_flow_table[i]->m_flow.end_reason = get_export_reason(m_flow_table[i]->m_flow);
+            plugins_pre_export(m_flow_table[i]->m_flow);
+            export_flow(i);
 #ifdef FLOW_CACHE_STATS
-         m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-      }
-   }
+        }
+    }
 
-   m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
+    m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
 }
 
-bool NHTFlowCache::create_hash_key(Packet &pkt)
+bool NHTFlowCache::create_hash_key(Packet& pkt)
 {
-   if (pkt.ip_version == IP::v4) {
-      struct flow_key_v4_t *key_v4 = reinterpret_cast<struct flow_key_v4_t *>(m_key);
-      struct flow_key_v4_t *key_v4_inv = reinterpret_cast<struct flow_key_v4_t *>(m_key_inv);
+    if (pkt.ip_version == IP::v4) {
+        struct flow_key_v4_t* key_v4 = reinterpret_cast<struct flow_key_v4_t*>(m_key);
+        struct flow_key_v4_t* key_v4_inv = reinterpret_cast<struct flow_key_v4_t*>(m_key_inv);
 
-      key_v4->proto = pkt.ip_proto;
-      key_v4->ip_version = IP::v4;
-      key_v4->src_port = pkt.src_port;
-      key_v4->dst_port = pkt.dst_port;
-      key_v4->src_ip = pkt.src_ip.v4;
-      key_v4->dst_ip = pkt.dst_ip.v4;
-      key_v4->vlan_id = pkt.vlan_id;
+        key_v4->proto = pkt.ip_proto;
+        key_v4->ip_version = IP::v4;
+        key_v4->src_port = pkt.src_port;
+        key_v4->dst_port = pkt.dst_port;
+        key_v4->src_ip = pkt.src_ip.v4;
+        key_v4->dst_ip = pkt.dst_ip.v4;
+        key_v4->vlan_id = pkt.vlan_id;
 
-      key_v4_inv->proto = pkt.ip_proto;
-      key_v4_inv->ip_version = IP::v4;
-      key_v4_inv->src_port = pkt.dst_port;
-      key_v4_inv->dst_port = pkt.src_port;
-      key_v4_inv->src_ip = pkt.dst_ip.v4;
-      key_v4_inv->dst_ip = pkt.src_ip.v4;
-      key_v4_inv->vlan_id = pkt.vlan_id;
+        key_v4_inv->proto = pkt.ip_proto;
+        key_v4_inv->ip_version = IP::v4;
+        key_v4_inv->src_port = pkt.dst_port;
+        key_v4_inv->dst_port = pkt.src_port;
+        key_v4_inv->src_ip = pkt.dst_ip.v4;
+        key_v4_inv->dst_ip = pkt.src_ip.v4;
+        key_v4_inv->vlan_id = pkt.vlan_id;
 
-      m_keylen = sizeof(flow_key_v4_t);
-      return true;
-   } else if (pkt.ip_version == IP::v6) {
-      struct flow_key_v6_t *key_v6 = reinterpret_cast<struct flow_key_v6_t *>(m_key);
-      struct flow_key_v6_t *key_v6_inv = reinterpret_cast<struct flow_key_v6_t *>(m_key_inv);
+        m_keylen = sizeof(flow_key_v4_t);
+        return true;
+    } else if (pkt.ip_version == IP::v6) {
+        struct flow_key_v6_t* key_v6 = reinterpret_cast<struct flow_key_v6_t*>(m_key);
+        struct flow_key_v6_t* key_v6_inv = reinterpret_cast<struct flow_key_v6_t*>(m_key_inv);
 
-      key_v6->proto = pkt.ip_proto;
-      key_v6->ip_version = IP::v6;
-      key_v6->src_port = pkt.src_port;
-      key_v6->dst_port = pkt.dst_port;
-      memcpy(key_v6->src_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
-      memcpy(key_v6->dst_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
-      key_v6->vlan_id = pkt.vlan_id;
+        key_v6->proto = pkt.ip_proto;
+        key_v6->ip_version = IP::v6;
+        key_v6->src_port = pkt.src_port;
+        key_v6->dst_port = pkt.dst_port;
+        memcpy(key_v6->src_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
+        memcpy(key_v6->dst_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
+        key_v6->vlan_id = pkt.vlan_id;
 
-      key_v6_inv->proto = pkt.ip_proto;
-      key_v6_inv->ip_version = IP::v6;
-      key_v6_inv->src_port = pkt.dst_port;
-      key_v6_inv->dst_port = pkt.src_port;
-      memcpy(key_v6_inv->src_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
-      memcpy(key_v6_inv->dst_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
-      key_v6_inv->vlan_id = pkt.vlan_id;
+        key_v6_inv->proto = pkt.ip_proto;
+        key_v6_inv->ip_version = IP::v6;
+        key_v6_inv->src_port = pkt.dst_port;
+        key_v6_inv->dst_port = pkt.src_port;
+        memcpy(key_v6_inv->src_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
+        memcpy(key_v6_inv->dst_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
+        key_v6_inv->vlan_id = pkt.vlan_id;
 
-      m_keylen = sizeof(flow_key_v6_t);
-      return true;
-   }
+        m_keylen = sizeof(flow_key_v6_t);
+        return true;
+    }
 
-   return false;
+    return false;
 }
 
 #ifdef FLOW_CACHE_STATS
 void NHTFlowCache::print_report()
 {
-   float tmp = float(m_lookups) / m_hits;
+    float tmp = float(m_lookups) / m_hits;
 
-   cout << "Hits: " << m_hits << endl;
-   cout << "Empty: " << m_empty << endl;
-   cout << "Not empty: " << m_not_empty << endl;
-   cout << "Expired: " << m_expired << endl;
-   cout << "Flushed: " << m_flushed << endl;
-   cout << "Average Lookup:  " << tmp << endl;
-   cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << endl;
+    cout << "Hits: " << m_hits << endl;
+    cout << "Empty: " << m_empty << endl;
+    cout << "Not empty: " << m_not_empty << endl;
+    cout << "Expired: " << m_expired << endl;
+    cout << "Flushed: " << m_flushed << endl;
+    cout << "Average Lookup:  " << tmp << endl;
+    cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << endl;
 }
 #endif /* FLOW_CACHE_STATS */
 
-}
+} // namespace ipxp

--- a/storage/cache.hpp
+++ b/storage/cache.hpp
@@ -34,31 +34,31 @@
 
 #include <string>
 
-#include <ipfixprobe/storage.hpp>
-#include <ipfixprobe/options.hpp>
 #include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/storage.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
 
 struct __attribute__((packed)) flow_key_v4_t {
-   uint16_t src_port;
-   uint16_t dst_port;
-   uint8_t proto;
-   uint8_t ip_version;
-   uint32_t src_ip;
-   uint32_t dst_ip;
-   uint16_t vlan_id;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t proto;
+    uint8_t ip_version;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+    uint16_t vlan_id;
 };
 
 struct __attribute__((packed)) flow_key_v6_t {
-   uint16_t src_port;
-   uint16_t dst_port;
-   uint8_t proto;
-   uint8_t ip_version;
-   uint8_t src_ip[16];
-   uint8_t dst_ip[16];
-   uint16_t vlan_id;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t proto;
+    uint8_t ip_version;
+    uint8_t src_ip[16];
+    uint8_t dst_ip[16];
+    uint16_t vlan_id;
 };
 
 #define MAX_KEY_LENGTH (max<size_t>(sizeof(flow_key_v4_t), sizeof(flow_key_v6_t)))
@@ -78,121 +78,180 @@ static const uint32_t DEFAULT_FLOW_LINE_SIZE = 4; // 16 records per line
 static const uint32_t DEFAULT_INACTIVE_TIMEOUT = 30;
 static const uint32_t DEFAULT_ACTIVE_TIMEOUT = 300;
 
-static_assert(std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(), "Static checks of default cache sizes won't properly work without unsigned type.");
-static_assert(bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE, "Flow cache size is too big to fit in variable!");
-static_assert(bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE, "Flow cache line size is too big to fit in variable!");
+static_assert(
+    std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(),
+    "Static checks of default cache sizes won't properly work without unsigned type.");
+static_assert(
+    bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE,
+    "Flow cache size is too big to fit in variable!");
+static_assert(
+    bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE,
+    "Flow cache line size is too big to fit in variable!");
 
 static_assert(DEFAULT_FLOW_LINE_SIZE >= 1, "Flow cache line size must be at least 1!");
-static_assert(DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE, "Flow cache size must be at least cache line size!");
+static_assert(
+    DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE,
+    "Flow cache size must be at least cache line size!");
 
-class CacheOptParser : public OptionsParser
-{
+class CacheOptParser : public OptionsParser {
 public:
-   uint32_t m_cache_size;
-   uint32_t m_line_size;
-   uint32_t m_active;
-   uint32_t m_inactive;
-   bool m_split_biflow;
+    uint32_t m_cache_size;
+    uint32_t m_line_size;
+    uint32_t m_active;
+    uint32_t m_inactive;
+    bool m_split_biflow;
 
-   CacheOptParser() : OptionsParser("cache", "Storage plugin implemented as a hash table"),
-      m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE), m_line_size(1 << DEFAULT_FLOW_LINE_SIZE),
-      m_active(DEFAULT_ACTIVE_TIMEOUT), m_inactive(DEFAULT_INACTIVE_TIMEOUT), m_split_biflow(false)
-   {
-      register_option("s", "size", "EXPONENT", "Cache size exponent to the power of two",
-         [this](const char *arg){try {unsigned exp = str2num<decltype(exp)>(arg);
-               if (exp < 4 || exp > 30) {
-                  throw PluginError("Flow cache size must be between 4 and 30");
-               }
-               m_cache_size = static_cast<uint32_t>(1) << exp;
-            } catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("l", "line", "EXPONENT", "Cache line size exponent to the power of two",
-         [this](const char *arg){try {m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
-               if (m_line_size < 1) {
-                  throw PluginError("Flow cache line size must be at least 1");
-               }
-            } catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("a", "active", "TIME", "Active timeout in seconds",
-         [this](const char *arg){try {m_active = str2num<decltype(m_active)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("i", "inactive", "TIME", "Inactive timeout in seconds",
-         [this](const char *arg){try {m_inactive = str2num<decltype(m_inactive)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("S", "split", "", "Split biflows into uniflows",
-         [this](const char *arg){ m_split_biflow = true; return true;}, OptionFlags::NoArgument);
-   }
+    CacheOptParser()
+        : OptionsParser("cache", "Storage plugin implemented as a hash table")
+        , m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE)
+        , m_line_size(1 << DEFAULT_FLOW_LINE_SIZE)
+        , m_active(DEFAULT_ACTIVE_TIMEOUT)
+        , m_inactive(DEFAULT_INACTIVE_TIMEOUT)
+        , m_split_biflow(false)
+    {
+        register_option(
+            "s",
+            "size",
+            "EXPONENT",
+            "Cache size exponent to the power of two",
+            [this](const char* arg) {
+                try {
+                    unsigned exp = str2num<decltype(exp)>(arg);
+                    if (exp < 4 || exp > 30) {
+                        throw PluginError("Flow cache size must be between 4 and 30");
+                    }
+                    m_cache_size = static_cast<uint32_t>(1) << exp;
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "l",
+            "line",
+            "EXPONENT",
+            "Cache line size exponent to the power of two",
+            [this](const char* arg) {
+                try {
+                    m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
+                    if (m_line_size < 1) {
+                        throw PluginError("Flow cache line size must be at least 1");
+                    }
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "a",
+            "active",
+            "TIME",
+            "Active timeout in seconds",
+            [this](const char* arg) {
+                try {
+                    m_active = str2num<decltype(m_active)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "i",
+            "inactive",
+            "TIME",
+            "Inactive timeout in seconds",
+            [this](const char* arg) {
+                try {
+                    m_inactive = str2num<decltype(m_inactive)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "S",
+            "split",
+            "",
+            "Split biflows into uniflows",
+            [this](const char* arg) {
+                m_split_biflow = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-class FlowRecord
-{
-   uint64_t m_hash;
+class FlowRecord {
+    uint64_t m_hash;
 
 public:
-   Flow m_flow;
+    Flow m_flow;
 
-   FlowRecord();
-   ~FlowRecord();
+    FlowRecord();
+    ~FlowRecord();
 
-   void erase();
-   void reuse();
+    void erase();
+    void reuse();
 
-   inline bool is_empty() const;
-   inline bool belongs(uint64_t pkt_hash) const;
-   void create(const Packet &pkt, uint64_t pkt_hash);
-   void update(const Packet &pkt, bool src);
+    inline bool is_empty() const;
+    inline bool belongs(uint64_t pkt_hash) const;
+    void create(const Packet& pkt, uint64_t pkt_hash);
+    void update(const Packet& pkt, bool src);
 };
 
-class NHTFlowCache : public StoragePlugin
-{
+class NHTFlowCache : public StoragePlugin {
 public:
-   NHTFlowCache();
-   ~NHTFlowCache();
-   void init(const char *params);
-   void close();
-   void set_queue(ipx_ring_t *queue);
-   OptionsParser *get_parser() const { return new CacheOptParser(); }
-   std::string get_name() const { return "cache"; }
+    NHTFlowCache();
+    ~NHTFlowCache();
+    void init(const char* params);
+    void close();
+    void set_queue(ipx_ring_t* queue);
+    OptionsParser* get_parser() const { return new CacheOptParser(); }
+    std::string get_name() const { return "cache"; }
 
-   int put_pkt(Packet &pkt);
-   void export_expired(time_t ts);
+    int put_pkt(Packet& pkt);
+    void export_expired(time_t ts);
 
 private:
-   uint32_t m_cache_size;
-   uint32_t m_line_size;
-   uint32_t m_line_mask;
-   uint32_t m_line_new_idx;
-   uint32_t m_qsize;
-   uint32_t m_qidx;
-   uint32_t m_timeout_idx;
+    uint32_t m_cache_size;
+    uint32_t m_line_size;
+    uint32_t m_line_mask;
+    uint32_t m_line_new_idx;
+    uint32_t m_qsize;
+    uint32_t m_qidx;
+    uint32_t m_timeout_idx;
 #ifdef FLOW_CACHE_STATS
-   uint64_t m_empty;
-   uint64_t m_not_empty;
-   uint64_t m_hits;
-   uint64_t m_expired;
-   uint64_t m_flushed;
-   uint64_t m_lookups;
-   uint64_t m_lookups2;
+    uint64_t m_empty;
+    uint64_t m_not_empty;
+    uint64_t m_hits;
+    uint64_t m_expired;
+    uint64_t m_flushed;
+    uint64_t m_lookups;
+    uint64_t m_lookups2;
 #endif /* FLOW_CACHE_STATS */
-   uint32_t m_active;
-   uint32_t m_inactive;
-   bool m_split_biflow;
-   uint8_t m_keylen;
-   char m_key[MAX_KEY_LENGTH];
-   char m_key_inv[MAX_KEY_LENGTH];
-   FlowRecord **m_flow_table;
-   FlowRecord *m_flow_records;
+    uint32_t m_active;
+    uint32_t m_inactive;
+    bool m_split_biflow;
+    uint8_t m_keylen;
+    char m_key[MAX_KEY_LENGTH];
+    char m_key_inv[MAX_KEY_LENGTH];
+    FlowRecord** m_flow_table;
+    FlowRecord* m_flow_records;
 
-   void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow);
-   bool create_hash_key(Packet &pkt);
-   void export_flow(size_t index);
-   static uint8_t get_export_reason(Flow &flow);
-   void finish();
+    void flush(Packet& pkt, size_t flow_index, int ret, bool source_flow);
+    bool create_hash_key(Packet& pkt);
+    void export_flow(size_t index);
+    static uint8_t get_export_reason(Flow& flow);
+    void finish();
 
 #ifdef FLOW_CACHE_STATS
-   void print_report();
+    void print_report();
 #endif /* FLOW_CACHE_STATS */
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_STORAGE_CACHE_HPP */

--- a/tests/unit/byte-utils.cpp
+++ b/tests/unit/byte-utils.cpp
@@ -6,16 +6,16 @@ namespace ipxp_test {
 
 using namespace ipxp;
 
-TEST(swap_uint64, all) {
-   EXPECT_EQ((uint64_t) 0x8877665544332211, swap_uint64(0x1122334455667788));
-}
-
-}
-
-int main(int argc, char **argv)
+TEST(swap_uint64, all)
 {
-   // invoking the tests
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+    EXPECT_EQ((uint64_t) 0x8877665544332211, swap_uint64(0x1122334455667788));
 }
 
+} // namespace ipxp_test
+
+int main(int argc, char** argv)
+{
+    // invoking the tests
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/unit/flowifc.cpp
+++ b/tests/unit/flowifc.cpp
@@ -1,5 +1,5 @@
-#include <algorithm>
 #include "gtest/gtest.h"
+#include <algorithm>
 
 #include "ipfixprobe/flowifc.hpp"
 
@@ -7,110 +7,112 @@ namespace ipxp_test {
 
 using namespace ipxp;
 
-RecordExt *genext(int id)
+RecordExt* genext(int id)
 {
-   return new RecordExt(id);
+    return new RecordExt(id);
 }
 
-class TestExt : public RecordExt
-{
+class TestExt : public RecordExt {
 public:
-   static int REGISTERED_ID;
+    static int REGISTERED_ID;
 
-   TestExt() : RecordExt(REGISTERED_ID) {}
+    TestExt()
+        : RecordExt(REGISTERED_ID)
+    {
+    }
 };
 
 int TestExt::REGISTERED_ID = -1;
 
-class TestRec : public::testing::Test, public Record
-{
+class TestRec
+    : public ::testing::Test
+    , public Record {
 protected:
-   std::vector<RecordExt *> m_vec;
+    std::vector<RecordExt*> m_vec;
 
-   void SetUp() {
-      m_vec.push_back(genext(1));
-      m_vec.push_back(genext(2));
-      m_vec.push_back(genext(1));
-      m_vec.push_back(genext(3));
+    void SetUp()
+    {
+        m_vec.push_back(genext(1));
+        m_vec.push_back(genext(2));
+        m_vec.push_back(genext(1));
+        m_vec.push_back(genext(3));
 
-      for (auto it : m_vec) {
-         add_extension(it);
-      }
-   }
+        for (auto it : m_vec) {
+            add_extension(it);
+        }
+    }
 
-   void TearDown() {
-      remove_extensions();
-   }
+    void TearDown() { remove_extensions(); }
 };
 
-TEST(RecordExt, llistAdd) {
-   RecordExt *head = genext(1);
-   head->add_extension(genext(2));
-   head->add_extension(genext(3));
-   head->add_extension(genext(1));
+TEST(RecordExt, llistAdd)
+{
+    RecordExt* head = genext(1);
+    head->add_extension(genext(2));
+    head->add_extension(genext(3));
+    head->add_extension(genext(1));
 
-   std::vector<int> vec = {1, 2, 3};
-   std::vector<RecordExt *> exts;
-   RecordExt *tmp = head;
-   while (tmp) {
-      EXPECT_NE(std::find(vec.begin(), vec.end(), tmp->m_ext_id), vec.end());
-      if (tmp->m_ext_id == 1) {
-         exts.push_back(tmp);
-      }
-      tmp = tmp->m_next;
-   }
-   EXPECT_EQ(exts.size(), 2U);
-   EXPECT_NE(exts[0], exts[1]);
+    std::vector<int> vec = {1, 2, 3};
+    std::vector<RecordExt*> exts;
+    RecordExt* tmp = head;
+    while (tmp) {
+        EXPECT_NE(std::find(vec.begin(), vec.end(), tmp->m_ext_id), vec.end());
+        if (tmp->m_ext_id == 1) {
+            exts.push_back(tmp);
+        }
+        tmp = tmp->m_next;
+    }
+    EXPECT_EQ(exts.size(), 2U);
+    EXPECT_NE(exts[0], exts[1]);
 }
 
 TEST_F(TestRec, add)
 {
-   RecordExt *tmp = genext(10);
-   add_extension(tmp);
-   EXPECT_EQ(get_extension(10), tmp);
+    RecordExt* tmp = genext(10);
+    add_extension(tmp);
+    EXPECT_EQ(get_extension(10), tmp);
 }
 
 TEST_F(TestRec, get)
 {
-   EXPECT_EQ(get_extension(1), m_vec[0]);
-   EXPECT_NE(get_extension(1), m_vec[2]);
-   EXPECT_EQ(get_extension(2), m_vec[1]);
-   EXPECT_EQ(get_extension(3), m_vec[3]);
+    EXPECT_EQ(get_extension(1), m_vec[0]);
+    EXPECT_NE(get_extension(1), m_vec[2]);
+    EXPECT_EQ(get_extension(2), m_vec[1]);
+    EXPECT_EQ(get_extension(3), m_vec[3]);
 
-   EXPECT_EQ(get_extension(666), nullptr);
+    EXPECT_EQ(get_extension(666), nullptr);
 }
 
 TEST_F(TestRec, remove)
 {
-   remove_extensions();
-   EXPECT_EQ(get_extension(1), nullptr);
+    remove_extensions();
+    EXPECT_EQ(get_extension(1), nullptr);
 }
 
 TEST(TestExt, registration)
 {
-   Record rec;
-   TestExt *ext1 = new TestExt();
-   rec.add_extension(ext1);
-   EXPECT_NE(rec.get_extension(TestExt::REGISTERED_ID), nullptr);
+    Record rec;
+    TestExt* ext1 = new TestExt();
+    rec.add_extension(ext1);
+    EXPECT_NE(rec.get_extension(TestExt::REGISTERED_ID), nullptr);
 
-   EXPECT_EQ(get_extension_cnt(), 0);
-   int id = register_extension();
-   TestExt::REGISTERED_ID = id;
-   EXPECT_EQ(get_extension_cnt(), 1);
-   EXPECT_EQ(register_extension(), id + 1);
+    EXPECT_EQ(get_extension_cnt(), 0);
+    int id = register_extension();
+    TestExt::REGISTERED_ID = id;
+    EXPECT_EQ(get_extension_cnt(), 1);
+    EXPECT_EQ(register_extension(), id + 1);
 
-   TestExt *ext2 = new TestExt();
-   rec.add_extension(ext2);
-   EXPECT_EQ(rec.get_extension(TestExt::REGISTERED_ID), ext2);
-   EXPECT_EQ(rec.get_extension(TestExt::REGISTERED_ID)->m_ext_id, id);
+    TestExt* ext2 = new TestExt();
+    rec.add_extension(ext2);
+    EXPECT_EQ(rec.get_extension(TestExt::REGISTERED_ID), ext2);
+    EXPECT_EQ(rec.get_extension(TestExt::REGISTERED_ID)->m_ext_id, id);
 }
 
-}
+} // namespace ipxp_test
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-   // invoking the tests
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+    // invoking the tests
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }
-

--- a/tests/unit/options.cpp
+++ b/tests/unit/options.cpp
@@ -7,129 +7,173 @@ namespace ipxp_test {
 
 using namespace ipxp;
 
-class TestParser1 : public OptionsParser
-{
+class TestParser1 : public OptionsParser {
 public:
-   std::vector<std::string> m_vec;
-   uint32_t m_num;
-   bool m_bool;
-   std::string m_str;
+    std::vector<std::string> m_vec;
+    uint32_t m_num;
+    bool m_bool;
+    std::string m_str;
 
-   TestParser1() : OptionsParser("testparser", "test parser description"),
-                     m_num(0), m_bool(false), m_str("")
-   {
-      m_delim = ' ';
+    TestParser1()
+        : OptionsParser("testparser", "test parser description")
+        , m_num(0)
+        , m_bool(false)
+        , m_str("")
+    {
+        m_delim = ' ';
 
-      register_option("-v", "--vec", "STR", "vector param",
-                      [this](const char *arg) {
-                          m_vec.push_back(arg);
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-n", "--num", "NUM", "num param",
-                      [this](const char *arg) {
-                          try { m_num = str2num<decltype(m_num)>(arg); } catch (
-                                  std::invalid_argument &e) { return false; }
-                          return true;
-                      }, OptionFlags::RequiredArgument);
-      register_option("-s", "--str", "STR", "str param", [this](const char *arg) {
-          m_str = arg ? arg : "";
-          return true;
-      }, OptionFlags::OptionalArgument);
-      register_option("-b", "--bool", "", "bool param", [this](const char *arg) {
-          m_bool = true;
-          return true;
-      }, OptionFlags::NoArgument);
-   }
+        register_option(
+            "-v",
+            "--vec",
+            "STR",
+            "vector param",
+            [this](const char* arg) {
+                m_vec.push_back(arg);
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-n",
+            "--num",
+            "NUM",
+            "num param",
+            [this](const char* arg) {
+                try {
+                    m_num = str2num<decltype(m_num)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "-s",
+            "--str",
+            "STR",
+            "str param",
+            [this](const char* arg) {
+                m_str = arg ? arg : "";
+                return true;
+            },
+            OptionFlags::OptionalArgument);
+        register_option(
+            "-b",
+            "--bool",
+            "",
+            "bool param",
+            [this](const char* arg) {
+                m_bool = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-class TestParser2 : public::testing::Test, public OptionsParser
-{
+class TestParser2
+    : public ::testing::Test
+    , public OptionsParser {
 protected:
-   void SetUp() {
-   }
+    void SetUp() {}
 
-   void TearDown() {
-   }
+    void TearDown() {}
 };
 
-TEST(OptionsParser, all) {
-   OptionsParser p("testparser", "dummy parser desc");
-}
-
-TEST(TestParser1, argline) {
-   TestParser1 p;
-   const char *arg[] = {"-s", "50", "-n", "100"};
-   EXPECT_NO_THROW(p.parse(4, arg));
-
-   EXPECT_EQ(p.m_str, "50");
-   EXPECT_EQ(p.m_num, 100U);
-}
-
-TEST(TestParser1, arglineError) {
-   TestParser1 p;
-   const char *arg[] = {"-s", "50", "-n"};
-   EXPECT_THROW(p.parse(3, arg), ParserError);
-
-   EXPECT_NO_THROW(p.parse(0, NULL));
-   EXPECT_THROW(p.parse(5, NULL), std::runtime_error);
-
-   const char *arg2[] = {"-s", "50", "-p", "-n", "100"};
-   EXPECT_THROW(p.parse(5, arg2), ParserError);
-}
-
-TEST(TestParser1, argstr) {
-   TestParser1 p;
-   EXPECT_NO_THROW(p.parse("-s=/path/str      --num=1024"));
-   EXPECT_EQ("/path/str", p.m_str);
-   EXPECT_EQ(1024U, p.m_num);
-
-   EXPECT_EQ(false, p.m_bool);
-   EXPECT_NO_THROW(p.parse("-n=0xFF -b"));
-   EXPECT_EQ(255U, p.m_num);
-   EXPECT_EQ(true, p.m_bool);
-
-   EXPECT_NO_THROW(p.parse("-v=1 -v=2 --vec=3 -v=4"));
-   EXPECT_EQ(p.m_vec.size(), 4U);
-   std::vector<std::string> ref = {"1", "2", "3", "4"};
-   EXPECT_EQ(p.m_vec, ref);
-
-   EXPECT_NO_THROW(p.parse("-v -v"));
-}
-
-TEST(TestParser1, argstrError) {
-   TestParser1 p;
-   EXPECT_THROW(p.parse("--num=-10"), ParserError);
-   EXPECT_THROW(p.parse("--num"), ParserError);
-   EXPECT_THROW(p.parse("--num="), ParserError);
-   EXPECT_THROW(p.parse("-b=ABC"), ParserError);
-
-   EXPECT_NO_THROW(p.parse(""));
-   EXPECT_NO_THROW(p.parse(NULL));
-}
-
-TEST_F(TestParser2, invalidOptions) {
-   auto func = [this](const char *arg){return true;};
-   EXPECT_THROW(register_option("", "", "", "", func, OptionFlags::NoArgument), std::runtime_error);
-   EXPECT_THROW(register_option("-s", "", "", "desc", func, OptionFlags::NoArgument), std::runtime_error);
-   EXPECT_THROW(register_option("", "--long", "", "desc", func, OptionFlags::NoArgument), std::runtime_error);
-   EXPECT_THROW(register_option("-d", "--desc", "", "", func, OptionFlags::NoArgument), std::runtime_error);
-}
-
-TEST_F(TestParser2, dupOptions) {
-   auto func = [this](const char *arg){return true;};
-   EXPECT_NO_THROW(register_option("a", "aaa", "", "a param", func, OptionFlags::NoArgument));
-   EXPECT_NO_THROW(register_option("b", "bbb", "", "b param", func, OptionFlags::NoArgument));
-   EXPECT_NO_THROW(register_option("c", "ccc", "", "c param", func, OptionFlags::NoArgument));
-   EXPECT_THROW(register_option("b", "ddd", "", "d param", func, OptionFlags::NoArgument), std::runtime_error);
-   EXPECT_THROW(register_option("e", "ccc", "", "e param", func, OptionFlags::NoArgument), std::runtime_error);
-}
-
-}
-
-int main(int argc, char **argv)
+TEST(OptionsParser, all)
 {
-   // invoking the tests
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+    OptionsParser p("testparser", "dummy parser desc");
 }
 
+TEST(TestParser1, argline)
+{
+    TestParser1 p;
+    const char* arg[] = {"-s", "50", "-n", "100"};
+    EXPECT_NO_THROW(p.parse(4, arg));
+
+    EXPECT_EQ(p.m_str, "50");
+    EXPECT_EQ(p.m_num, 100U);
+}
+
+TEST(TestParser1, arglineError)
+{
+    TestParser1 p;
+    const char* arg[] = {"-s", "50", "-n"};
+    EXPECT_THROW(p.parse(3, arg), ParserError);
+
+    EXPECT_NO_THROW(p.parse(0, NULL));
+    EXPECT_THROW(p.parse(5, NULL), std::runtime_error);
+
+    const char* arg2[] = {"-s", "50", "-p", "-n", "100"};
+    EXPECT_THROW(p.parse(5, arg2), ParserError);
+}
+
+TEST(TestParser1, argstr)
+{
+    TestParser1 p;
+    EXPECT_NO_THROW(p.parse("-s=/path/str      --num=1024"));
+    EXPECT_EQ("/path/str", p.m_str);
+    EXPECT_EQ(1024U, p.m_num);
+
+    EXPECT_EQ(false, p.m_bool);
+    EXPECT_NO_THROW(p.parse("-n=0xFF -b"));
+    EXPECT_EQ(255U, p.m_num);
+    EXPECT_EQ(true, p.m_bool);
+
+    EXPECT_NO_THROW(p.parse("-v=1 -v=2 --vec=3 -v=4"));
+    EXPECT_EQ(p.m_vec.size(), 4U);
+    std::vector<std::string> ref = {"1", "2", "3", "4"};
+    EXPECT_EQ(p.m_vec, ref);
+
+    EXPECT_NO_THROW(p.parse("-v -v"));
+}
+
+TEST(TestParser1, argstrError)
+{
+    TestParser1 p;
+    EXPECT_THROW(p.parse("--num=-10"), ParserError);
+    EXPECT_THROW(p.parse("--num"), ParserError);
+    EXPECT_THROW(p.parse("--num="), ParserError);
+    EXPECT_THROW(p.parse("-b=ABC"), ParserError);
+
+    EXPECT_NO_THROW(p.parse(""));
+    EXPECT_NO_THROW(p.parse(NULL));
+}
+
+TEST_F(TestParser2, invalidOptions)
+{
+    auto func = [this](const char* arg) { return true; };
+    EXPECT_THROW(
+        register_option("", "", "", "", func, OptionFlags::NoArgument),
+        std::runtime_error);
+    EXPECT_THROW(
+        register_option("-s", "", "", "desc", func, OptionFlags::NoArgument),
+        std::runtime_error);
+    EXPECT_THROW(
+        register_option("", "--long", "", "desc", func, OptionFlags::NoArgument),
+        std::runtime_error);
+    EXPECT_THROW(
+        register_option("-d", "--desc", "", "", func, OptionFlags::NoArgument),
+        std::runtime_error);
+}
+
+TEST_F(TestParser2, dupOptions)
+{
+    auto func = [this](const char* arg) { return true; };
+    EXPECT_NO_THROW(register_option("a", "aaa", "", "a param", func, OptionFlags::NoArgument));
+    EXPECT_NO_THROW(register_option("b", "bbb", "", "b param", func, OptionFlags::NoArgument));
+    EXPECT_NO_THROW(register_option("c", "ccc", "", "c param", func, OptionFlags::NoArgument));
+    EXPECT_THROW(
+        register_option("b", "ddd", "", "d param", func, OptionFlags::NoArgument),
+        std::runtime_error);
+    EXPECT_THROW(
+        register_option("e", "ccc", "", "e param", func, OptionFlags::NoArgument),
+        std::runtime_error);
+}
+
+} // namespace ipxp_test
+
+int main(int argc, char** argv)
+{
+    // invoking the tests
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/unit/skip.cpp
+++ b/tests/unit/skip.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-   std::cout << "compiled without google test" << std::endl;
-   return 77;
+    std::cout << "compiled without google test" << std::endl;
+    return 77;
 }

--- a/tests/unit/unirec.cpp
+++ b/tests/unit/unirec.cpp
@@ -6,54 +6,55 @@ namespace ipxp_test {
 
 using namespace ipxp;
 
-TEST(UnirecOptParser, pluginMap) {
-   UnirecOptParser p;
-
-   EXPECT_THROW(p.parse("p=foo,,,,,,,,"), ParserError);
-   EXPECT_THROW(p.parse("p=foo,"), ParserError);
-
-   EXPECT_NO_THROW(p.parse("p=foo"));
-   EXPECT_NO_THROW(p.parse("p=foo,bar"));
-   EXPECT_NO_THROW(p.parse("p=foo,(bar)"));
-   EXPECT_NO_THROW(p.parse("p=(foo)"));
-   EXPECT_NO_THROW(p.parse("p=(foo,bar)"));
-   EXPECT_NO_THROW(p.parse("p=foo1,(bar1,bar2),foo2"));
-   EXPECT_NO_THROW(p.parse("p=(f)"));
-
-   EXPECT_THROW(p.parse("p="), ParserError);
-   EXPECT_THROW(p.parse("p=    "), ParserError);
-   EXPECT_THROW(p.parse("p=foo,"), ParserError);
-   EXPECT_THROW(p.parse("p=,foo"), ParserError);
-   EXPECT_THROW(p.parse("p=()"), ParserError);
-   EXPECT_THROW(p.parse("p=(,)"), ParserError);
-   EXPECT_THROW(p.parse("p=foo,(,bar)"), ParserError);
-   EXPECT_THROW(p.parse("p=foo,(bar"), ParserError);
-   EXPECT_THROW(p.parse("p=bar),foo"), ParserError);
-   EXPECT_THROW(p.parse("p=foo()"), ParserError);
-   EXPECT_THROW(p.parse("p=foo,()"), ParserError);
-   EXPECT_THROW(p.parse("p=(foo,(bar))"), ParserError);
-   EXPECT_THROW(p.parse("p=foo(),bar"), ParserError);
-}
-
-TEST(UnirecOptParser, plugins) {
-   UnirecOptParser p;
-   EXPECT_NO_THROW(p.parse("p=foo1,(bar1,bar2),foo2"));
-
-   auto m = p.m_ifc_map;
-   EXPECT_EQ(m.size(), 3U);
-   EXPECT_EQ(m[0][0], "foo1");
-   EXPECT_EQ(m[1].size(), 2U);
-   EXPECT_EQ(m[1][0], "bar1");
-   EXPECT_EQ(m[1][1], "bar2");
-   EXPECT_EQ(m[2][0], "foo2");
-}
-
-}
-
-int main(int argc, char **argv)
+TEST(UnirecOptParser, pluginMap)
 {
-   // invoking the tests
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+    UnirecOptParser p;
+
+    EXPECT_THROW(p.parse("p=foo,,,,,,,,"), ParserError);
+    EXPECT_THROW(p.parse("p=foo,"), ParserError);
+
+    EXPECT_NO_THROW(p.parse("p=foo"));
+    EXPECT_NO_THROW(p.parse("p=foo,bar"));
+    EXPECT_NO_THROW(p.parse("p=foo,(bar)"));
+    EXPECT_NO_THROW(p.parse("p=(foo)"));
+    EXPECT_NO_THROW(p.parse("p=(foo,bar)"));
+    EXPECT_NO_THROW(p.parse("p=foo1,(bar1,bar2),foo2"));
+    EXPECT_NO_THROW(p.parse("p=(f)"));
+
+    EXPECT_THROW(p.parse("p="), ParserError);
+    EXPECT_THROW(p.parse("p=    "), ParserError);
+    EXPECT_THROW(p.parse("p=foo,"), ParserError);
+    EXPECT_THROW(p.parse("p=,foo"), ParserError);
+    EXPECT_THROW(p.parse("p=()"), ParserError);
+    EXPECT_THROW(p.parse("p=(,)"), ParserError);
+    EXPECT_THROW(p.parse("p=foo,(,bar)"), ParserError);
+    EXPECT_THROW(p.parse("p=foo,(bar"), ParserError);
+    EXPECT_THROW(p.parse("p=bar),foo"), ParserError);
+    EXPECT_THROW(p.parse("p=foo()"), ParserError);
+    EXPECT_THROW(p.parse("p=foo,()"), ParserError);
+    EXPECT_THROW(p.parse("p=(foo,(bar))"), ParserError);
+    EXPECT_THROW(p.parse("p=foo(),bar"), ParserError);
 }
 
+TEST(UnirecOptParser, plugins)
+{
+    UnirecOptParser p;
+    EXPECT_NO_THROW(p.parse("p=foo1,(bar1,bar2),foo2"));
+
+    auto m = p.m_ifc_map;
+    EXPECT_EQ(m.size(), 3U);
+    EXPECT_EQ(m[0][0], "foo1");
+    EXPECT_EQ(m[1].size(), 2U);
+    EXPECT_EQ(m[1][0], "bar1");
+    EXPECT_EQ(m[1][1], "bar2");
+    EXPECT_EQ(m[2][0], "foo2");
+}
+
+} // namespace ipxp_test
+
+int main(int argc, char** argv)
+{
+    // invoking the tests
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/unit/utils.cpp
+++ b/tests/unit/utils.cpp
@@ -6,90 +6,97 @@ namespace ipxp_test {
 
 using namespace ipxp;
 
-TEST(max, all) {
-   EXPECT_EQ(10U, ipxp::max<uint16_t>(5, 10));
-   EXPECT_EQ(10U, ipxp::max<uint16_t>(10, 5));
-   EXPECT_EQ(10U, ipxp::max<uint32_t>(10, 10));
-   EXPECT_EQ(-100, ipxp::max<int>(-100, -101));
-}
-
-TEST(bitcount, all) {
-   EXPECT_EQ(0U, bitcount<uint32_t>(0x00));
-   EXPECT_EQ(5U, bitcount<uint32_t>(0x1234));
-   EXPECT_EQ(4U, bitcount<uint64_t>(0x0F0));
-   EXPECT_EQ(1U, bitcount<bool>(true));
-}
-
-TEST(parse_range, all) {
-   std::string from;
-   std::string to;
-
-   parse_range("10-20", from, to);
-   EXPECT_EQ("10", from);
-   EXPECT_EQ("20", to);
-
-
-   parse_range(" \t -10 - 5", from, to);
-   EXPECT_EQ("-10", from);
-   EXPECT_EQ("5", to);
-
-   parse_range("  -10 - -5", from, to);
-   EXPECT_EQ("-10", from);
-   EXPECT_EQ("-5", to);
-
-   parse_range("       1   \t -   \n -5    \n", from, to);
-   EXPECT_EQ("1", from);
-   EXPECT_EQ("-5", to);
-}
-
-TEST(trim_str, all) {
-   std::string tmp1 = "   foo bar \t  \n";
-   trim_str(tmp1);
-   EXPECT_EQ("foo bar", tmp1);
-
-   std::string tmp2 = "foo \t  \n    bar";
-   trim_str(tmp2);
-   EXPECT_EQ(tmp2, tmp2);
-}
-
-TEST(str2num, valid) {
-   EXPECT_EQ(128, str2num<uint8_t>("128"));
-   EXPECT_EQ(-10, str2num<int>("-10"));
-   EXPECT_FLOAT_EQ(6.666, str2num<float>("6.666"));
-   EXPECT_EQ((uint32_t) 0xDEADBEEF, str2num<uint32_t>(" \t \n  0xDEADBEEF"));
-}
-
-TEST(str2num, invalid) {
-   EXPECT_THROW(str2num<unsigned>(""), std::invalid_argument);
-   EXPECT_THROW(str2num<unsigned>("-1"), std::invalid_argument);
-   EXPECT_THROW(str2num<uint8_t>("256"), std::invalid_argument);
-   EXPECT_THROW(str2num<uint64_t>("2000000000000000000000000000000000000000000"), std::invalid_argument);
-   EXPECT_THROW(str2num<uint32_t>("  25  v "), std::invalid_argument);
-}
-
-TEST(str2bool, all) {
-   EXPECT_TRUE(str2bool("yEs"));
-   EXPECT_TRUE(str2bool("y"));
-   EXPECT_TRUE(str2bool("true"));
-   EXPECT_TRUE(str2bool("truE"));
-   EXPECT_TRUE(str2bool("t"));
-   EXPECT_TRUE(str2bool("1"));
-   EXPECT_TRUE(str2bool("on"));
-
-   EXPECT_FALSE(str2bool("no"));
-   EXPECT_FALSE(str2bool("0"));
-   EXPECT_FALSE(str2bool("false"));
-   EXPECT_FALSE(str2bool("f"));
-   EXPECT_FALSE(str2bool("off"));
-   EXPECT_FALSE(str2bool("abc"));
-}
-
-}
-
-int main(int argc, char **argv)
+TEST(max, all)
 {
-   // invoking the tests
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+    EXPECT_EQ(10U, ipxp::max<uint16_t>(5, 10));
+    EXPECT_EQ(10U, ipxp::max<uint16_t>(10, 5));
+    EXPECT_EQ(10U, ipxp::max<uint32_t>(10, 10));
+    EXPECT_EQ(-100, ipxp::max<int>(-100, -101));
 }
 
+TEST(bitcount, all)
+{
+    EXPECT_EQ(0U, bitcount<uint32_t>(0x00));
+    EXPECT_EQ(5U, bitcount<uint32_t>(0x1234));
+    EXPECT_EQ(4U, bitcount<uint64_t>(0x0F0));
+    EXPECT_EQ(1U, bitcount<bool>(true));
+}
+
+TEST(parse_range, all)
+{
+    std::string from;
+    std::string to;
+
+    parse_range("10-20", from, to);
+    EXPECT_EQ("10", from);
+    EXPECT_EQ("20", to);
+
+    parse_range(" \t -10 - 5", from, to);
+    EXPECT_EQ("-10", from);
+    EXPECT_EQ("5", to);
+
+    parse_range("  -10 - -5", from, to);
+    EXPECT_EQ("-10", from);
+    EXPECT_EQ("-5", to);
+
+    parse_range("       1   \t -   \n -5    \n", from, to);
+    EXPECT_EQ("1", from);
+    EXPECT_EQ("-5", to);
+}
+
+TEST(trim_str, all)
+{
+    std::string tmp1 = "   foo bar \t  \n";
+    trim_str(tmp1);
+    EXPECT_EQ("foo bar", tmp1);
+
+    std::string tmp2 = "foo \t  \n    bar";
+    trim_str(tmp2);
+    EXPECT_EQ(tmp2, tmp2);
+}
+
+TEST(str2num, valid)
+{
+    EXPECT_EQ(128, str2num<uint8_t>("128"));
+    EXPECT_EQ(-10, str2num<int>("-10"));
+    EXPECT_FLOAT_EQ(6.666, str2num<float>("6.666"));
+    EXPECT_EQ((uint32_t) 0xDEADBEEF, str2num<uint32_t>(" \t \n  0xDEADBEEF"));
+}
+
+TEST(str2num, invalid)
+{
+    EXPECT_THROW(str2num<unsigned>(""), std::invalid_argument);
+    EXPECT_THROW(str2num<unsigned>("-1"), std::invalid_argument);
+    EXPECT_THROW(str2num<uint8_t>("256"), std::invalid_argument);
+    EXPECT_THROW(
+        str2num<uint64_t>("2000000000000000000000000000000000000000000"),
+        std::invalid_argument);
+    EXPECT_THROW(str2num<uint32_t>("  25  v "), std::invalid_argument);
+}
+
+TEST(str2bool, all)
+{
+    EXPECT_TRUE(str2bool("yEs"));
+    EXPECT_TRUE(str2bool("y"));
+    EXPECT_TRUE(str2bool("true"));
+    EXPECT_TRUE(str2bool("truE"));
+    EXPECT_TRUE(str2bool("t"));
+    EXPECT_TRUE(str2bool("1"));
+    EXPECT_TRUE(str2bool("on"));
+
+    EXPECT_FALSE(str2bool("no"));
+    EXPECT_FALSE(str2bool("0"));
+    EXPECT_FALSE(str2bool("false"));
+    EXPECT_FALSE(str2bool("f"));
+    EXPECT_FALSE(str2bool("off"));
+    EXPECT_FALSE(str2bool("abc"));
+}
+
+} // namespace ipxp_test
+
+int main(int argc, char** argv)
+{
+    // invoking the tests
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/utils.cpp
+++ b/utils.cpp
@@ -134,8 +134,8 @@ uint32_t variable2ipfix_buffer(uint8_t* buffer2write, uint8_t* buffer2read, uint
 
 uint64_t timeval2usec(const struct timeval& tv)
 {
-   constexpr size_t usec_in_sec = 1000000;
-   return tv.tv_sec * usec_in_sec + tv.tv_usec;
+    constexpr size_t usec_in_sec = 1000000;
+    return tv.tv_sec * usec_in_sec + tv.tv_usec;
 }
 
 } // namespace ipxp

--- a/workers.cpp
+++ b/workers.cpp
@@ -26,205 +26,214 @@
  *
  */
 
-#include <unistd.h>
 #include <sys/time.h>
+#include <unistd.h>
 
-#include "workers.hpp"
 #include "ipfixprobe.hpp"
+#include "workers.hpp"
 
 namespace ipxp {
 
 #define MICRO_SEC 1000000L
 
-void input_storage_worker(InputPlugin *plugin, StoragePlugin *cache, size_t queue_size, uint64_t pkt_limit,
-                  std::promise<WorkerResult> *out, std::atomic<InputStats> *out_stats)
+void input_storage_worker(
+    InputPlugin* plugin,
+    StoragePlugin* cache,
+    size_t queue_size,
+    uint64_t pkt_limit,
+    std::promise<WorkerResult>* out,
+    std::atomic<InputStats>* out_stats)
 {
-   struct timespec start_cache;
-   struct timespec end_cache;
-   struct timespec begin = {0, 0};
-   struct timespec end = {0, 0};
-   struct timeval ts = {0, 0};
-   bool timeout = false;
-   InputPlugin::Result ret;
-   InputStats stats = {0, 0, 0, 0, 0};
-   WorkerResult res = {false, ""};
+    struct timespec start_cache;
+    struct timespec end_cache;
+    struct timespec begin = {0, 0};
+    struct timespec end = {0, 0};
+    struct timeval ts = {0, 0};
+    bool timeout = false;
+    InputPlugin::Result ret;
+    InputStats stats = {0, 0, 0, 0, 0};
+    WorkerResult res = {false, ""};
 
-   PacketBlock block(queue_size);
+    PacketBlock block(queue_size);
 
 #ifdef __linux__
-   const clockid_t clk_id = CLOCK_MONOTONIC_COARSE;
+    const clockid_t clk_id = CLOCK_MONOTONIC_COARSE;
 #else
-   const clockid_t clk_id = CLOCK_MONOTONIC;
+    const clockid_t clk_id = CLOCK_MONOTONIC;
 #endif
 
-   while (!terminate_input) {
-      block.cnt = 0;
-      block.bytes = 0;
+    while (!terminate_input) {
+        block.cnt = 0;
+        block.bytes = 0;
 
-      if (pkt_limit && plugin->m_parsed + block.size >= pkt_limit) {
-         if (plugin->m_parsed >= pkt_limit) {
-            break;
-         }
-         block.size = pkt_limit - plugin->m_parsed;
-      }
-      try {
-         ret = plugin->get(block);
-      } catch (PluginError &e) {
-         res.error = true;
-         res.msg = e.what();
-         break;
-      }
-      if (ret == InputPlugin::Result::TIMEOUT) {
-         clock_gettime(clk_id, &end);
-         if (!timeout) {
-            timeout = true;
-            begin = end;
-         }
-         struct timespec diff = {end.tv_sec - begin.tv_sec, end.tv_nsec - begin.tv_nsec};
-         if (diff.tv_nsec < 0) {
-            diff.tv_nsec += 1000000000;
-            diff.tv_sec--;
-         }
-         cache->export_expired(ts.tv_sec + diff.tv_sec);
-         usleep(1);
-         continue;
-      } else if (ret == InputPlugin::Result::PARSED) {
-         stats.packets = plugin->m_seen;
-         stats.parsed = plugin->m_parsed;
-         stats.dropped = plugin->m_dropped;
-         stats.bytes += block.bytes;
-         clock_gettime(clk_id, &start_cache);
-         try {
-            for (unsigned i = 0; i < block.cnt; i++) {
-               cache->put_pkt(block.pkts[i]);
+        if (pkt_limit && plugin->m_parsed + block.size >= pkt_limit) {
+            if (plugin->m_parsed >= pkt_limit) {
+                break;
             }
-            ts = block.pkts[block.cnt - 1].ts;
-         } catch (PluginError &e) {
+            block.size = pkt_limit - plugin->m_parsed;
+        }
+        try {
+            ret = plugin->get(block);
+        } catch (PluginError& e) {
             res.error = true;
             res.msg = e.what();
             break;
-         }
-         timeout = false;
-         clock_gettime(clk_id, &end_cache);
+        }
+        if (ret == InputPlugin::Result::TIMEOUT) {
+            clock_gettime(clk_id, &end);
+            if (!timeout) {
+                timeout = true;
+                begin = end;
+            }
+            struct timespec diff = {end.tv_sec - begin.tv_sec, end.tv_nsec - begin.tv_nsec};
+            if (diff.tv_nsec < 0) {
+                diff.tv_nsec += 1000000000;
+                diff.tv_sec--;
+            }
+            cache->export_expired(ts.tv_sec + diff.tv_sec);
+            usleep(1);
+            continue;
+        } else if (ret == InputPlugin::Result::PARSED) {
+            stats.packets = plugin->m_seen;
+            stats.parsed = plugin->m_parsed;
+            stats.dropped = plugin->m_dropped;
+            stats.bytes += block.bytes;
+            clock_gettime(clk_id, &start_cache);
+            try {
+                for (unsigned i = 0; i < block.cnt; i++) {
+                    cache->put_pkt(block.pkts[i]);
+                }
+                ts = block.pkts[block.cnt - 1].ts;
+            } catch (PluginError& e) {
+                res.error = true;
+                res.msg = e.what();
+                break;
+            }
+            timeout = false;
+            clock_gettime(clk_id, &end_cache);
 
-         int64_t time = end_cache.tv_nsec - start_cache.tv_nsec;
-         if (start_cache.tv_sec != end_cache.tv_sec) {
-            time += 1000000000;
-         }
-         stats.qtime += time;
+            int64_t time = end_cache.tv_nsec - start_cache.tv_nsec;
+            if (start_cache.tv_sec != end_cache.tv_sec) {
+                time += 1000000000;
+            }
+            stats.qtime += time;
 
-         out_stats->store(stats);
-      } else if (ret == InputPlugin::Result::ERROR) {
-         res.error = true;
-         res.msg = "error occured during reading";
-         break;
-      } else if (ret == InputPlugin::Result::END_OF_FILE) {
-         break;
-      }
-   }
-
-   stats.packets = plugin->m_seen;
-   stats.parsed = plugin->m_parsed;
-   stats.dropped = plugin->m_dropped;
-   out_stats->store(stats);
-   cache->finish();
-   auto outq = cache->get_queue();
-   while (ipx_ring_cnt(outq)) {
-      usleep(1);
-   }
-   out->set_value(res);
-}
-
-static long timeval_diff(const struct timeval *start, const struct timeval *end)
-{
-   return (end->tv_sec - start->tv_sec) * MICRO_SEC
-          + (end->tv_usec - start->tv_usec);
-}
-
-void output_worker(OutputPlugin *exp, ipx_ring_t *queue, std::promise<WorkerResult> *out, std::atomic<OutputStats> *out_stats,
-   uint32_t fps)
-{
-   WorkerResult res = {false, ""};
-   OutputStats stats = {0, 0, 0, 0};
-   struct timespec sleep_time = {0};
-   struct timeval begin;
-   struct timeval end;
-   struct timeval last_flush;
-   uint32_t pkts_from_begin = 0;
-   double time_per_pkt = 0;
-
-   if (fps != 0) {
-      time_per_pkt = 1000000.0 / fps; // [micro seconds]
-   }
-
-   // Rate limiting algorithm from https://github.com/CESNET/ipfixcol2/blob/master/src/tools/ipfixsend/sender.c#L98
-   gettimeofday(&begin, nullptr);
-   last_flush = begin;
-   while (1) {
-      gettimeofday(&end, nullptr);
-
-      Flow *flow = static_cast<Flow *>(ipx_ring_pop(queue));
-      if (!flow) {
-         if (end.tv_sec - last_flush.tv_sec > 1) {
-            last_flush = end;
-            exp->flush();
-         }
-         if (terminate_export && !ipx_ring_cnt(queue)) {
+            out_stats->store(stats);
+        } else if (ret == InputPlugin::Result::ERROR) {
+            res.error = true;
+            res.msg = "error occured during reading";
             break;
-         }
-         continue;
-      }
+        } else if (ret == InputPlugin::Result::END_OF_FILE) {
+            break;
+        }
+    }
 
-      stats.biflows++;
-      stats.bytes += flow->src_bytes + flow->dst_bytes;
-      stats.packets += flow->src_packets + flow->dst_packets;
-      stats.dropped = exp->m_flows_dropped;
-      out_stats->store(stats);
-      try {
-         exp->export_flow(*flow);
-      } catch (PluginError &e) {
-         res.error = true;
-         res.msg = e.what();
-         break;
-      }
-
-      pkts_from_begin++;
-      if (fps == 0) {
-         // Limit for packets/s is not enabled
-         continue;
-      }
-
-      // Calculate expected time of sending next packet
-      long elapsed = timeval_diff(&begin, &end);
-      if (elapsed < 0) {
-         // Should be never negative. Just for sure...
-         elapsed = pkts_from_begin * time_per_pkt;
-      }
-
-      long next_start = pkts_from_begin * time_per_pkt;
-      long diff = next_start - elapsed;
-
-      if (diff >= MICRO_SEC) {
-         diff = MICRO_SEC - 1;
-      }
-
-      // Sleep
-      if (diff > 0) {
-         sleep_time.tv_nsec = diff * 1000L;
-         nanosleep(&sleep_time, nullptr);
-      }
-
-      if (pkts_from_begin >= fps) {
-         // Restart counter
-         gettimeofday(&begin, nullptr);
-         pkts_from_begin = 0;
-      }
-   }
-
-   exp->flush();
-   stats.dropped = exp->m_flows_dropped;
-   out_stats->store(stats);
-   out->set_value(res);
+    stats.packets = plugin->m_seen;
+    stats.parsed = plugin->m_parsed;
+    stats.dropped = plugin->m_dropped;
+    out_stats->store(stats);
+    cache->finish();
+    auto outq = cache->get_queue();
+    while (ipx_ring_cnt(outq)) {
+        usleep(1);
+    }
+    out->set_value(res);
 }
 
+static long timeval_diff(const struct timeval* start, const struct timeval* end)
+{
+    return (end->tv_sec - start->tv_sec) * MICRO_SEC + (end->tv_usec - start->tv_usec);
 }
+
+void output_worker(
+    OutputPlugin* exp,
+    ipx_ring_t* queue,
+    std::promise<WorkerResult>* out,
+    std::atomic<OutputStats>* out_stats,
+    uint32_t fps)
+{
+    WorkerResult res = {false, ""};
+    OutputStats stats = {0, 0, 0, 0};
+    struct timespec sleep_time = {0};
+    struct timeval begin;
+    struct timeval end;
+    struct timeval last_flush;
+    uint32_t pkts_from_begin = 0;
+    double time_per_pkt = 0;
+
+    if (fps != 0) {
+        time_per_pkt = 1000000.0 / fps; // [micro seconds]
+    }
+
+    // Rate limiting algorithm from
+    // https://github.com/CESNET/ipfixcol2/blob/master/src/tools/ipfixsend/sender.c#L98
+    gettimeofday(&begin, nullptr);
+    last_flush = begin;
+    while (1) {
+        gettimeofday(&end, nullptr);
+
+        Flow* flow = static_cast<Flow*>(ipx_ring_pop(queue));
+        if (!flow) {
+            if (end.tv_sec - last_flush.tv_sec > 1) {
+                last_flush = end;
+                exp->flush();
+            }
+            if (terminate_export && !ipx_ring_cnt(queue)) {
+                break;
+            }
+            continue;
+        }
+
+        stats.biflows++;
+        stats.bytes += flow->src_bytes + flow->dst_bytes;
+        stats.packets += flow->src_packets + flow->dst_packets;
+        stats.dropped = exp->m_flows_dropped;
+        out_stats->store(stats);
+        try {
+            exp->export_flow(*flow);
+        } catch (PluginError& e) {
+            res.error = true;
+            res.msg = e.what();
+            break;
+        }
+
+        pkts_from_begin++;
+        if (fps == 0) {
+            // Limit for packets/s is not enabled
+            continue;
+        }
+
+        // Calculate expected time of sending next packet
+        long elapsed = timeval_diff(&begin, &end);
+        if (elapsed < 0) {
+            // Should be never negative. Just for sure...
+            elapsed = pkts_from_begin * time_per_pkt;
+        }
+
+        long next_start = pkts_from_begin * time_per_pkt;
+        long diff = next_start - elapsed;
+
+        if (diff >= MICRO_SEC) {
+            diff = MICRO_SEC - 1;
+        }
+
+        // Sleep
+        if (diff > 0) {
+            sleep_time.tv_nsec = diff * 1000L;
+            nanosleep(&sleep_time, nullptr);
+        }
+
+        if (pkts_from_begin >= fps) {
+            // Restart counter
+            gettimeofday(&begin, nullptr);
+            pkts_from_begin = 0;
+        }
+    }
+
+    exp->flush();
+    stats.dropped = exp->m_flows_dropped;
+    out_stats->store(stats);
+    out->set_value(res);
+}
+
+} // namespace ipxp

--- a/workers.hpp
+++ b/workers.hpp
@@ -29,15 +29,15 @@
 #ifndef IPXP_WORKERS_HPP
 #define IPXP_WORKERS_HPP
 
-#include <future>
 #include <atomic>
+#include <future>
 
 #include <ipfixprobe/input.hpp>
-#include <ipfixprobe/storage.hpp>
 #include <ipfixprobe/output.hpp>
-#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/packet.hpp>
+#include <ipfixprobe/process.hpp>
 #include <ipfixprobe/ring.h>
+#include <ipfixprobe/storage.hpp>
 
 #include "stats.hpp"
 
@@ -46,36 +46,45 @@ namespace ipxp {
 #define MICRO_SEC 1000000L
 
 struct WorkerResult {
-   bool error;
-   std::string msg;
+    bool error;
+    std::string msg;
 };
 
 struct WorkPipeline {
-   struct {
-      InputPlugin *plugin;
-      std::thread *thread;
-      std::promise<WorkerResult> *promise;
-      std::atomic<InputStats> *stats;
-   } input;
-   struct {
-      StoragePlugin *plugin;
-      std::vector<ProcessPlugin *> plugins;
-   } storage;
+    struct {
+        InputPlugin* plugin;
+        std::thread* thread;
+        std::promise<WorkerResult>* promise;
+        std::atomic<InputStats>* stats;
+    } input;
+    struct {
+        StoragePlugin* plugin;
+        std::vector<ProcessPlugin*> plugins;
+    } storage;
 };
 
 struct OutputWorker {
-   OutputPlugin *plugin;
-   std::thread *thread;
-   std::promise<WorkerResult> *promise;
-   std::atomic<OutputStats> *stats;
-   ipx_ring_t *queue;
+    OutputPlugin* plugin;
+    std::thread* thread;
+    std::promise<WorkerResult>* promise;
+    std::atomic<OutputStats>* stats;
+    ipx_ring_t* queue;
 };
 
-void input_storage_worker(InputPlugin *plugin, StoragePlugin *cache, size_t queue_size, uint64_t pkt_limit, 
-      std::promise<WorkerResult> *out, std::atomic<InputStats> *out_stats);
-void output_worker(OutputPlugin *exp, ipx_ring_t *queue, std::promise<WorkerResult> *out, std::atomic<OutputStats> *out_stats,
-      uint32_t fps);
+void input_storage_worker(
+    InputPlugin* plugin,
+    StoragePlugin* cache,
+    size_t queue_size,
+    uint64_t pkt_limit,
+    std::promise<WorkerResult>* out,
+    std::atomic<InputStats>* out_stats);
+void output_worker(
+    OutputPlugin* exp,
+    ipx_ring_t* queue,
+    std::promise<WorkerResult>* out,
+    std::atomic<OutputStats>* out_stats,
+    uint32_t fps);
 
-}
+} // namespace ipxp
 
 #endif /* IPXP_WORKERS_HPP */


### PR DESCRIPTION
**Adds new options to the Makefile:** 
Introduces new options, "format-check" and "format-fix," to the Makefile for checking and fixing code formatting in .cpp and .hpp files.

**Performs code reformatting across the entire repository:** 
Aims to achieve consistent and uniform code formatting by addressing code indentation, spacing, and other style-related issues in all relevant code files.

**Incorporates a new step into the Continuous Integration (CI) process:** 
Enhances code quality by adding the "make format-check" command to the CI pipeline, ensuring that code formatting is validated automatically for all code changes pushed to the repository. This step is crucial for maintaining code consistency and adherence to coding standards.