### PR TITLE
Refactor cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,8 @@ endif
 ipfixprobe_storage_src=\
 		storage/cache.cpp \
 		storage/cache.hpp \
+		storage/old_cache.cpp \
+		storage/old_cache.hpp \
 		storage/xxhash.c \
 		storage/xxhash.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,12 @@ if [[ -z "$WITH_NDP_TRUE" ]]; then
    RPM_BUILDREQ+=" netcope-common-devel"
 fi
 
+AC_ARG_WITH([debugcache], [AS_HELP_STRING([--with-debugcache], [Enable cache statistic prints])])
+if test "x$with_debugcache" = "xyes"; then
+  CPPFLAGS="$CPPFLAGS -DFLOW_CACHE_STATS"
+fi
+
+
 AC_ARG_WITH([pcap],
         AC_HELP_STRING([--with-pcap],[Compile ipfixprobe with pcap plugin for capturing using libpcap library]),
         [

--- a/storage/cache.cpp
+++ b/storage/cache.cpp
@@ -31,8 +31,8 @@
  */
 
 #include <cstdlib>
-#include <iostream>
 #include <cstring>
+#include <iostream>
 #include <sys/time.h>
 
 #include "cache.hpp"
@@ -45,405 +45,446 @@ namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin() noexcept
 {
-   //static PluginRecord rec = PluginRecord("cache", [](){return new NHTFlowCache<PRINT_FLOW_CACHE_STATS>();});
-   static PluginRecord rec = PluginRecord("cache", [](){return new NHTFlowCache<true>();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("cache", []() { return new NHTFlowCache<PRINT_FLOW_CACHE_STATS>(); });
+    register_plugin(&rec);
 }
 
 template<uint16_t IPSize>
-flow_key<IPSize>& flow_key<IPSize>::operator=(const Packet &pkt)noexcept{
-   proto = pkt.ip_proto;
-   src_port = pkt.src_port;
-   dst_port = pkt.dst_port;
-   vlan_id = pkt.vlan_id;
-   return *this;
+flow_key<IPSize>& flow_key<IPSize>::operator=(const Packet& pkt) noexcept
+{
+    proto = pkt.ip_proto;
+    src_port = pkt.src_port;
+    dst_port = pkt.dst_port;
+    vlan_id = pkt.vlan_id;
+    return *this;
 }
 
 template<uint16_t IPSize>
-flow_key<IPSize>& flow_key<IPSize>::save_reversed(const Packet &pkt)noexcept{
-   *this=pkt;
-   src_port = pkt.dst_port;
-   dst_port = pkt.src_port;
-   return *this;
+flow_key<IPSize>& flow_key<IPSize>::save_reversed(const Packet& pkt) noexcept
+{
+    *this = pkt;
+    src_port = pkt.dst_port;
+    dst_port = pkt.src_port;
+    return *this;
 }
 
-flow_key_v4& flow_key_v4::operator=(const Packet &pkt)noexcept{
-   flow_key::operator=(pkt);
-   ip_version = IP::v4;
-   memcpy(src_ip.data(), &pkt.src_ip.v4, 4);
-   memcpy(dst_ip.data(), &pkt.dst_ip.v4, 4);
-   return *this;
+flow_key_v4& flow_key_v4::operator=(const Packet& pkt) noexcept
+{
+    flow_key::operator=(pkt);
+    ip_version = IP::v4;
+    memcpy(src_ip.data(), &pkt.src_ip.v4, 4);
+    memcpy(dst_ip.data(), &pkt.dst_ip.v4, 4);
+    return *this;
 }
 
-flow_key_v4& flow_key_v4::save_reversed(const Packet &pkt)noexcept{
-   flow_key::save_reversed(pkt);
-   ip_version = IP::v4;
-   memcpy(src_ip.data(), &pkt.dst_ip.v4, 4);
-   memcpy(dst_ip.data(), &pkt.src_ip.v4, 4);
-   return *this;
+flow_key_v4& flow_key_v4::save_reversed(const Packet& pkt) noexcept
+{
+    flow_key::save_reversed(pkt);
+    ip_version = IP::v4;
+    memcpy(src_ip.data(), &pkt.dst_ip.v4, 4);
+    memcpy(dst_ip.data(), &pkt.src_ip.v4, 4);
+    return *this;
 }
 
-flow_key_v6& flow_key_v6::operator=(const Packet &pkt)noexcept{
-   flow_key::operator=(pkt);
-   ip_version = IP::v6;
-   memcpy(src_ip.data(), pkt.src_ip.v6, 16);
-   memcpy(dst_ip.data(), pkt.dst_ip.v6, 16);
-   return *this;
+flow_key_v6& flow_key_v6::operator=(const Packet& pkt) noexcept
+{
+    flow_key::operator=(pkt);
+    ip_version = IP::v6;
+    memcpy(src_ip.data(), pkt.src_ip.v6, 16);
+    memcpy(dst_ip.data(), pkt.dst_ip.v6, 16);
+    return *this;
 }
 
-flow_key_v6& flow_key_v6::save_reversed(const Packet &pkt)noexcept{
-   flow_key::save_reversed(pkt);
-   ip_version = IP::v6;
-   memcpy(src_ip.data(), pkt.dst_ip.v6, 16);
-   memcpy(dst_ip.data(), pkt.src_ip.v6, 16);
-   return *this;
+flow_key_v6& flow_key_v6::save_reversed(const Packet& pkt) noexcept
+{
+    flow_key::save_reversed(pkt);
+    ip_version = IP::v6;
+    memcpy(src_ip.data(), pkt.dst_ip.v6, 16);
+    memcpy(dst_ip.data(), pkt.src_ip.v6, 16);
+    return *this;
 }
 
 FlowRecord::FlowRecord()
 {
-   erase();
+    erase();
 }
 
 FlowRecord::~FlowRecord()
 {
-   erase();
+    erase();
 }
 
 void FlowRecord::erase()
 {
-   m_flow.remove_extensions();
-   m_hash = 0;
-
-   memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
-   memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
-   m_flow.ip_version = 0;
-   m_flow.ip_proto = 0;
-   memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
-   memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
-   m_flow.src_port = 0;
-   m_flow.dst_port = 0;
-   m_flow.src_packets = 0;
-   m_flow.dst_packets = 0;
-   m_flow.src_bytes = 0;
-   m_flow.dst_bytes = 0;
-   m_flow.src_tcp_flags = 0;
-   m_flow.dst_tcp_flags = 0;
+    m_flow.remove_extensions();
+    m_hash = 0;
+    memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
+    memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
+    m_flow.ip_version = 0;
+    m_flow.ip_proto = 0;
+    memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
+    memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
+    m_flow.src_port = 0;
+    m_flow.dst_port = 0;
+    m_flow.src_packets = 0;
+    m_flow.dst_packets = 0;
+    m_flow.src_bytes = 0;
+    m_flow.dst_bytes = 0;
+    m_flow.src_tcp_flags = 0;
+    m_flow.dst_tcp_flags = 0;
 }
 void FlowRecord::reuse()
 {
-   m_flow.remove_extensions();
-   m_flow.time_first = m_flow.time_last;
-   m_flow.src_packets = 0;
-   m_flow.dst_packets = 0;
-   m_flow.src_bytes = 0;
-   m_flow.dst_bytes = 0;
-   m_flow.src_tcp_flags = 0;
-   m_flow.dst_tcp_flags = 0;
+    m_flow.remove_extensions();
+    m_flow.time_first = m_flow.time_last;
+    m_flow.src_packets = 0;
+    m_flow.dst_packets = 0;
+    m_flow.src_bytes = 0;
+    m_flow.dst_bytes = 0;
+    m_flow.src_tcp_flags = 0;
+    m_flow.dst_tcp_flags = 0;
 }
 
 inline __attribute__((always_inline)) bool FlowRecord::is_empty() const
 {
-   return m_hash == 0;
+    return m_hash == 0;
 }
 
 inline __attribute__((always_inline)) bool FlowRecord::belongs(uint64_t hash) const
 {
-   return hash == m_hash;
+    return hash == m_hash;
 }
 
-void FlowRecord::create(const Packet &pkt, uint64_t hash)
+void FlowRecord::create(const Packet& pkt, uint64_t hash)
 {
-   m_flow.src_packets = 1;
+    m_flow.src_packets = 1;
 
-   m_hash = hash;
+    m_hash = hash;
 
-   m_flow.time_first = pkt.ts;
-   m_flow.time_last = pkt.ts;
-   m_flow.flow_hash = hash;
+    m_flow.time_first = pkt.ts;
+    m_flow.time_last = pkt.ts;
+    m_flow.flow_hash = hash;
 
-   memcpy(m_flow.src_mac, pkt.src_mac, 6);
-   memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
+    memcpy(m_flow.src_mac, pkt.src_mac, 6);
+    memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
 
-   if (pkt.ip_version == IP::v4) {
-      m_flow.ip_version = pkt.ip_version;
-      m_flow.ip_proto = pkt.ip_proto;
-      m_flow.src_ip.v4 = pkt.src_ip.v4;
-      m_flow.dst_ip.v4 = pkt.dst_ip.v4;
-      m_flow.src_bytes = pkt.ip_len;
-   } else if (pkt.ip_version == IP::v6) {
-      m_flow.ip_version = pkt.ip_version;
-      m_flow.ip_proto = pkt.ip_proto;
-      memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
-      memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
-      m_flow.src_bytes = pkt.ip_len;
-   }
+    if (pkt.ip_version == IP::v4) {
+        m_flow.ip_version = pkt.ip_version;
+        m_flow.ip_proto = pkt.ip_proto;
+        m_flow.src_ip.v4 = pkt.src_ip.v4;
+        m_flow.dst_ip.v4 = pkt.dst_ip.v4;
+        m_flow.src_bytes = pkt.ip_len;
+    } else if (pkt.ip_version == IP::v6) {
+        m_flow.ip_version = pkt.ip_version;
+        m_flow.ip_proto = pkt.ip_proto;
+        memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
+        memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
+        m_flow.src_bytes = pkt.ip_len;
+    }
 
-   if (pkt.ip_proto == IPPROTO_TCP) {
-      m_flow.src_port = pkt.src_port;
-      m_flow.dst_port = pkt.dst_port;
-      m_flow.src_tcp_flags = pkt.tcp_flags;
-   } else if (pkt.ip_proto == IPPROTO_UDP) {
-      m_flow.src_port = pkt.src_port;
-      m_flow.dst_port = pkt.dst_port;
-   } else if (pkt.ip_proto == IPPROTO_ICMP ||
-      pkt.ip_proto == IPPROTO_ICMPV6) {
-      m_flow.src_port = pkt.src_port;
-      m_flow.dst_port = pkt.dst_port;
-   }
+    if (pkt.ip_proto == IPPROTO_TCP) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+        m_flow.src_tcp_flags = pkt.tcp_flags;
+    } else if (pkt.ip_proto == IPPROTO_UDP) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+    } else if (pkt.ip_proto == IPPROTO_ICMP || pkt.ip_proto == IPPROTO_ICMPV6) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+    }
 }
 
-void FlowRecord::update(const Packet &pkt, bool src)
+void FlowRecord::update(const Packet& pkt, bool src)
 {
-   m_flow.time_last = pkt.ts;
-   if (src) {
-      m_flow.src_packets++;
-      m_flow.src_bytes += pkt.ip_len;
+    m_flow.time_last = pkt.ts;
+    if (src) {
+        m_flow.src_packets++;
+        m_flow.src_bytes += pkt.ip_len;
 
-      if (pkt.ip_proto == IPPROTO_TCP) {
-         m_flow.src_tcp_flags |= pkt.tcp_flags;
-      }
-   } else {
-      m_flow.dst_packets++;
-      m_flow.dst_bytes += pkt.ip_len;
+        if (pkt.ip_proto == IPPROTO_TCP) {
+            m_flow.src_tcp_flags |= pkt.tcp_flags;
+        }
+    } else {
+        m_flow.dst_packets++;
+        m_flow.dst_bytes += pkt.ip_len;
 
-      if (pkt.ip_proto == IPPROTO_TCP) {
-         m_flow.dst_tcp_flags |= pkt.tcp_flags;
-      }
-   }
+        if (pkt.ip_proto == IPPROTO_TCP) {
+            m_flow.dst_tcp_flags |= pkt.tcp_flags;
+        }
+    }
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-NHTFlowCache<NEED_FLOW_CACHE_STATS>::NHTFlowCache():
-    m_cache_size(0), m_line_size(0), m_line_mask(0), m_line_new_idx(0),
-    m_qsize(0), m_qidx(0), m_timeout_idx(0), m_active(0), m_inactive(0),
-    m_split_biflow(false), m_keylen(0), m_key(), m_key_inv(), m_flow_table(nullptr), m_flow_records(nullptr)
+NHTFlowCache<NEED_FLOW_CACHE_STATS>::NHTFlowCache()
+    : m_cache_size(0)
+    , m_line_size(0)
+    , m_line_mask(0)
+    , m_line_new_idx(0)
+    , m_qsize(0)
+    , m_qidx(0)
+    , m_timeout_idx(0)
+    , m_active(0)
+    , m_inactive(0)
+    , m_split_biflow(false)
+    , m_keylen(0)
+    , m_key()
+    , m_key_inv()
+    , m_flow_table(nullptr)
+    , m_flow_records(nullptr)
 {
-    //test_attributes();
+    test_attributes();
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
 NHTFlowCache<NEED_FLOW_CACHE_STATS>::~NHTFlowCache()
 {
-   NHTFlowCache::close();
+    NHTFlowCache::close();
 }
 
 NHTFlowCache<true>::~NHTFlowCache()
 {
-   print_report();
-   NHTFlowCache::close();
-}
-
-void NHTFlowCache<true>::print_cache_dump()const noexcept{
-   /*std::ofstream outfile;
-   outfile.open("cache_res.txt", std::ios_base::app);
-   const uint32_t field_count = sizeof(FlowRecord)/sizeof(uint32_t);
-   for(uint32_t i = 0; i < m_cache_size + m_qsize; i++)
-      for(uint32_t k = 0; k < field_count; k++)
-         outfile<<reinterpret_cast<uint32_t*>(&m_flow_records[i])[k];
-   outfile.close();*/
+    print_report();
+    NHTFlowCache::close();
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
 void NHTFlowCache<NEED_FLOW_CACHE_STATS>::test_attributes()
 {
-   static_assert(std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(), "Static checks of default cache sizes won't properly work without unsigned type.");
-   static_assert(bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE, "Flow cache size is too big to fit in variable!");
-   static_assert(bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE, "Flow cache line size is too big to fit in variable!");
-   static_assert(DEFAULT_FLOW_LINE_SIZE >= 1, "Flow cache line size must be at least 1!");
-   static_assert(DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE, "Flow cache size must be at least cache line size!");
+    static_assert(
+        std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(),
+        "Static checks of default cache sizes won't properly work without unsigned type.");
+    static_assert(
+        bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE,
+        "Flow cache size is too big to fit in variable!");
+    static_assert(
+        bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE,
+        "Flow cache line size is too big to fit in variable!");
+    static_assert(DEFAULT_FLOW_LINE_SIZE >= 1, "Flow cache line size must be at least 1!");
+    static_assert(
+        DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE,
+        "Flow cache size must be at least cache line size!");
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-void NHTFlowCache<NEED_FLOW_CACHE_STATS>::get_opts_from_parser(const CacheOptParser& parser){
-   m_cache_size = parser.m_cache_size;
-   m_line_size = parser.m_line_size;
-   m_active = parser.m_active;
-   m_inactive = parser.m_inactive;
-   m_split_biflow = parser.m_split_biflow;
-}
-
-template<bool NEED_FLOW_CACHE_STATS>
-void NHTFlowCache<NEED_FLOW_CACHE_STATS>::init(const char *params)
+void NHTFlowCache<NEED_FLOW_CACHE_STATS>::get_opts_from_parser(const CacheOptParser& parser)
 {
-   CacheOptParser parser;
-   try {
-      parser.parse(params);
-   } catch (ParserError &e) {
-      throw PluginError(e.what());
-   }
-
-   get_opts_from_parser(parser);
-   m_qidx = 0;
-   m_timeout_idx = 0;
-   m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
-   m_line_new_idx = m_line_size / 2;
-
-   if (m_export_queue == nullptr) {
-      throw PluginError("output queue must be set before init");
-   }
-
-   if (m_line_size > m_cache_size) {
-      throw PluginError("flow cache line size must be greater or equal to cache size");
-   }
-   if (m_cache_size == 0) {
-      throw PluginError("flow cache won't properly work with 0 records");
-   }
-
-   try {
-      m_flow_table = std::unique_ptr<FlowRecord*[]>(new FlowRecord*[m_cache_size + m_qsize]);
-      m_flow_records = std::unique_ptr<FlowRecord[]>(new FlowRecord[m_cache_size + m_qsize]);
-      for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
-         m_flow_table[i] = &m_flow_records[i];
-      }
-   } catch (std::bad_alloc &e) {
-      throw PluginError("not enough memory for flow cache allocation");
-   }
+    m_cache_size = parser.m_cache_size;
+    m_line_size = parser.m_line_size;
+    m_active = parser.m_active;
+    m_inactive = parser.m_inactive;
+    m_split_biflow = parser.m_split_biflow;
 }
-void NHTFlowCache<true>::init(const char *params){
-   NHTFlowCache<false>::init(params);
-   m_empty = 0;
-   m_not_empty = 0;
-   m_hits = 0;
-   m_expired = 0;
-   m_flushed = 0;
-   m_lookups = 0;
-   m_lookups2 = 0;
+
+template<bool NEED_FLOW_CACHE_STATS>
+void NHTFlowCache<NEED_FLOW_CACHE_STATS>::init(const char* params)
+{
+    CacheOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
+
+    get_opts_from_parser(parser);
+    m_qidx = 0;
+    m_timeout_idx = 0;
+    m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
+    m_line_new_idx = m_line_size / 2;
+
+    if (m_export_queue == nullptr) {
+        throw PluginError("output queue must be set before init");
+    }
+
+    if (m_line_size > m_cache_size) {
+        throw PluginError("flow cache line size must be greater or equal to cache size");
+    }
+    if (m_cache_size == 0) {
+        throw PluginError("flow cache won't properly work with 0 records");
+    }
+
+    try {
+        m_flow_table = std::unique_ptr<FlowRecord*[]>(new FlowRecord*[m_cache_size + m_qsize]);
+        m_flow_records = std::unique_ptr<FlowRecord[]>(new FlowRecord[m_cache_size + m_qsize]);
+        for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
+            m_flow_table[i] = &m_flow_records[i];
+        }
+    } catch (std::bad_alloc& e) {
+        throw PluginError("not enough memory for flow cache allocation");
+    }
+}
+void NHTFlowCache<true>::init(const char* params)
+{
+    NHTFlowCache<false>::init(params);
+    m_empty = 0;
+    m_not_empty = 0;
+    m_hits = 0;
+    m_expired = 0;
+    m_flushed = 0;
+    m_lookups = 0;
+    m_lookups2 = 0;
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
 void NHTFlowCache<NEED_FLOW_CACHE_STATS>::close()
 {
-   m_flow_records.reset();
-   m_flow_table.reset();
+    m_flow_records.reset();
+    m_flow_table.reset();
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-void NHTFlowCache<NEED_FLOW_CACHE_STATS>::set_queue(ipx_ring_t *queue)
+void NHTFlowCache<NEED_FLOW_CACHE_STATS>::set_queue(ipx_ring_t* queue)
 {
-   m_export_queue = queue;
-   m_qsize = ipx_ring_size(queue);
+    m_export_queue = queue;
+    m_qsize = ipx_ring_size(queue);
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
 void NHTFlowCache<NEED_FLOW_CACHE_STATS>::export_flow(size_t index)
 {
-   ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
-   std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
-   m_flow_table[index]->erase();
-   m_qidx = (m_qidx + 1) % m_qsize;
+    ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
+    std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
+    m_flow_table[index]->erase();
+    m_qidx = (m_qidx + 1) % m_qsize;
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
 void NHTFlowCache<NEED_FLOW_CACHE_STATS>::finish()
 {
-   for (decltype(m_cache_size) i = 0; i < m_cache_size; i++)
-      if (!m_flow_table[i]->is_empty())
-         prepare_and_export(i,FLOW_END_FORCED);
+    for (decltype(m_cache_size) i = 0; i < m_cache_size; i++)
+        if (!m_flow_table[i]->is_empty())
+            prepare_and_export(i, FLOW_END_FORCED);
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-void NHTFlowCache<NEED_FLOW_CACHE_STATS>::prepare_and_export(uint32_t flow_index) noexcept{
+void NHTFlowCache<NEED_FLOW_CACHE_STATS>::prepare_and_export(uint32_t flow_index) noexcept
+{
     plugins_pre_export(m_flow_table[flow_index]->m_flow);
-    m_flow_table[flow_index]->m_flow.end_reason = get_export_reason(m_flow_table[flow_index]->m_flow);
+    m_flow_table[flow_index]->m_flow.end_reason
+        = get_export_reason(m_flow_table[flow_index]->m_flow);
     export_flow(flow_index);
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-void NHTFlowCache<NEED_FLOW_CACHE_STATS>::prepare_and_export(uint32_t flow_index,uint32_t reason) noexcept{
-   plugins_pre_export(m_flow_table[flow_index]->m_flow);
-   m_flow_table[flow_index]->m_flow.end_reason = reason;
-   export_flow(flow_index);
-}
-
-void NHTFlowCache<true>::prepare_and_export(uint32_t flow_index) noexcept{
-   NHTFlowCache<false>::prepare_and_export(flow_index);
-   m_expired++;
-}
-
-void NHTFlowCache<true>::prepare_and_export(uint32_t flow_index,uint32_t reason) noexcept{
-   NHTFlowCache<false>::prepare_and_export(flow_index,reason);
-   m_expired++;
-}
-
-template<bool NEED_FLOW_CACHE_STATS>
-void NHTFlowCache<NEED_FLOW_CACHE_STATS>::flush(Packet &pkt, size_t flow_index, int ret, bool source_flow)
+void NHTFlowCache<NEED_FLOW_CACHE_STATS>::prepare_and_export(
+    uint32_t flow_index,
+    uint32_t reason) noexcept
 {
-   if (ret == FLOW_FLUSH_WITH_REINSERT) {
-      FlowRecord *flow = m_flow_table[flow_index];
-      flow->m_flow.end_reason = FLOW_END_FORCED;
-      ipx_ring_push(m_export_queue, &flow->m_flow);
-
-      std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
-
-      flow = m_flow_table[flow_index];
-      flow->m_flow.remove_extensions();
-      *flow = *m_flow_table[m_cache_size + m_qidx];
-      m_qidx = (m_qidx + 1) % m_qsize;
-
-      flow->m_flow.m_exts = nullptr;
-      flow->reuse(); // Clean counters, set time first to last
-      flow->update(pkt, source_flow); // Set new counters from packet
-
-      ret = plugins_post_create(flow->m_flow, pkt);
-      if (ret & FLOW_FLUSH) {
-         flush(pkt, flow_index, ret, source_flow);
-      }
-   } else {
-      m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
-      export_flow(flow_index);
-   }
+    plugins_pre_export(m_flow_table[flow_index]->m_flow);
+    m_flow_table[flow_index]->m_flow.end_reason = reason;
+    export_flow(flow_index);
 }
 
-void NHTFlowCache<true>::flush(Packet &pkt, size_t flow_index, int ret, bool source_flow)
+void NHTFlowCache<true>::prepare_and_export(uint32_t flow_index) noexcept
 {
-   m_flushed++;
-   NHTFlowCache<false>::flush(pkt,flow_index, ret,source_flow);
+    NHTFlowCache<false>::prepare_and_export(flow_index);
+    m_expired++;
+}
+
+void NHTFlowCache<true>::prepare_and_export(uint32_t flow_index, uint32_t reason) noexcept
+{
+    NHTFlowCache<false>::prepare_and_export(flow_index, reason);
+    m_expired++;
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-std::pair<bool,uint32_t> NHTFlowCache<NEED_FLOW_CACHE_STATS>::find_existing_record(uint32_t begin_line,uint32_t end_line,uint64_t hashval) const noexcept{
-   for (uint32_t flow_index = begin_line; flow_index < end_line; flow_index++) {
-      if (m_flow_table[flow_index]->belongs(hashval))
-         return {true,flow_index};
-   }
-   return {false,0};
+void NHTFlowCache<NEED_FLOW_CACHE_STATS>::flush(
+    Packet& pkt,
+    size_t flow_index,
+    int ret,
+    bool source_flow)
+{
+    if (ret == FLOW_FLUSH_WITH_REINSERT) {
+        FlowRecord* flow = m_flow_table[flow_index];
+        flow->m_flow.end_reason = FLOW_END_FORCED;
+        ipx_ring_push(m_export_queue, &flow->m_flow);
+
+        std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
+
+        flow = m_flow_table[flow_index];
+        flow->m_flow.remove_extensions();
+        *flow = *m_flow_table[m_cache_size + m_qidx];
+        m_qidx = (m_qidx + 1) % m_qsize;
+
+        flow->m_flow.m_exts = nullptr;
+        flow->reuse(); // Clean counters, set time first to last
+        flow->update(pkt, source_flow); // Set new counters from packet
+
+        ret = plugins_post_create(flow->m_flow, pkt);
+        if (ret & FLOW_FLUSH) {
+            flush(pkt, flow_index, ret, source_flow);
+        }
+    } else {
+        m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
+        export_flow(flow_index);
+    }
+}
+
+void NHTFlowCache<true>::flush(Packet& pkt, size_t flow_index, int ret, bool source_flow)
+{
+    m_flushed++;
+    NHTFlowCache<false>::flush(pkt, flow_index, ret, source_flow);
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-uint32_t  NHTFlowCache<NEED_FLOW_CACHE_STATS>::enhance_existing_flow_record(uint32_t flow_index,uint32_t line_index) noexcept{
-   auto flow = m_flow_table[flow_index];
-   for (decltype(flow_index) j = flow_index; j > line_index; j--) {
-      m_flow_table[j] = m_flow_table[j - 1];
-   }
-   m_flow_table[line_index] = flow;
-   return line_index;
-}
-
-uint32_t NHTFlowCache<true>::enhance_existing_flow_record(uint32_t flow_index,uint32_t line_index) noexcept{
-   m_lookups += (flow_index - line_index + 1);
-   m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
-   m_hits++;
-   return NHTFlowCache<false>::enhance_existing_flow_record(flow_index, line_index);
+std::pair<bool, uint32_t> NHTFlowCache<NEED_FLOW_CACHE_STATS>::find_existing_record(
+    uint32_t begin_line,
+    uint32_t end_line,
+    uint64_t hashval) const noexcept
+{
+    for (uint32_t flow_index = begin_line; flow_index < end_line; flow_index++) {
+        if (m_flow_table[flow_index]->belongs(hashval))
+            return {true, flow_index};
+    }
+    return {false, 0};
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-std::pair<bool,uint32_t> NHTFlowCache<NEED_FLOW_CACHE_STATS>::find_empty_place(uint32_t begin_line,uint32_t end_line) const noexcept{
-   for (uint32_t flow_index = begin_line; flow_index < end_line; flow_index++) {
-      if (m_flow_table[flow_index]->is_empty())
-         return {true,flow_index};
-   }
-   return {false,0};
+uint32_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::enhance_existing_flow_record(
+    uint32_t flow_index,
+    uint32_t line_index) noexcept
+{
+    auto flow = m_flow_table[flow_index];
+    for (decltype(flow_index) j = flow_index; j > line_index; j--) {
+        m_flow_table[j] = m_flow_table[j - 1];
+    }
+    m_flow_table[line_index] = flow;
+    return line_index;
 }
 
+uint32_t
+NHTFlowCache<true>::enhance_existing_flow_record(uint32_t flow_index, uint32_t line_index) noexcept
+{
+    m_lookups += (flow_index - line_index + 1);
+    m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
+    m_hits++;
+    return NHTFlowCache<false>::enhance_existing_flow_record(flow_index, line_index);
+}
 
 template<bool NEED_FLOW_CACHE_STATS>
-uint32_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_into_free_place(uint32_t flow_index,bool empty_place_found,uint32_t begin_line,uint32_t end_line) noexcept
+std::pair<bool, uint32_t> NHTFlowCache<NEED_FLOW_CACHE_STATS>::find_empty_place(
+    uint32_t begin_line,
+    uint32_t end_line) const noexcept
+{
+    for (uint32_t flow_index = begin_line; flow_index < end_line; flow_index++) {
+        if (m_flow_table[flow_index]->is_empty())
+            return {true, flow_index};
+    }
+    return {false, 0};
+}
+
+template<bool NEED_FLOW_CACHE_STATS>
+uint32_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_into_free_place(
+    uint32_t flow_index,
+    bool empty_place_found,
+    uint32_t begin_line,
+    uint32_t end_line) noexcept
 {
     /* If free place was not found (flow line is full), find
-        * record which will be replaced by new record. */
+     * record which will be replaced by new record. */
     if (empty_place_found)
-      return flow_index;
-    prepare_and_export(end_line - 1,FLOW_END_NO_RES);
+        return flow_index;
+    prepare_and_export(end_line - 1, FLOW_END_NO_RES);
     uint32_t flow_new_index = begin_line + m_line_new_idx;
 
     auto flow = m_flow_table[flow_index];
@@ -453,201 +494,209 @@ uint32_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_into_free_place(uint32_t flow_
     return flow_new_index;
 }
 
-uint32_t NHTFlowCache<true>::put_into_free_place(uint32_t flow_index,bool empty_place_found,uint32_t begin_line,uint32_t end_line) noexcept{
-   if (empty_place_found)
-      m_empty++;
-   else
-      m_not_empty++;
-   return NHTFlowCache<false>::put_into_free_place(flow_index,empty_place_found,begin_line,end_line);
-}
-
-/*template<bool NEED_FLOW_CACHE_STATS>
-uint32_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_new_flow_record(uint32_t flow_index,uint32_t begin_line,uint32_t end_line) noexcept{
-   auto res = find_empty_place(begin_line,end_line);
-   bool empty_place_found = res.first;
-   return put_into_free_place(flow_index,empty_place_found,begin_line,end_line);
-}*/
-
-template<bool NEED_FLOW_CACHE_STATS>
-bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::processing_last_tcp_packet(Packet& pkt,uint32_t flow_index) noexcept{
-   uint8_t flw_flags = pkt.source_pkt ? m_flow_table[flow_index]->m_flow.src_tcp_flags : m_flow_table[flow_index]->m_flow.dst_tcp_flags;
-   if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
-      // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
-      m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
-      export_flow(flow_index);
-      put_pkt(pkt);
-      return true;
-   }
-   return false;
+uint32_t NHTFlowCache<true>::put_into_free_place(
+    uint32_t flow_index,
+    bool empty_place_found,
+    uint32_t begin_line,
+    uint32_t end_line) noexcept
+{
+    if (empty_place_found)
+        m_empty++;
+    else
+        m_not_empty++;
+    return NHTFlowCache<false>::put_into_free_place(
+        flow_index,
+        empty_place_found,
+        begin_line,
+        end_line);
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::create_new_flow(uint32_t flow_index, Packet& pkt,uint64_t hashval) noexcept{
-   m_flow_table[flow_index]->create(pkt, hashval);
-   auto ret = plugins_post_create(m_flow_table[flow_index]->m_flow, pkt);
-   if (ret & FLOW_FLUSH) {
-      export_flow(flow_index);
-      return true;
-   }
-   return false;
-}
-bool NHTFlowCache<true>::create_new_flow(uint32_t flow_index, Packet& pkt,uint64_t hashval) noexcept{
-   if (NHTFlowCache<false>::create_new_flow(flow_index,pkt,hashval))
-      m_flushed++;
-   return true;
-}
-
-
-template<bool NEED_FLOW_CACHE_STATS>
-bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::flush_and_update_flow(uint32_t flow_index,Packet& pkt) noexcept{
-    auto ret = plugins_pre_update(m_flow_table[flow_index]->m_flow, pkt);
-    if (ret & FLOW_FLUSH) {
-      flush(pkt, flow_index, ret, pkt.source_pkt);
-      return true;
-    } else {
-      m_flow_table[flow_index]->update(pkt, pkt.source_pkt);
-      ret = plugins_post_update(m_flow_table[flow_index]->m_flow, pkt);
-      if (ret & FLOW_FLUSH) {
-         flush(pkt, flow_index, ret, pkt.source_pkt);
-         return true;
-      }
+bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::process_last_tcp_packet(
+    Packet& pkt,
+    uint32_t flow_index) noexcept
+{
+    uint8_t flw_flags = pkt.source_pkt ? m_flow_table[flow_index]->m_flow.src_tcp_flags
+                                       : m_flow_table[flow_index]->m_flow.dst_tcp_flags;
+    if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
+        // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
+        m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
+        export_flow(flow_index);
+        put_pkt(pkt);
+        return true;
     }
     return false;
 }
 
-int NHTFlowCache<true>::put_pkt(Packet &pkt){
-    print_cache_dump();
-    return NHTFlowCache<false>::put_pkt(pkt);
+template<bool NEED_FLOW_CACHE_STATS>
+bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::create_new_flow(
+    uint32_t flow_index,
+    Packet& pkt,
+    uint64_t hashval) noexcept
+{
+    m_flow_table[flow_index]->create(pkt, hashval);
+    auto ret = plugins_post_create(m_flow_table[flow_index]->m_flow, pkt);
+    if (ret & FLOW_FLUSH) {
+        export_flow(flow_index);
+        return true;
+    }
+    return false;
+}
+bool NHTFlowCache<true>::create_new_flow(
+    uint32_t flow_index,
+    Packet& pkt,
+    uint64_t hashval) noexcept
+{
+    if (NHTFlowCache<false>::create_new_flow(flow_index, pkt, hashval))
+        m_flushed++;
+    return true;
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-int NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_pkt(Packet &pkt)
+bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::flush_and_update_flow(
+    uint32_t flow_index,
+    Packet& pkt) noexcept
 {
-    m_order++;
-   plugins_pre_create(pkt);
-   if (!create_hash_key(pkt)) // saves key value and key length into attributes NHTFlowCache::key and NHTFlowCache::m_keylen
-      return 0;
-   uint64_t hashval = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
-   //FlowRecord *flow; /* Pointer to flow we will be working with. */
-   bool source_flow = true;
-   uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
-   uint32_t next_line = line_index + m_line_size;
+    auto ret = plugins_pre_update(m_flow_table[flow_index]->m_flow, pkt);
+    if (ret & FLOW_FLUSH) {
+        flush(pkt, flow_index, ret, pkt.source_pkt);
+        return true;
+    } else {
+        m_flow_table[flow_index]->update(pkt, pkt.source_pkt);
+        ret = plugins_post_update(m_flow_table[flow_index]->m_flow, pkt);
+        if (ret & FLOW_FLUSH) {
+            flush(pkt, flow_index, ret, pkt.source_pkt);
+            return true;
+        }
+    }
+    return false;
+}
 
-   /* Find existing flow record in flow cache. */
-   auto res = find_existing_record(line_index,next_line,hashval);
-   bool found = res.first;
-   uint32_t flow_index = res.second;
+template<bool NEED_FLOW_CACHE_STATS>
+int NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_pkt(Packet& pkt)
+{
+    plugins_pre_create(pkt);
+    if (!create_hash_key(pkt)) // saves key value and key length into attributes NHTFlowCache::key
+                               // and NHTFlowCache::m_keylen
+        return 0;
+    uint64_t hashval
+        = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
+    bool source_flow = true;
+    uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
+    uint32_t next_line = line_index + m_line_size;
 
-   /* Find inversed flow. */
-   if (!found && !m_split_biflow) {
-      uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
-      uint64_t line_index_inv = hashval_inv & m_line_mask;
-      uint64_t next_line_inv = line_index_inv + m_line_size;
-      res = find_existing_record(line_index_inv,next_line_inv,hashval_inv);
-      found = res.first;
-      if (found) {
-         //std::cout<< m_order << " was found directly\n";
-         flow_index = res.second;
-         source_flow = false;
-         hashval = hashval_inv;
-         line_index = line_index_inv;
-      }
-   }
+    auto res = find_existing_record(line_index, next_line, hashval);
+    bool found = res.first;
+    uint32_t flow_index = res.second;
 
-   /* Existing flow record was found, put flow record at the first index of flow line. */
-   if (found) {
-      flow_index = enhance_existing_flow_record(flow_index, line_index);
-      //std::cout<< m_order << " was found reversely\n";
-      /* Existing flow record was not found. Find free place in flow line or replace some existing record. */
-   }else{
-      ///std::cout<< m_order << " was not found\n";
-      res = find_empty_place(line_index,next_line);
-      bool empty_place_found = res.first;
-      flow_index = res.second;
-      flow_index = put_into_free_place(flow_index,empty_place_found,line_index,next_line);
-   }
+    /* Find inversed flow. */
+    if (!found && !m_split_biflow) {
+        uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
+        uint64_t line_index_inv = hashval_inv & m_line_mask;
+        uint64_t next_line_inv = line_index_inv + m_line_size;
+        res = find_existing_record(line_index_inv, next_line_inv, hashval_inv);
+        found = res.first;
+        if (found) {
+            flow_index = res.second;
+            source_flow = false;
+            hashval = hashval_inv;
+            line_index = line_index_inv;
+        }
+    }
 
-   pkt.source_pkt = source_flow;
-   if (processing_last_tcp_packet(pkt,flow_index))
-      return 0;
+    /* Existing flow record was found, put flow record at the first index of flow line. */
+    if (found) {
+        flow_index = enhance_existing_flow_record(flow_index, line_index);
+        /* Existing flow record was not found. Find free place in flow line or replace some existing
+         * record. */
+    } else {
+        res = find_empty_place(line_index, next_line);
+        bool empty_place_found = res.first;
+        flow_index = res.second;
+        flow_index = put_into_free_place(flow_index, empty_place_found, line_index, next_line);
+    }
+
+    pkt.source_pkt = source_flow;
+    if (process_last_tcp_packet(pkt, flow_index))
+        return 0;
 
     if (m_flow_table[flow_index]->is_empty())
-        create_new_flow(flow_index,pkt,hashval);
-    else{
+        create_new_flow(flow_index, pkt, hashval);
+    else {
         /* Check if flow record is expired (inactive timeout). */
-         if (pkt.ts.tv_sec - m_flow_table[flow_index]->m_flow.time_last.tv_sec >= m_inactive) {
-             prepare_and_export(flow_index);
-             return put_pkt(pkt);
-         }
-         /* Check if flow record is expired (active timeout). */
-         if (pkt.ts.tv_sec - m_flow_table[flow_index]->m_flow.time_first.tv_sec >= m_active) {
-             prepare_and_export(flow_index,FLOW_END_ACTIVE);
-             return put_pkt(pkt);
-         }
-        if (flush_and_update_flow(flow_index,pkt))
-         return 0;
-   }
-   export_expired(pkt.ts.tv_sec);
-   return 0;
+        if (pkt.ts.tv_sec - m_flow_table[flow_index]->m_flow.time_last.tv_sec >= m_inactive) {
+            prepare_and_export(flow_index);
+            return put_pkt(pkt);
+        }
+        /* Check if flow record is expired (active timeout). */
+        if (pkt.ts.tv_sec - m_flow_table[flow_index]->m_flow.time_first.tv_sec >= m_active) {
+            prepare_and_export(flow_index, FLOW_END_ACTIVE);
+            return put_pkt(pkt);
+        }
+        if (flush_and_update_flow(flow_index, pkt))
+            return 0;
+    }
+    export_expired(pkt.ts.tv_sec);
+    return 0;
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-uint8_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::get_export_reason(Flow &flow)
+uint8_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::get_export_reason(Flow& flow)
 {
-   if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
-      // When FIN or RST is set, TCP connection ended naturally
-      return FLOW_END_EOF;
-   } else {
-      return FLOW_END_INACTIVE;
-   }
+    if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
+        // When FIN or RST is set, TCP connection ended naturally
+        return FLOW_END_EOF;
+    } else {
+        return FLOW_END_INACTIVE;
+    }
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
 void NHTFlowCache<NEED_FLOW_CACHE_STATS>::export_expired(time_t ts)
 {
-   for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
-      if (!m_flow_table[i]->is_empty() && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
-         prepare_and_export(i);
-      }
-   }
-   m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
+    for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
+        if (!m_flow_table[i]->is_empty()
+            && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
+            prepare_and_export(i);
+        }
+    }
+    m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
 }
 
 template<bool NEED_FLOW_CACHE_STATS>
-bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::create_hash_key(const Packet &pkt) noexcept
+bool NHTFlowCache<NEED_FLOW_CACHE_STATS>::create_hash_key(const Packet& pkt) noexcept
 {
-   if (pkt.ip_version == IP::v4) {
-      auto key_v4 = reinterpret_cast<struct flow_key_v4*>(m_key);
-      auto key_v4_inv = reinterpret_cast<struct flow_key_v4*>(m_key_inv);
+    if (pkt.ip_version == IP::v4) {
+        auto key_v4 = reinterpret_cast<struct flow_key_v4*>(m_key);
+        auto key_v4_inv = reinterpret_cast<struct flow_key_v4*>(m_key_inv);
 
-      *key_v4 = pkt;
-      key_v4_inv->save_reversed(pkt);
-      m_keylen = sizeof(flow_key_v4);
-      return true;
-   }
-   if (pkt.ip_version == IP::v6) {
-      auto key_v6 = reinterpret_cast<struct flow_key_v6*>(m_key);
-      auto key_v6_inv = reinterpret_cast<struct flow_key_v6*>(m_key_inv);
+        *key_v4 = pkt;
+        key_v4_inv->save_reversed(pkt);
+        m_keylen = sizeof(flow_key_v4);
+        return true;
+    }
+    if (pkt.ip_version == IP::v6) {
+        auto key_v6 = reinterpret_cast<struct flow_key_v6*>(m_key);
+        auto key_v6_inv = reinterpret_cast<struct flow_key_v6*>(m_key_inv);
 
-      *key_v6 = pkt;
-      key_v6_inv->save_reversed(pkt);
-      m_keylen = sizeof(flow_key_v6);
-      return true;
-   }
-   return false;
+        *key_v6 = pkt;
+        key_v6_inv->save_reversed(pkt);
+        m_keylen = sizeof(flow_key_v6);
+        return true;
+    }
+    return false;
 }
 
 void NHTFlowCache<true>::print_report() const noexcept
 {
-   float tmp = float(m_lookups) / m_hits;
-   std::cout << "Hits: " << m_hits << std::endl;
-   std::cout << "Empty: " << m_empty << std::endl;
-   std::cout << "Not empty: " << m_not_empty << std::endl;
-   std::cout << "Expired: " << m_expired << std::endl;
-   std::cout << "Flushed: " << m_flushed << std::endl;
-   std::cout << "Average Lookup:  " << tmp << std::endl;
-   std::cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << std::endl;
+    float tmp = float(m_lookups) / m_hits;
+    std::cout << "Hits: " << m_hits << std::endl;
+    std::cout << "Empty: " << m_empty << std::endl;
+    std::cout << "Not empty: " << m_not_empty << std::endl;
+    std::cout << "Expired: " << m_expired << std::endl;
+    std::cout << "Flushed: " << m_flushed << std::endl;
+    std::cout << "Average Lookup:  " << tmp << std::endl;
+    std::cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << std::endl;
 }
 
-
-}
+} // namespace ipxp

--- a/storage/cache.cpp
+++ b/storage/cache.cpp
@@ -471,6 +471,7 @@ std::pair<bool, uint32_t> NHTFlowCache<NEED_FLOW_CACHE_STATS>::find_empty_place(
         if (m_flow_table[flow_index]->is_empty())
             return {true, flow_index};
     }
+    //No empty place was found.
     return {false, 0};
 }
 
@@ -582,7 +583,6 @@ int NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_pkt(Packet& pkt)
         return 0;
     /* Calculates hash value from key created before. */
     uint64_t hashval = XXH64(m_key, m_keylen, 0);
-    //std::cerr<< hashval << std::endl;
     bool source_flow = true;
 
     /* Get index of flow line. */
@@ -644,13 +644,12 @@ int NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_pkt(Packet& pkt)
     return 0;
 }
 
-
-    int NHTFlowCache<true>::put_pkt(Packet& pkt){
-        auto start = std::chrono::high_resolution_clock::now();
-        auto res = NHTFlowCache<false>::put_pkt(pkt);
-        m_put_time += std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start).count();
-        return res;
-    }
+int NHTFlowCache<true>::put_pkt(Packet& pkt){
+    auto start = std::chrono::high_resolution_clock::now();
+    auto res = NHTFlowCache<false>::put_pkt(pkt);
+    m_put_time += std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start).count();
+    return res;
+}
 
 template<bool NEED_FLOW_CACHE_STATS>
 uint8_t NHTFlowCache<NEED_FLOW_CACHE_STATS>::get_export_reason(Flow& flow)

--- a/storage/cache.cpp
+++ b/storage/cache.cpp
@@ -582,6 +582,7 @@ int NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_pkt(Packet& pkt)
         return 0;
     /* Calculates hash value from key created before. */
     uint64_t hashval = XXH64(m_key, m_keylen, 0);
+    //std::cerr<< hashval << std::endl;
     bool source_flow = true;
 
     /* Get index of flow line. */

--- a/storage/cache.cpp
+++ b/storage/cache.cpp
@@ -708,7 +708,7 @@ void NHTFlowCache<true>::print_report() const noexcept
     std::cout << "Flushed: " << m_flushed << std::endl;
     std::cout << "Average Lookup:  " << tmp << std::endl;
     std::cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << std::endl;
-    std::cout << "Spent in put_pkt: " << m_put_time << " us" << std::endl;
+    //std::cout << "Spent in put_pkt: " << m_put_time << " us" << std::endl;
 }
 
 } // namespace ipxp

--- a/storage/cache.cpp
+++ b/storage/cache.cpp
@@ -30,22 +30,23 @@
  *
  */
 
-#include <cstdlib>
-#include <cstring>
-#include <iostream>
-#include <sys/time.h>
-#include <chrono>
 #include "cache.hpp"
 #include "xxhash.h"
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <ipfixprobe/ring.h>
+#include <sys/time.h>
 
 namespace ipxp {
 
 __attribute__((constructor)) static void register_this_plugin() noexcept
 {
-    static PluginRecord rec = PluginRecord("cache", []() { return new NHTFlowCache<PRINT_FLOW_CACHE_STATS>(); });
+    static PluginRecord rec
+        = PluginRecord("cache", []() { return new NHTFlowCache<PRINT_FLOW_CACHE_STATS>(); });
     register_plugin(&rec);
 }
 
@@ -471,7 +472,7 @@ std::pair<bool, uint32_t> NHTFlowCache<NEED_FLOW_CACHE_STATS>::find_empty_place(
         if (m_flow_table[flow_index]->is_empty())
             return {true, flow_index};
     }
-    //No empty place was found.
+    // No empty place was found.
     return {false, 0};
 }
 
@@ -644,10 +645,13 @@ int NHTFlowCache<NEED_FLOW_CACHE_STATS>::put_pkt(Packet& pkt)
     return 0;
 }
 
-int NHTFlowCache<true>::put_pkt(Packet& pkt){
+int NHTFlowCache<true>::put_pkt(Packet& pkt)
+{
     auto start = std::chrono::high_resolution_clock::now();
     auto res = NHTFlowCache<false>::put_pkt(pkt);
-    m_put_time += std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start).count();
+    m_put_time += std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::high_resolution_clock::now() - start)
+                      .count();
     return res;
 }
 
@@ -708,7 +712,7 @@ void NHTFlowCache<true>::print_report() const noexcept
     std::cout << "Flushed: " << m_flushed << std::endl;
     std::cout << "Average Lookup:  " << tmp << std::endl;
     std::cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << std::endl;
-    //std::cout << "Spent in put_pkt: " << m_put_time << " us" << std::endl;
+    // std::cout << "Spent in put_pkt: " << m_put_time << " us" << std::endl;
 }
 
 } // namespace ipxp

--- a/storage/cache.hpp
+++ b/storage/cache.hpp
@@ -198,11 +198,11 @@ protected:
    static constexpr uint32_t m_default_flow_cache_size = DEFAULT_FLOW_CACHE_SIZE;
    static constexpr const uint32_t m_default_flow_line_size =  DEFAULT_FLOW_LINE_SIZE;
 
-   void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow);
+   virtual void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow);
    bool create_hash_key(const Packet &pkt) noexcept;
    void export_flow(size_t index);
    static uint8_t get_export_reason(Flow &flow);
-   void finish();
+   void finish() override;
    void get_opts_from_parser(const CacheOptParser& parser);
    static void test_attributes();
    std::enable_if<PRINT_FLOW_CACHE_STATS,void> print_report();
@@ -236,6 +236,8 @@ class NHTFlowCache<true> : public NHTFlowCache<false>{
    bool export_inactive_timeout(Packet& pkt,uint32_t flow_index) noexcept override;
    bool export_active_timeout(Packet& pkt,uint32_t flow_index) noexcept override;
    void print_report() const noexcept;
+   void export_expired(time_t ts)noexcept override;
+   void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow) override;
 };
 
 }

--- a/storage/cache.hpp
+++ b/storage/cache.hpp
@@ -32,9 +32,9 @@
 #ifndef IPXP_STORAGE_CACHE_HPP
 #define IPXP_STORAGE_CACHE_HPP
 
-#include <string>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include <array>
 #include <ipfixprobe/flowifc.hpp>
@@ -45,213 +45,237 @@
 namespace ipxp {
 
 template<uint16_t IPSize>
-struct __attribute__((packed)) flow_key{
+struct __attribute__((packed)) flow_key {
     uint16_t src_port;
     uint16_t dst_port;
     uint8_t proto;
     uint8_t ip_version;
-    std::array<uint8_t,IPSize> src_ip;
-    std::array<uint8_t,IPSize> dst_ip;
+    std::array<uint8_t, IPSize> src_ip;
+    std::array<uint8_t, IPSize> dst_ip;
     uint16_t vlan_id;
-    flow_key<IPSize>& operator=(const Packet &pkt)noexcept;
-    flow_key<IPSize>& save_reversed(const Packet &pkt)noexcept;
+    flow_key<IPSize>& operator=(const Packet& pkt) noexcept;
+    flow_key<IPSize>& save_reversed(const Packet& pkt) noexcept;
 };
-struct __attribute__((packed)) flow_key_v4 : public flow_key<4>{
-    flow_key_v4& operator=(const Packet &pkt)noexcept;
-    flow_key_v4& save_reversed(const Packet &pkt)noexcept;
+struct __attribute__((packed)) flow_key_v4 : public flow_key<4> {
+    flow_key_v4& operator=(const Packet& pkt) noexcept;
+    flow_key_v4& save_reversed(const Packet& pkt) noexcept;
 };
-struct __attribute__((packed)) flow_key_v6 : public flow_key<16>{
-    flow_key_v6& operator=(const Packet &pkt)noexcept;
-    flow_key_v6& save_reversed(const Packet &pkt)noexcept;
+struct __attribute__((packed)) flow_key_v6 : public flow_key<16> {
+    flow_key_v6& operator=(const Packet& pkt) noexcept;
+    flow_key_v6& save_reversed(const Packet& pkt) noexcept;
 };
-/*struct __attribute__((packed)) flow_key_v4 {
-   uint16_t src_port;
-   uint16_t dst_port;
-   uint8_t proto;
-   uint8_t ip_version;
-   uint32_t src_ip;
-   uint32_t dst_ip;
-   uint16_t vlan_id;
-
-
-};
-
-struct __attribute__((packed)) flow_key_v6 {
-   uint16_t src_port;
-   uint16_t dst_port;
-   uint8_t proto;
-   uint8_t ip_version;
-   uint8_t src_ip[16];
-   uint8_t dst_ip[16];
-   uint16_t vlan_id;
-
-};*/
-
 
 #ifdef FLOW_CACHE_STATS
-    static const constexpr bool PRINT_FLOW_CACHE_STATS = true;
+static const constexpr bool PRINT_FLOW_CACHE_STATS = true;
 #else
-    static const constexpr bool PRINT_FLOW_CACHE_STATS = false;
+static const constexpr bool PRINT_FLOW_CACHE_STATS = false;
 #endif /* FLOW_CACHE_STATS */
 
 #ifdef IPXP_FLOW_CACHE_SIZE
-    static const uint32_t DEFAULT_FLOW_CACHE_SIZE = IPXP_FLOW_CACHE_SIZE;
+static const uint32_t DEFAULT_FLOW_CACHE_SIZE = IPXP_FLOW_CACHE_SIZE;
 #else
-    static const uint32_t DEFAULT_FLOW_CACHE_SIZE = 17; // 131072 records total
+static const uint32_t DEFAULT_FLOW_CACHE_SIZE = 17; // 131072 records total
 #endif /* IPXP_FLOW_CACHE_SIZE */
 
 #ifdef IPXP_FLOW_LINE_SIZE
-    static const uint32_t DEFAULT_FLOW_LINE_SIZE = IPXP_FLOW_LINE_SIZE;
+static const uint32_t DEFAULT_FLOW_LINE_SIZE = IPXP_FLOW_LINE_SIZE;
 #else
-    static const uint32_t DEFAULT_FLOW_LINE_SIZE = 4; // 16 records per line
+static const uint32_t DEFAULT_FLOW_LINE_SIZE = 4; // 16 records per line
 #endif /* IPXP_FLOW_LINE_SIZE */
 
-class CacheOptParser : public OptionsParser
-{
+class CacheOptParser : public OptionsParser {
 public:
-   uint32_t m_cache_size;
-   uint32_t m_line_size;
-   uint32_t m_active = 300;
-   uint32_t m_inactive = 30;
-   bool m_split_biflow;
+    uint32_t m_cache_size;
+    uint32_t m_line_size;
+    uint32_t m_active = 300;
+    uint32_t m_inactive = 30;
+    bool m_split_biflow;
 
-   CacheOptParser() : OptionsParser("cache", "Storage plugin implemented as a hash table"),
-      m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE), m_line_size(1 << DEFAULT_FLOW_LINE_SIZE),m_split_biflow(false)
-   {
-      register_option("s", "size", "EXPONENT", "Cache size exponent to the power of two",
-         [this](const char *arg){try {unsigned exp = str2num<decltype(exp)>(arg);
-               if (exp < 4 || exp > 30) {
-                  throw PluginError("Flow cache size must be between 4 and 30");
-               }
-               m_cache_size = static_cast<uint32_t>(1) << exp;
-            } catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("l", "line", "EXPONENT", "Cache line size exponent to the power of two",
-         [this](const char *arg){try {m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
-               if (m_line_size < 1) {
-                  throw PluginError("Flow cache line size must be at least 1");
-               }
-            } catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("a", "active", "TIME", "Active timeout in seconds",
-         [this](const char *arg){try {m_active = str2num<decltype(m_active)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("i", "inactive", "TIME", "Inactive timeout in seconds",
-         [this](const char *arg){try {m_inactive = str2num<decltype(m_inactive)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-         OptionFlags::RequiredArgument);
-      register_option("S", "split", "", "Split biflows into uniflows",
-         [this](const char *arg){ m_split_biflow = true; return true;}, OptionFlags::NoArgument);
-   }
+    CacheOptParser()
+        : OptionsParser("cache", "Storage plugin implemented as a hash table")
+        , m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE)
+        , m_line_size(1 << DEFAULT_FLOW_LINE_SIZE)
+        , m_split_biflow(false)
+    {
+        register_option(
+            "s",
+            "size",
+            "EXPONENT",
+            "Cache size exponent to the power of two",
+            [this](const char* arg) {
+                try {
+                    unsigned exp = str2num<decltype(exp)>(arg);
+                    if (exp < 4 || exp > 30) {
+                        throw PluginError("Flow cache size must be between 4 and 30");
+                    }
+                    m_cache_size = static_cast<uint32_t>(1) << exp;
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "l",
+            "line",
+            "EXPONENT",
+            "Cache line size exponent to the power of two",
+            [this](const char* arg) {
+                try {
+                    m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
+                    if (m_line_size < 1) {
+                        throw PluginError("Flow cache line size must be at least 1");
+                    }
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "a",
+            "active",
+            "TIME",
+            "Active timeout in seconds",
+            [this](const char* arg) {
+                try {
+                    m_active = str2num<decltype(m_active)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "i",
+            "inactive",
+            "TIME",
+            "Inactive timeout in seconds",
+            [this](const char* arg) {
+                try {
+                    m_inactive = str2num<decltype(m_inactive)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "S",
+            "split",
+            "",
+            "Split biflows into uniflows",
+            [this](const char* arg) {
+                m_split_biflow = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-class FlowRecord
-{
-   uint64_t m_hash;
+class FlowRecord {
+    uint64_t m_hash;
 
 public:
-   Flow m_flow;
+    Flow m_flow;
 
-   FlowRecord();
-   ~FlowRecord();
+    FlowRecord();
+    ~FlowRecord();
 
-   void erase();
-   void reuse();
+    void erase();
+    void reuse();
 
-   inline bool is_empty() const;
-   inline bool belongs(uint64_t pkt_hash) const;
-   void create(const Packet &pkt, uint64_t pkt_hash);
-   void update(const Packet &pkt, bool src);
+    inline bool is_empty() const;
+    inline bool belongs(uint64_t pkt_hash) const;
+    void create(const Packet& pkt, uint64_t pkt_hash);
+    void update(const Packet& pkt, bool src);
 };
 
 template<bool NEED_FLOW_CACHE_STATS = false>
 class NHTFlowCache : public StoragePlugin {
-   public:
-   NHTFlowCache();
-   ~NHTFlowCache() override;
-   void init(const char* params) override;
-   void close() override;
-   void set_queue(ipx_ring_t* queue) override;
-   OptionsParser* get_parser() const override { return new CacheOptParser(); }
-   std::string get_name() const override { return "cache"; }
+public:
+    NHTFlowCache();
+    ~NHTFlowCache() override;
+    void init(const char* params) override;
+    void close() override;
+    void set_queue(ipx_ring_t* queue) override;
+    OptionsParser* get_parser() const override { return new CacheOptParser(); }
+    std::string get_name() const override { return "cache"; }
 
-   int put_pkt(Packet& pkt) override;
-   void export_expired(time_t ts) override;
+    int put_pkt(Packet& pkt) override;
+    void export_expired(time_t ts) override;
 
-   protected:
-   uint32_t m_cache_size;
-   uint32_t m_line_size;
-   uint32_t m_line_mask;
-   uint32_t m_line_new_idx;
-   uint32_t m_qsize;
-   uint32_t m_qidx;
-   uint32_t m_timeout_idx;
-   uint32_t m_active;
-   uint32_t m_inactive;
-   bool m_split_biflow;
-   uint8_t m_keylen;
-   char m_key[max<size_t>(sizeof(flow_key_v4), sizeof(flow_key_v6))];
-   char m_key_inv[max<size_t>(sizeof(flow_key_v4), sizeof(flow_key_v6))];
-   std::unique_ptr<FlowRecord*[]> m_flow_table;
-   std::unique_ptr<FlowRecord[]> m_flow_records;
+protected:
+    uint32_t m_cache_size;
+    uint32_t m_line_size;
+    uint32_t m_line_mask;
+    uint32_t m_line_new_idx;
+    uint32_t m_qsize;
+    uint32_t m_qidx;
+    uint32_t m_timeout_idx;
+    uint32_t m_active;
+    uint32_t m_inactive;
+    bool m_split_biflow;
+    uint8_t m_keylen;
+    char m_key[max<size_t>(sizeof(flow_key_v4), sizeof(flow_key_v6))];
+    char m_key_inv[max<size_t>(sizeof(flow_key_v4), sizeof(flow_key_v6))];
+    std::unique_ptr<FlowRecord*[]> m_flow_table;
+    std::unique_ptr<FlowRecord[]> m_flow_records;
 
-   static constexpr uint32_t m_default_flow_cache_size = DEFAULT_FLOW_CACHE_SIZE;
-   static constexpr const uint32_t m_default_flow_line_size = DEFAULT_FLOW_LINE_SIZE;
+    virtual void flush(Packet& pkt, size_t flow_index, int ret, bool source_flow);
+    bool create_hash_key(const Packet& pkt) noexcept;
+    void export_flow(size_t index);
+    static uint8_t get_export_reason(Flow& flow);
+    void finish() override;
+    void get_opts_from_parser(const CacheOptParser& parser);
 
-   virtual void flush(Packet& pkt, size_t flow_index, int ret, bool source_flow);
-   bool create_hash_key(const Packet& pkt) noexcept;
-   void export_flow(size_t index);
-   static uint8_t get_export_reason(Flow& flow);
-   void finish() override;
-   void get_opts_from_parser(const CacheOptParser& parser);
-   static void test_attributes();
-   //std::enable_if<PRINT_FLOW_CACHE_STATS, void> print_report();
-   std::pair<bool, uint32_t>
-   find_existing_record(uint32_t begin_line, uint32_t end_line, uint64_t hashval) const noexcept;
-   virtual uint32_t enhance_existing_flow_record(uint32_t flow_index, uint32_t line_index) noexcept;
-   std::pair<bool, uint32_t>
-   find_empty_place(uint32_t begin_line, uint32_t end_line) const noexcept;
-   //virtual void free_index(uint32_t flow_index) noexcept;
-  // virtual uint32_t put_new_flow_record(uint32_t flow_index, uint32_t begin_line, uint32_t end_line) noexcept;
-   virtual uint32_t put_into_free_place(
-       uint32_t flow_index,
-       bool empty_place_found,
-       uint32_t begin_line,
-       uint32_t end_line) noexcept;
-   bool processing_last_tcp_packet(Packet& pkt, uint32_t flow_index) noexcept;
-   virtual bool create_new_flow(uint32_t flow_index, Packet& pkt, uint64_t hashval) noexcept;
-   //virtual bool export_inactive_timeout(Packet& pkt, uint32_t flow_index) noexcept;
-   //virtual bool export_active_timeout(Packet& pkt, uint32_t flow_index) noexcept;
-   virtual bool flush_and_update_flow(uint32_t flow_index, Packet& pkt) noexcept;
-   virtual void prepare_and_export(uint32_t flow_index) noexcept;
-   virtual void prepare_and_export(uint32_t flow_index,uint32_t reason) noexcept;
-   uint64_t m_order;
+    std::pair<bool, uint32_t>
+    find_existing_record(uint32_t begin_line, uint32_t end_line, uint64_t hashval) const noexcept;
+    virtual uint32_t
+    enhance_existing_flow_record(uint32_t flow_index, uint32_t line_index) noexcept;
+    std::pair<bool, uint32_t>
+    find_empty_place(uint32_t begin_line, uint32_t end_line) const noexcept;
+    virtual uint32_t put_into_free_place(
+        uint32_t flow_index,
+        bool empty_place_found,
+        uint32_t begin_line,
+        uint32_t end_line) noexcept;
+
+    bool process_last_tcp_packet(Packet& pkt, uint32_t flow_index) noexcept;
+    virtual bool create_new_flow(uint32_t flow_index, Packet& pkt, uint64_t hashval) noexcept;
+    virtual bool flush_and_update_flow(uint32_t flow_index, Packet& pkt) noexcept;
+    virtual void prepare_and_export(uint32_t flow_index) noexcept;
+    virtual void prepare_and_export(uint32_t flow_index, uint32_t reason) noexcept;
+
+    static void test_attributes();
 };
 template<>
-class NHTFlowCache<true> : public NHTFlowCache<false>{
-   uint64_t m_empty;
-   uint64_t m_not_empty;
-   uint64_t m_hits;
-   uint64_t m_expired;
-   uint64_t m_flushed;
-   uint64_t m_lookups;
-   uint64_t m_lookups2;
+class NHTFlowCache<true> : public NHTFlowCache<false> {
+    uint64_t m_empty;
+    uint64_t m_not_empty;
+    uint64_t m_hits;
+    uint64_t m_expired;
+    uint64_t m_flushed;
+    uint64_t m_lookups;
+    uint64_t m_lookups2;
 
-   void init(const char *params) override;
-   uint32_t enhance_existing_flow_record(uint32_t flow_index,uint32_t line_index) noexcept override;
-   ~NHTFlowCache() override;
-   uint32_t put_into_free_place(uint32_t flow_index,bool empty_place_found,uint32_t begin_line,uint32_t end_line) noexcept override;
-   bool create_new_flow(uint32_t flow_index, Packet& pkt,uint64_t hashval) noexcept override;
-   //bool export_inactive_timeout(Packet& pkt,uint32_t flow_index) noexcept override;
-   //bool export_active_timeout(Packet& pkt,uint32_t flow_index) noexcept override;
-   void print_report() const noexcept;
-   //void export_expired(time_t ts)noexcept override;
-   void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow) override;
-   //void finish() override;
-   void prepare_and_export(uint32_t flow_index) noexcept override;
-   void prepare_and_export(uint32_t flow_index,uint32_t reason) noexcept override;
-   void print_cache_dump()const noexcept;
-   int put_pkt(Packet &pkt) override;
+    void init(const char* params) override;
+    ~NHTFlowCache() override;
+
+    uint32_t
+    enhance_existing_flow_record(uint32_t flow_index, uint32_t line_index) noexcept override;
+    uint32_t put_into_free_place(
+        uint32_t flow_index,
+        bool empty_place_found,
+        uint32_t begin_line,
+        uint32_t end_line) noexcept override;
+    bool create_new_flow(uint32_t flow_index, Packet& pkt, uint64_t hashval) noexcept override;
+    void flush(Packet& pkt, size_t flow_index, int ret, bool source_flow) override;
+    void prepare_and_export(uint32_t flow_index) noexcept override;
+    void prepare_and_export(uint32_t flow_index, uint32_t reason) noexcept override;
+    void print_report() const noexcept;
+
 };
 
-}
+} // namespace ipxp
 #endif /* IPXP_STORAGE_CACHE_HPP */

--- a/storage/cache.hpp
+++ b/storage/cache.hpp
@@ -275,7 +275,6 @@ class NHTFlowCache<true> : public NHTFlowCache<false> {
     void prepare_and_export(uint32_t flow_index) noexcept override;
     void prepare_and_export(uint32_t flow_index, uint32_t reason) noexcept override;
     void print_report() const noexcept;
-
 };
 
 } // namespace ipxp

--- a/storage/cache.hpp
+++ b/storage/cache.hpp
@@ -258,9 +258,10 @@ class NHTFlowCache<true> : public NHTFlowCache<false> {
     uint64_t m_flushed;
     uint64_t m_lookups;
     uint64_t m_lookups2;
-
+    uint64_t m_put_time;
     void init(const char* params) override;
     ~NHTFlowCache() override;
+    int put_pkt(Packet& pkt) override;
 
     uint32_t
     enhance_existing_flow_record(uint32_t flow_index, uint32_t line_index) noexcept override;

--- a/storage/old_cache.cpp
+++ b/storage/old_cache.cpp
@@ -324,6 +324,7 @@ int OldNHTFlowCache::put_pkt(Packet& pkt)
     uint64_t hashval
         = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
 
+    //std::cerr<< hashval << std::endl;
     FlowRecord* flow; /* Pointer to flow we will be working with. */
     bool found = false;
     bool source_flow = true;

--- a/storage/old_cache.cpp
+++ b/storage/old_cache.cpp
@@ -34,517 +34,557 @@
 #include <iostream>
 #include <cstring>
 #include <sys/time.h>
+#include <iomanip>
+#include <fstream>
 
 #include <ipfixprobe/ring.h>
-#include "cache.hpp"
+#include "old_cache.hpp"
 #include "xxhash.h"
 
 namespace ipxp {
-
+namespace old_cache {
 __attribute__((constructor)) static void register_this_plugin()
 {
-   static PluginRecord rec = PluginRecord("cache", [](){return new NHTFlowCache();});
-   register_plugin(&rec);
+    static PluginRecord rec = PluginRecord("old_cache", []() { return new OldNHTFlowCache(); });
+    register_plugin(&rec);
 }
 
 FlowRecord::FlowRecord()
 {
-   erase();
+    erase();
 };
 
 FlowRecord::~FlowRecord()
 {
-   erase();
+    erase();
 };
 
 void FlowRecord::erase()
 {
-   m_flow.remove_extensions();
-   m_hash = 0;
+    m_flow.remove_extensions();
+    m_hash = 0;
 
-   memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
-   memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
-   m_flow.ip_version = 0;
-   m_flow.ip_proto = 0;
-   memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
-   memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
-   m_flow.src_port = 0;
-   m_flow.dst_port = 0;
-   m_flow.src_packets = 0;
-   m_flow.dst_packets = 0;
-   m_flow.src_bytes = 0;
-   m_flow.dst_bytes = 0;
-   m_flow.src_tcp_flags = 0;
-   m_flow.dst_tcp_flags = 0;
+    memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
+    memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
+    m_flow.ip_version = 0;
+    m_flow.ip_proto = 0;
+    memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
+    memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
+    m_flow.src_port = 0;
+    m_flow.dst_port = 0;
+    m_flow.src_packets = 0;
+    m_flow.dst_packets = 0;
+    m_flow.src_bytes = 0;
+    m_flow.dst_bytes = 0;
+    m_flow.src_tcp_flags = 0;
+    m_flow.dst_tcp_flags = 0;
 }
 void FlowRecord::reuse()
 {
-   m_flow.remove_extensions();
-   m_flow.time_first = m_flow.time_last;
-   m_flow.src_packets = 0;
-   m_flow.dst_packets = 0;
-   m_flow.src_bytes = 0;
-   m_flow.dst_bytes = 0;
-   m_flow.src_tcp_flags = 0;
-   m_flow.dst_tcp_flags = 0;
+    m_flow.remove_extensions();
+    m_flow.time_first = m_flow.time_last;
+    m_flow.src_packets = 0;
+    m_flow.dst_packets = 0;
+    m_flow.src_bytes = 0;
+    m_flow.dst_bytes = 0;
+    m_flow.src_tcp_flags = 0;
+    m_flow.dst_tcp_flags = 0;
 }
 
 inline __attribute__((always_inline)) bool FlowRecord::is_empty() const
 {
-   return m_hash == 0;
+    return m_hash == 0;
 }
 
 inline __attribute__((always_inline)) bool FlowRecord::belongs(uint64_t hash) const
 {
-   return hash == m_hash;
+    return hash == m_hash;
 }
 
-void FlowRecord::create(const Packet &pkt, uint64_t hash)
+void FlowRecord::create(const Packet& pkt, uint64_t hash)
 {
-   m_flow.src_packets = 1;
+    m_flow.src_packets = 1;
 
-   m_hash = hash;
+    m_hash = hash;
 
-   m_flow.time_first = pkt.ts;
-   m_flow.time_last = pkt.ts;
-   m_flow.flow_hash = hash;
+    m_flow.time_first = pkt.ts;
+    m_flow.time_last = pkt.ts;
+    m_flow.flow_hash = hash;
 
-   memcpy(m_flow.src_mac, pkt.src_mac, 6);
-   memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
+    memcpy(m_flow.src_mac, pkt.src_mac, 6);
+    memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
 
-   if (pkt.ip_version == IP::v4) {
-       m_flow.ip_version = pkt.ip_version;
-       m_flow.ip_proto = pkt.ip_proto;
-       m_flow.src_ip.v4 = pkt.src_ip.v4;
-       m_flow.dst_ip.v4 = pkt.dst_ip.v4;
-       m_flow.src_bytes = pkt.ip_len;
-   } else if (pkt.ip_version == IP::v6) {
-       m_flow.ip_version = pkt.ip_version;
-       m_flow.ip_proto = pkt.ip_proto;
-       memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
-       memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
-       m_flow.src_bytes = pkt.ip_len;
-   }
+    if (pkt.ip_version == IP::v4) {
+        m_flow.ip_version = pkt.ip_version;
+        m_flow.ip_proto = pkt.ip_proto;
+        m_flow.src_ip.v4 = pkt.src_ip.v4;
+        m_flow.dst_ip.v4 = pkt.dst_ip.v4;
+        m_flow.src_bytes = pkt.ip_len;
+    } else if (pkt.ip_version == IP::v6) {
+        m_flow.ip_version = pkt.ip_version;
+        m_flow.ip_proto = pkt.ip_proto;
+        memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
+        memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
+        m_flow.src_bytes = pkt.ip_len;
+    }
 
-   if (pkt.ip_proto == IPPROTO_TCP) {
-       m_flow.src_port = pkt.src_port;
-       m_flow.dst_port = pkt.dst_port;
-       m_flow.src_tcp_flags = pkt.tcp_flags;
-   } else if (pkt.ip_proto == IPPROTO_UDP) {
-       m_flow.src_port = pkt.src_port;
-       m_flow.dst_port = pkt.dst_port;
-   } else if (pkt.ip_proto == IPPROTO_ICMP ||
-              pkt.ip_proto == IPPROTO_ICMPV6) {
-       m_flow.src_port = pkt.src_port;
-       m_flow.dst_port = pkt.dst_port;
-   }
+    if (pkt.ip_proto == IPPROTO_TCP) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+        m_flow.src_tcp_flags = pkt.tcp_flags;
+    } else if (pkt.ip_proto == IPPROTO_UDP) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+    } else if (pkt.ip_proto == IPPROTO_ICMP || pkt.ip_proto == IPPROTO_ICMPV6) {
+        m_flow.src_port = pkt.src_port;
+        m_flow.dst_port = pkt.dst_port;
+    }
 }
 
-void FlowRecord::update(const Packet &pkt, bool src)
+void FlowRecord::update(const Packet& pkt, bool src)
 {
-   m_flow.time_last = pkt.ts;
-   if (src) {
-       m_flow.src_packets++;
-       m_flow.src_bytes += pkt.ip_len;
+    m_flow.time_last = pkt.ts;
+    if (src) {
+        m_flow.src_packets++;
+        m_flow.src_bytes += pkt.ip_len;
 
-       if (pkt.ip_proto == IPPROTO_TCP) {
-           m_flow.src_tcp_flags |= pkt.tcp_flags;
-       }
-   } else {
-       m_flow.dst_packets++;
-       m_flow.dst_bytes += pkt.ip_len;
+        if (pkt.ip_proto == IPPROTO_TCP) {
+            m_flow.src_tcp_flags |= pkt.tcp_flags;
+        }
+    } else {
+        m_flow.dst_packets++;
+        m_flow.dst_bytes += pkt.ip_len;
 
-       if (pkt.ip_proto == IPPROTO_TCP) {
-           m_flow.dst_tcp_flags |= pkt.tcp_flags;
-       }
-   }
+        if (pkt.ip_proto == IPPROTO_TCP) {
+            m_flow.dst_tcp_flags |= pkt.tcp_flags;
+        }
+    }
 }
 
-
-NHTFlowCache::NHTFlowCache() :
-   m_cache_size(0), m_line_size(0), m_line_mask(0), m_line_new_idx(0),
-   m_qsize(0), m_qidx(0), m_timeout_idx(0), m_active(0), m_inactive(0),
-   m_split_biflow(false), m_keylen(0), m_key(), m_key_inv(), m_flow_table(nullptr), m_flow_records(nullptr)
+OldNHTFlowCache::OldNHTFlowCache()
+    : m_cache_size(0)
+    , m_line_size(0)
+    , m_line_mask(0)
+    , m_line_new_idx(0)
+    , m_qsize(0)
+    , m_qidx(0)
+    , m_timeout_idx(0)
+    , m_active(0)
+    , m_inactive(0)
+    , m_split_biflow(false)
+    , m_keylen(0)
+    , m_key()
+    , m_key_inv()
+    , m_flow_table(nullptr)
+    , m_flow_records(nullptr)
 {
 }
 
-NHTFlowCache::~NHTFlowCache()
+OldNHTFlowCache::~OldNHTFlowCache()
 {
-   close();
+#ifdef FLOW_CACHE_STATS
+    print_report();
+#endif /*FLOW_CACHE_STATS */
+    close();
 }
 
-void NHTFlowCache::init(const char *params)
+void OldNHTFlowCache::init(const char* params)
 {
-   CacheOptParser parser;
-   try {
-       parser.parse(params);
-   } catch (ParserError &e) {
-       throw PluginError(e.what());
-   }
+    CacheOptParser parser;
+    try {
+        parser.parse(params);
+    } catch (ParserError& e) {
+        throw PluginError(e.what());
+    }
 
-   m_cache_size = parser.m_cache_size;
-   m_line_size = parser.m_line_size;
-   m_active = parser.m_active;
-   m_inactive = parser.m_inactive;
-   m_qidx = 0;
-   m_timeout_idx = 0;
-   m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
-   m_line_new_idx = m_line_size / 2;
+    m_cache_size = parser.m_cache_size;
+    m_line_size = parser.m_line_size;
+    m_active = parser.m_active;
+    m_inactive = parser.m_inactive;
+    m_qidx = 0;
+    m_timeout_idx = 0;
+    m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
+    m_line_new_idx = m_line_size / 2;
 
-   if (m_export_queue == nullptr) {
-       throw PluginError("output queue must be set before init");
-   }
+    if (m_export_queue == nullptr) {
+        throw PluginError("output queue must be set before init");
+    }
 
-   if (m_line_size > m_cache_size) {
-       throw PluginError("flow cache line size must be greater or equal to cache size");
-   }
-   if (m_cache_size == 0) {
-       throw PluginError("flow cache won't properly work with 0 records");
-   }
+    if (m_line_size > m_cache_size) {
+        throw PluginError("flow cache line size must be greater or equal to cache size");
+    }
+    if (m_cache_size == 0) {
+        throw PluginError("flow cache won't properly work with 0 records");
+    }
 
-   try {
-       m_flow_table = new FlowRecord*[m_cache_size + m_qsize];
-       m_flow_records = new FlowRecord[m_cache_size + m_qsize];
-       for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
-           m_flow_table[i] = m_flow_records + i;
-       }
-   } catch (std::bad_alloc &e) {
-       throw PluginError("not enough memory for flow cache allocation");
-   }
+    try {
+        m_flow_table = new FlowRecord*[m_cache_size + m_qsize];
+        m_flow_records = new FlowRecord[m_cache_size + m_qsize];
+        for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
+            m_flow_table[i] = m_flow_records + i;
+        }
+    } catch (std::bad_alloc& e) {
+        throw PluginError("not enough memory for flow cache allocation");
+    }
 
-   m_split_biflow = parser.m_split_biflow;
+    m_split_biflow = parser.m_split_biflow;
 
 #ifdef FLOW_CACHE_STATS
-   m_empty = 0;
-   m_not_empty = 0;
-   m_hits = 0;
-   m_expired = 0;
-   m_flushed = 0;
-   m_lookups = 0;
-   m_lookups2 = 0;
+    m_empty = 0;
+    m_not_empty = 0;
+    m_hits = 0;
+    m_expired = 0;
+    m_flushed = 0;
+    m_lookups = 0;
+    m_lookups2 = 0;
 #endif /* FLOW_CACHE_STATS */
 }
 
-void NHTFlowCache::close()
+void OldNHTFlowCache::close()
 {
-   if (m_flow_records != nullptr) {
-       delete [] m_flow_records;
-       m_flow_records = nullptr;
-   }
-   if (m_flow_table != nullptr) {
-       delete [] m_flow_table;
-       m_flow_table = nullptr;
-   }
+    if (m_flow_records != nullptr) {
+        delete[] m_flow_records;
+        m_flow_records = nullptr;
+    }
+    if (m_flow_table != nullptr) {
+        delete[] m_flow_table;
+        m_flow_table = nullptr;
+    }
 }
 
-void NHTFlowCache::set_queue(ipx_ring_t *queue)
+void OldNHTFlowCache::set_queue(ipx_ring_t* queue)
 {
-   m_export_queue = queue;
-   m_qsize = ipx_ring_size(queue);
+    m_export_queue = queue;
+    m_qsize = ipx_ring_size(queue);
 }
 
-void NHTFlowCache::export_flow(size_t index)
+void OldNHTFlowCache::export_flow(size_t index)
 {
-   ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
-   std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
-   m_flow_table[index]->erase();
-   m_qidx = (m_qidx + 1) % m_qsize;
+    ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
+    std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
+    m_flow_table[index]->erase();
+    m_qidx = (m_qidx + 1) % m_qsize;
 }
 
-void NHTFlowCache::finish()
+void OldNHTFlowCache::finish()
 {
-   for (decltype(m_cache_size) i = 0; i < m_cache_size; i++) {
-       if (!m_flow_table[i]->is_empty()) {
-           plugins_pre_export(m_flow_table[i]->m_flow);
-           m_flow_table[i]->m_flow.end_reason = FLOW_END_FORCED;
-           export_flow(i);
+    for (decltype(m_cache_size) i = 0; i < m_cache_size; i++) {
+        if (!m_flow_table[i]->is_empty()) {
+            plugins_pre_export(m_flow_table[i]->m_flow);
+            m_flow_table[i]->m_flow.end_reason = FLOW_END_FORCED;
+            export_flow(i);
 #ifdef FLOW_CACHE_STATS
-           m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-       }
-   }
+        }
+    }
 }
 
-void NHTFlowCache::flush(Packet &pkt, size_t flow_index, int ret, bool source_flow)
+void OldNHTFlowCache::flush(Packet& pkt, size_t flow_index, int ret, bool source_flow)
 {
 #ifdef FLOW_CACHE_STATS
-   m_flushed++;
-#endif /* FLOW_CACHE_STATS */
-
-   if (ret == FLOW_FLUSH_WITH_REINSERT) {
-       FlowRecord *flow = m_flow_table[flow_index];
-       flow->m_flow.end_reason = FLOW_END_FORCED;
-       ipx_ring_push(m_export_queue, &flow->m_flow);
-
-       std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
-
-       flow = m_flow_table[flow_index];
-       flow->m_flow.remove_extensions();
-       *flow = *m_flow_table[m_cache_size + m_qidx];
-       m_qidx = (m_qidx + 1) % m_qsize;
-
-       flow->m_flow.m_exts = nullptr;
-       flow->reuse(); // Clean counters, set time first to last
-       flow->update(pkt, source_flow); // Set new counters from packet
-
-       ret = plugins_post_create(flow->m_flow, pkt);
-       if (ret & FLOW_FLUSH) {
-           flush(pkt, flow_index, ret, source_flow);
-       }
-   } else {
-       m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
-       export_flow(flow_index);
-   }
-}
-
-int NHTFlowCache::put_pkt(Packet &pkt)
-{
-   int ret = plugins_pre_create(pkt);
-
-   if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key and NHTFlowCache::m_keylen
-       return 0;
-   }
-
-   uint64_t hashval = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
-
-   FlowRecord *flow; /* Pointer to flow we will be working with. */
-   bool found = false;
-   bool source_flow = true;
-   uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
-   uint32_t flow_index = 0;
-   uint32_t next_line = line_index + m_line_size;
-
-   /* Find existing flow record in flow cache. */
-   for (flow_index = line_index; flow_index < next_line; flow_index++) {
-       if (m_flow_table[flow_index]->belongs(hashval)) {
-           found = true;
-           break;
-       }
-   }
-
-   /* Find inversed flow. */
-   if (!found && !m_split_biflow) {
-       uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
-       uint64_t line_index_inv = hashval_inv & m_line_mask;
-       uint64_t next_line_inv = line_index_inv + m_line_size;
-       for (flow_index = line_index_inv; flow_index < next_line_inv; flow_index++) {
-           if (m_flow_table[flow_index]->belongs(hashval_inv)) {
-               found = true;
-               source_flow = false;
-               hashval = hashval_inv;
-               line_index = line_index_inv;
-               break;
-           }
-       }
-   }
-
-   if (found) {
-       /* Existing flow record was found, put flow record at the first index of flow line. */
-#ifdef FLOW_CACHE_STATS
-       m_lookups += (flow_index - line_index + 1);
-       m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
+    m_flushed++;
 #endif /* FLOW_CACHE_STATS */
 
-       flow = m_flow_table[flow_index];
-       for (decltype(flow_index) j = flow_index; j > line_index; j--) {
-           m_flow_table[j] = m_flow_table[j - 1];
-       }
+    if (ret == FLOW_FLUSH_WITH_REINSERT) {
+        FlowRecord* flow = m_flow_table[flow_index];
+        flow->m_flow.end_reason = FLOW_END_FORCED;
+        ipx_ring_push(m_export_queue, &flow->m_flow);
 
-       m_flow_table[line_index] = flow;
-       flow_index = line_index;
+        std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
+
+        flow = m_flow_table[flow_index];
+        flow->m_flow.remove_extensions();
+        *flow = *m_flow_table[m_cache_size + m_qidx];
+        m_qidx = (m_qidx + 1) % m_qsize;
+
+        flow->m_flow.m_exts = nullptr;
+        flow->reuse(); // Clean counters, set time first to last
+        flow->update(pkt, source_flow); // Set new counters from packet
+
+        ret = plugins_post_create(flow->m_flow, pkt);
+        if (ret & FLOW_FLUSH) {
+            flush(pkt, flow_index, ret, source_flow);
+        }
+    } else {
+        m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
+        export_flow(flow_index);
+    }
+}
 #ifdef FLOW_CACHE_STATS
-       m_hits++;
+void OldNHTFlowCache::print_cache_dump()const noexcept{
+    /*std::ofstream outfile;
+    outfile.open("old_cache_res.txt", std::ios_base::app);
+    const uint32_t field_count = sizeof(FlowRecord)/sizeof(uint32_t);
+    for(uint32_t i = 0; i < m_cache_size + m_qsize; i++)
+        for(uint32_t k = 0; k < field_count; k++)
+            outfile<<reinterpret_cast<uint32_t*>(&m_flow_records[i])[k];
+    outfile.close();*/
+}
+#endif /*FLOW_CACHE_STATS*/
+
+int OldNHTFlowCache::put_pkt(Packet& pkt)
+{
+#ifdef FLOW_CACHE_STATS
+    print_cache_dump();
+#endif /*FLOW_CACHE_STATS*/
+    int ret = plugins_pre_create(pkt);
+
+    if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key and NHTFlowCache::m_keylen
+        return 0;
+    }
+
+    uint64_t hashval
+        = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
+
+    FlowRecord* flow; /* Pointer to flow we will be working with. */
+    bool found = false;
+    bool source_flow = true;
+    uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
+    uint32_t flow_index = 0;
+    uint32_t next_line = line_index + m_line_size;
+
+    /* Find existing flow record in flow cache. */
+    for (flow_index = line_index; flow_index < next_line; flow_index++) {
+        if (m_flow_table[flow_index]->belongs(hashval)) {
+            found = true;
+#ifdef FLOW_CACHE_STATS
+            //std::cout<<m_order << " was found directly\n";
+#endif /*FLOW_CACHE_STATS*/
+            break;
+        }
+    }
+
+    /* Find inversed flow. */
+    if (!found && !m_split_biflow) {
+        uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
+        uint64_t line_index_inv = hashval_inv & m_line_mask;
+        uint64_t next_line_inv = line_index_inv + m_line_size;
+        for (flow_index = line_index_inv; flow_index < next_line_inv; flow_index++) {
+            if (m_flow_table[flow_index]->belongs(hashval_inv)) {
+                found = true;
+                source_flow = false;
+                hashval = hashval_inv;
+                line_index = line_index_inv;
+#ifdef FLOW_CACHE_STATS
+                //std::cout<<m_order << " was found reversed\n";
+#endif /*FLOW_CACHE_STATS*/
+                break;
+            }
+        }
+    }
+
+    if (found) {
+        /* Existing flow record was found, put flow record at the first index of flow line. */
+#ifdef FLOW_CACHE_STATS
+        m_lookups += (flow_index - line_index + 1);
+        m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
 #endif /* FLOW_CACHE_STATS */
-   } else {
-       /* Existing flow record was not found. Find free place in flow line. */
-       for (flow_index = line_index; flow_index < next_line; flow_index++) {
-           if (m_flow_table[flow_index]->is_empty()) {
-               found = true;
-               break;
-           }
-       }
-       if (!found) {
-           /* If free place was not found (flow line is full), find
+
+        flow = m_flow_table[flow_index];
+        for (decltype(flow_index) j = flow_index; j > line_index; j--) {
+            m_flow_table[j] = m_flow_table[j - 1];
+        }
+
+        m_flow_table[line_index] = flow;
+        flow_index = line_index;
+#ifdef FLOW_CACHE_STATS
+        m_hits++;
+#endif /* FLOW_CACHE_STATS */
+    } else {
+#ifdef FLOW_CACHE_STATS
+       // std::cout<<m_order << " was not found\n";
+#endif /*FLOW_CACHE_STATS*/
+        /* Existing flow record was not found. Find free place in flow line. */
+        for (flow_index = line_index; flow_index < next_line; flow_index++) {
+            if (m_flow_table[flow_index]->is_empty()) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            /* If free place was not found (flow line is full), find
          * record which will be replaced by new record. */
-           flow_index = next_line - 1;
+            flow_index = next_line - 1;
 
-           // Export flow
-           plugins_pre_export(m_flow_table[flow_index]->m_flow);
-           m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_NO_RES;
-           export_flow(flow_index);
+            // Export flow
+            plugins_pre_export(m_flow_table[flow_index]->m_flow);
+            m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_NO_RES;
+            export_flow(flow_index);
 
 #ifdef FLOW_CACHE_STATS
-           m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-           uint32_t flow_new_index = line_index + m_line_new_idx;
-           flow = m_flow_table[flow_index];
-           for (decltype(flow_index) j = flow_index; j > flow_new_index; j--) {
-               m_flow_table[j] = m_flow_table[j - 1];
-           }
-           flow_index = flow_new_index;
-           m_flow_table[flow_new_index] = flow;
+            uint32_t flow_new_index = line_index + m_line_new_idx;
+            flow = m_flow_table[flow_index];
+            for (decltype(flow_index) j = flow_index; j > flow_new_index; j--) {
+                m_flow_table[j] = m_flow_table[j - 1];
+            }
+            flow_index = flow_new_index;
+            m_flow_table[flow_new_index] = flow;
 #ifdef FLOW_CACHE_STATS
-           m_not_empty++;
-       } else {
-           m_empty++;
+            m_not_empty++;
+        } else {
+            m_empty++;
 #endif /* FLOW_CACHE_STATS */
-       }
-   }
+        }
+    }
 
-   pkt.source_pkt = source_flow;
-   flow = m_flow_table[flow_index];
+    pkt.source_pkt = source_flow;
+    flow = m_flow_table[flow_index];
 
-   uint8_t flw_flags = source_flow ? flow->m_flow.src_tcp_flags : flow->m_flow.dst_tcp_flags;
-   if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
-       // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
-       m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
-       export_flow(flow_index);
-       put_pkt(pkt);
-       return 0;
-   }
+    uint8_t flw_flags = source_flow ? flow->m_flow.src_tcp_flags : flow->m_flow.dst_tcp_flags;
+    if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
+        // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
+        m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
+        export_flow(flow_index);
+        put_pkt(pkt);
+        return 0;
+    }
 
-   if (flow->is_empty()) {
-       flow->create(pkt, hashval);
-       ret = plugins_post_create(flow->m_flow, pkt);
+    if (flow->is_empty()) {
+        flow->create(pkt, hashval);
+        ret = plugins_post_create(flow->m_flow, pkt);
 
-       if (ret & FLOW_FLUSH) {
-           export_flow(flow_index);
+        if (ret & FLOW_FLUSH) {
+            export_flow(flow_index);
 #ifdef FLOW_CACHE_STATS
-           m_flushed++;
+            m_flushed++;
 #endif /* FLOW_CACHE_STATS */
-       }
-   } else {
-       /* Check if flow record is expired (inactive timeout). */
-       if (pkt.ts.tv_sec - flow->m_flow.time_last.tv_sec >= m_inactive) {
-           m_flow_table[flow_index]->m_flow.end_reason = get_export_reason(flow->m_flow);
-           plugins_pre_export(flow->m_flow);
-           export_flow(flow_index);
+        }
+    } else {
+        /* Check if flow record is expired (inactive timeout). */
+        if (pkt.ts.tv_sec - flow->m_flow.time_last.tv_sec >= m_inactive) {
+            m_flow_table[flow_index]->m_flow.end_reason = get_export_reason(flow->m_flow);
+            plugins_pre_export(flow->m_flow);
+            export_flow(flow_index);
 #ifdef FLOW_CACHE_STATS
-           m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-           return put_pkt(pkt);
-       }
+            return put_pkt(pkt);
+        }
 
-       /* Check if flow record is expired (active timeout). */
-       if (pkt.ts.tv_sec - flow->m_flow.time_first.tv_sec >= m_active) {
-           m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_ACTIVE;
-           plugins_pre_export(flow->m_flow);
-           export_flow(flow_index);
+        /* Check if flow record is expired (active timeout). */
+        if (pkt.ts.tv_sec - flow->m_flow.time_first.tv_sec >= m_active) {
+            m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_ACTIVE;
+            plugins_pre_export(flow->m_flow);
+            export_flow(flow_index);
 #ifdef FLOW_CACHE_STATS
-           m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-           return put_pkt(pkt);
-       }
+            return put_pkt(pkt);
+        }
 
-       ret = plugins_pre_update(flow->m_flow, pkt);
-       if (ret & FLOW_FLUSH) {
-           flush(pkt, flow_index, ret, source_flow);
-           return 0;
-       } else {
-           flow->update(pkt, source_flow);
-           ret = plugins_post_update(flow->m_flow, pkt);
+        ret = plugins_pre_update(flow->m_flow, pkt);
+        if (ret & FLOW_FLUSH) {
+            flush(pkt, flow_index, ret, source_flow);
+            return 0;
+        } else {
+            flow->update(pkt, source_flow);
+            ret = plugins_post_update(flow->m_flow, pkt);
 
-           if (ret & FLOW_FLUSH) {
-               flush(pkt, flow_index, ret, source_flow);
-               return 0;
-           }
-       }
-   }
+            if (ret & FLOW_FLUSH) {
+                flush(pkt, flow_index, ret, source_flow);
+                return 0;
+            }
+        }
+    }
 
-   export_expired(pkt.ts.tv_sec);
-   return 0;
+    export_expired(pkt.ts.tv_sec);
+    return 0;
 }
 
-uint8_t NHTFlowCache::get_export_reason(Flow &flow)
+uint8_t OldNHTFlowCache::get_export_reason(Flow& flow)
 {
-   if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
-       // When FIN or RST is set, TCP connection ended naturally
-       return FLOW_END_EOF;
-   } else {
-       return FLOW_END_INACTIVE;
-   }
+    if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
+        // When FIN or RST is set, TCP connection ended naturally
+        return FLOW_END_EOF;
+    } else {
+        return FLOW_END_INACTIVE;
+    }
 }
 
-void NHTFlowCache::export_expired(time_t ts)
+void OldNHTFlowCache::export_expired(time_t ts)
 {
-   for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
-       if (!m_flow_table[i]->is_empty() && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
-           m_flow_table[i]->m_flow.end_reason = get_export_reason(m_flow_table[i]->m_flow);
-           plugins_pre_export(m_flow_table[i]->m_flow);
-           export_flow(i);
+    for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
+        if (!m_flow_table[i]->is_empty()
+            && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
+            m_flow_table[i]->m_flow.end_reason = get_export_reason(m_flow_table[i]->m_flow);
+            plugins_pre_export(m_flow_table[i]->m_flow);
+            export_flow(i);
 #ifdef FLOW_CACHE_STATS
-           m_expired++;
+            m_expired++;
 #endif /* FLOW_CACHE_STATS */
-       }
-   }
+        }
+    }
 
-   m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
+    m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
 }
 
-bool NHTFlowCache::create_hash_key(Packet &pkt)
+bool OldNHTFlowCache::create_hash_key(Packet& pkt)
 {
-   if (pkt.ip_version == IP::v4) {
-       struct flow_key_v4_t *key_v4 = reinterpret_cast<struct flow_key_v4_t *>(m_key);
-       struct flow_key_v4_t *key_v4_inv = reinterpret_cast<struct flow_key_v4_t *>(m_key_inv);
+    if (pkt.ip_version == IP::v4) {
+        struct flow_key_v4_t* key_v4 = reinterpret_cast<struct flow_key_v4_t*>(m_key);
+        struct flow_key_v4_t* key_v4_inv = reinterpret_cast<struct flow_key_v4_t*>(m_key_inv);
 
-       key_v4->proto = pkt.ip_proto;
-       key_v4->ip_version = IP::v4;
-       key_v4->src_port = pkt.src_port;
-       key_v4->dst_port = pkt.dst_port;
-       key_v4->src_ip = pkt.src_ip.v4;
-       key_v4->dst_ip = pkt.dst_ip.v4;
-       key_v4->vlan_id = pkt.vlan_id;
+        key_v4->proto = pkt.ip_proto;
+        key_v4->ip_version = IP::v4;
+        key_v4->src_port = pkt.src_port;
+        key_v4->dst_port = pkt.dst_port;
+        key_v4->src_ip = pkt.src_ip.v4;
+        key_v4->dst_ip = pkt.dst_ip.v4;
+        key_v4->vlan_id = pkt.vlan_id;
 
-       key_v4_inv->proto = pkt.ip_proto;
-       key_v4_inv->ip_version = IP::v4;
-       key_v4_inv->src_port = pkt.dst_port;
-       key_v4_inv->dst_port = pkt.src_port;
-       key_v4_inv->src_ip = pkt.dst_ip.v4;
-       key_v4_inv->dst_ip = pkt.src_ip.v4;
-       key_v4_inv->vlan_id = pkt.vlan_id;
+        key_v4_inv->proto = pkt.ip_proto;
+        key_v4_inv->ip_version = IP::v4;
+        key_v4_inv->src_port = pkt.dst_port;
+        key_v4_inv->dst_port = pkt.src_port;
+        key_v4_inv->src_ip = pkt.dst_ip.v4;
+        key_v4_inv->dst_ip = pkt.src_ip.v4;
+        key_v4_inv->vlan_id = pkt.vlan_id;
 
-       m_keylen = sizeof(flow_key_v4_t);
-       return true;
-   } else if (pkt.ip_version == IP::v6) {
-       struct flow_key_v6_t *key_v6 = reinterpret_cast<struct flow_key_v6_t *>(m_key);
-       struct flow_key_v6_t *key_v6_inv = reinterpret_cast<struct flow_key_v6_t *>(m_key_inv);
+        m_keylen = sizeof(flow_key_v4_t);
+        return true;
+    } else if (pkt.ip_version == IP::v6) {
+        struct flow_key_v6_t* key_v6 = reinterpret_cast<struct flow_key_v6_t*>(m_key);
+        struct flow_key_v6_t* key_v6_inv = reinterpret_cast<struct flow_key_v6_t*>(m_key_inv);
 
-       key_v6->proto = pkt.ip_proto;
-       key_v6->ip_version = IP::v6;
-       key_v6->src_port = pkt.src_port;
-       key_v6->dst_port = pkt.dst_port;
-       memcpy(key_v6->src_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
-       memcpy(key_v6->dst_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
-       key_v6->vlan_id = pkt.vlan_id;
+        key_v6->proto = pkt.ip_proto;
+        key_v6->ip_version = IP::v6;
+        key_v6->src_port = pkt.src_port;
+        key_v6->dst_port = pkt.dst_port;
+        memcpy(key_v6->src_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
+        memcpy(key_v6->dst_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
+        key_v6->vlan_id = pkt.vlan_id;
 
-       key_v6_inv->proto = pkt.ip_proto;
-       key_v6_inv->ip_version = IP::v6;
-       key_v6_inv->src_port = pkt.dst_port;
-       key_v6_inv->dst_port = pkt.src_port;
-       memcpy(key_v6_inv->src_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
-       memcpy(key_v6_inv->dst_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
-       key_v6_inv->vlan_id = pkt.vlan_id;
+        key_v6_inv->proto = pkt.ip_proto;
+        key_v6_inv->ip_version = IP::v6;
+        key_v6_inv->src_port = pkt.dst_port;
+        key_v6_inv->dst_port = pkt.src_port;
+        memcpy(key_v6_inv->src_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
+        memcpy(key_v6_inv->dst_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
+        key_v6_inv->vlan_id = pkt.vlan_id;
 
-       m_keylen = sizeof(flow_key_v6_t);
-       return true;
-   }
+        m_keylen = sizeof(flow_key_v6_t);
+        return true;
+    }
 
-   return false;
+    return false;
 }
 
 #ifdef FLOW_CACHE_STATS
-void NHTFlowCache::print_report()
+void OldNHTFlowCache::print_report()
 {
-   float tmp = float(m_lookups) / m_hits;
+    float tmp = float(m_lookups) / m_hits;
 
-   cout << "Hits: " << m_hits << endl;
-   cout << "Empty: " << m_empty << endl;
-   cout << "Not empty: " << m_not_empty << endl;
-   cout << "Expired: " << m_expired << endl;
-   cout << "Flushed: " << m_flushed << endl;
-   cout << "Average Lookup:  " << tmp << endl;
-   cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << endl;
+    std::cout << "Hits: " << m_hits << std::endl;
+    std::cout << "Empty: " << m_empty << std::endl;
+    std::cout << "Not empty: " << m_not_empty << std::endl;
+    std::cout << "Expired: " << m_expired << std::endl;
+    std::cout << "Flushed: " << m_flushed << std::endl;
+    std::cout << "Average Lookup:  " << tmp << std::endl;
+    std::cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << std::endl;
 }
 #endif /* FLOW_CACHE_STATS */
-
+}
 }

--- a/storage/old_cache.cpp
+++ b/storage/old_cache.cpp
@@ -1,0 +1,550 @@
+/**
+* \file cache.cpp
+* \brief "NewHashTable" flow cache
+* \author Martin Zadnik <zadnik@cesnet.cz>
+* \author Vaclav Bartos <bartos@cesnet.cz>
+* \author Jiri Havranek <havranek@cesnet.cz>
+* \date 2014
+* \date 2015
+* \date 2016
+*/
+/*
+* Copyright (C) 2014-2016 CESNET
+*
+* LICENSE TERMS
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name of the Company nor the names of its contributors
+*    may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+*
+*
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <cstring>
+#include <sys/time.h>
+
+#include <ipfixprobe/ring.h>
+#include "cache.hpp"
+#include "xxhash.h"
+
+namespace ipxp {
+
+__attribute__((constructor)) static void register_this_plugin()
+{
+   static PluginRecord rec = PluginRecord("cache", [](){return new NHTFlowCache();});
+   register_plugin(&rec);
+}
+
+FlowRecord::FlowRecord()
+{
+   erase();
+};
+
+FlowRecord::~FlowRecord()
+{
+   erase();
+};
+
+void FlowRecord::erase()
+{
+   m_flow.remove_extensions();
+   m_hash = 0;
+
+   memset(&m_flow.time_first, 0, sizeof(m_flow.time_first));
+   memset(&m_flow.time_last, 0, sizeof(m_flow.time_last));
+   m_flow.ip_version = 0;
+   m_flow.ip_proto = 0;
+   memset(&m_flow.src_ip, 0, sizeof(m_flow.src_ip));
+   memset(&m_flow.dst_ip, 0, sizeof(m_flow.dst_ip));
+   m_flow.src_port = 0;
+   m_flow.dst_port = 0;
+   m_flow.src_packets = 0;
+   m_flow.dst_packets = 0;
+   m_flow.src_bytes = 0;
+   m_flow.dst_bytes = 0;
+   m_flow.src_tcp_flags = 0;
+   m_flow.dst_tcp_flags = 0;
+}
+void FlowRecord::reuse()
+{
+   m_flow.remove_extensions();
+   m_flow.time_first = m_flow.time_last;
+   m_flow.src_packets = 0;
+   m_flow.dst_packets = 0;
+   m_flow.src_bytes = 0;
+   m_flow.dst_bytes = 0;
+   m_flow.src_tcp_flags = 0;
+   m_flow.dst_tcp_flags = 0;
+}
+
+inline __attribute__((always_inline)) bool FlowRecord::is_empty() const
+{
+   return m_hash == 0;
+}
+
+inline __attribute__((always_inline)) bool FlowRecord::belongs(uint64_t hash) const
+{
+   return hash == m_hash;
+}
+
+void FlowRecord::create(const Packet &pkt, uint64_t hash)
+{
+   m_flow.src_packets = 1;
+
+   m_hash = hash;
+
+   m_flow.time_first = pkt.ts;
+   m_flow.time_last = pkt.ts;
+   m_flow.flow_hash = hash;
+
+   memcpy(m_flow.src_mac, pkt.src_mac, 6);
+   memcpy(m_flow.dst_mac, pkt.dst_mac, 6);
+
+   if (pkt.ip_version == IP::v4) {
+       m_flow.ip_version = pkt.ip_version;
+       m_flow.ip_proto = pkt.ip_proto;
+       m_flow.src_ip.v4 = pkt.src_ip.v4;
+       m_flow.dst_ip.v4 = pkt.dst_ip.v4;
+       m_flow.src_bytes = pkt.ip_len;
+   } else if (pkt.ip_version == IP::v6) {
+       m_flow.ip_version = pkt.ip_version;
+       m_flow.ip_proto = pkt.ip_proto;
+       memcpy(m_flow.src_ip.v6, pkt.src_ip.v6, 16);
+       memcpy(m_flow.dst_ip.v6, pkt.dst_ip.v6, 16);
+       m_flow.src_bytes = pkt.ip_len;
+   }
+
+   if (pkt.ip_proto == IPPROTO_TCP) {
+       m_flow.src_port = pkt.src_port;
+       m_flow.dst_port = pkt.dst_port;
+       m_flow.src_tcp_flags = pkt.tcp_flags;
+   } else if (pkt.ip_proto == IPPROTO_UDP) {
+       m_flow.src_port = pkt.src_port;
+       m_flow.dst_port = pkt.dst_port;
+   } else if (pkt.ip_proto == IPPROTO_ICMP ||
+              pkt.ip_proto == IPPROTO_ICMPV6) {
+       m_flow.src_port = pkt.src_port;
+       m_flow.dst_port = pkt.dst_port;
+   }
+}
+
+void FlowRecord::update(const Packet &pkt, bool src)
+{
+   m_flow.time_last = pkt.ts;
+   if (src) {
+       m_flow.src_packets++;
+       m_flow.src_bytes += pkt.ip_len;
+
+       if (pkt.ip_proto == IPPROTO_TCP) {
+           m_flow.src_tcp_flags |= pkt.tcp_flags;
+       }
+   } else {
+       m_flow.dst_packets++;
+       m_flow.dst_bytes += pkt.ip_len;
+
+       if (pkt.ip_proto == IPPROTO_TCP) {
+           m_flow.dst_tcp_flags |= pkt.tcp_flags;
+       }
+   }
+}
+
+
+NHTFlowCache::NHTFlowCache() :
+   m_cache_size(0), m_line_size(0), m_line_mask(0), m_line_new_idx(0),
+   m_qsize(0), m_qidx(0), m_timeout_idx(0), m_active(0), m_inactive(0),
+   m_split_biflow(false), m_keylen(0), m_key(), m_key_inv(), m_flow_table(nullptr), m_flow_records(nullptr)
+{
+}
+
+NHTFlowCache::~NHTFlowCache()
+{
+   close();
+}
+
+void NHTFlowCache::init(const char *params)
+{
+   CacheOptParser parser;
+   try {
+       parser.parse(params);
+   } catch (ParserError &e) {
+       throw PluginError(e.what());
+   }
+
+   m_cache_size = parser.m_cache_size;
+   m_line_size = parser.m_line_size;
+   m_active = parser.m_active;
+   m_inactive = parser.m_inactive;
+   m_qidx = 0;
+   m_timeout_idx = 0;
+   m_line_mask = (m_cache_size - 1) & ~(m_line_size - 1);
+   m_line_new_idx = m_line_size / 2;
+
+   if (m_export_queue == nullptr) {
+       throw PluginError("output queue must be set before init");
+   }
+
+   if (m_line_size > m_cache_size) {
+       throw PluginError("flow cache line size must be greater or equal to cache size");
+   }
+   if (m_cache_size == 0) {
+       throw PluginError("flow cache won't properly work with 0 records");
+   }
+
+   try {
+       m_flow_table = new FlowRecord*[m_cache_size + m_qsize];
+       m_flow_records = new FlowRecord[m_cache_size + m_qsize];
+       for (decltype(m_cache_size + m_qsize) i = 0; i < m_cache_size + m_qsize; i++) {
+           m_flow_table[i] = m_flow_records + i;
+       }
+   } catch (std::bad_alloc &e) {
+       throw PluginError("not enough memory for flow cache allocation");
+   }
+
+   m_split_biflow = parser.m_split_biflow;
+
+#ifdef FLOW_CACHE_STATS
+   m_empty = 0;
+   m_not_empty = 0;
+   m_hits = 0;
+   m_expired = 0;
+   m_flushed = 0;
+   m_lookups = 0;
+   m_lookups2 = 0;
+#endif /* FLOW_CACHE_STATS */
+}
+
+void NHTFlowCache::close()
+{
+   if (m_flow_records != nullptr) {
+       delete [] m_flow_records;
+       m_flow_records = nullptr;
+   }
+   if (m_flow_table != nullptr) {
+       delete [] m_flow_table;
+       m_flow_table = nullptr;
+   }
+}
+
+void NHTFlowCache::set_queue(ipx_ring_t *queue)
+{
+   m_export_queue = queue;
+   m_qsize = ipx_ring_size(queue);
+}
+
+void NHTFlowCache::export_flow(size_t index)
+{
+   ipx_ring_push(m_export_queue, &m_flow_table[index]->m_flow);
+   std::swap(m_flow_table[index], m_flow_table[m_cache_size + m_qidx]);
+   m_flow_table[index]->erase();
+   m_qidx = (m_qidx + 1) % m_qsize;
+}
+
+void NHTFlowCache::finish()
+{
+   for (decltype(m_cache_size) i = 0; i < m_cache_size; i++) {
+       if (!m_flow_table[i]->is_empty()) {
+           plugins_pre_export(m_flow_table[i]->m_flow);
+           m_flow_table[i]->m_flow.end_reason = FLOW_END_FORCED;
+           export_flow(i);
+#ifdef FLOW_CACHE_STATS
+           m_expired++;
+#endif /* FLOW_CACHE_STATS */
+       }
+   }
+}
+
+void NHTFlowCache::flush(Packet &pkt, size_t flow_index, int ret, bool source_flow)
+{
+#ifdef FLOW_CACHE_STATS
+   m_flushed++;
+#endif /* FLOW_CACHE_STATS */
+
+   if (ret == FLOW_FLUSH_WITH_REINSERT) {
+       FlowRecord *flow = m_flow_table[flow_index];
+       flow->m_flow.end_reason = FLOW_END_FORCED;
+       ipx_ring_push(m_export_queue, &flow->m_flow);
+
+       std::swap(m_flow_table[flow_index], m_flow_table[m_cache_size + m_qidx]);
+
+       flow = m_flow_table[flow_index];
+       flow->m_flow.remove_extensions();
+       *flow = *m_flow_table[m_cache_size + m_qidx];
+       m_qidx = (m_qidx + 1) % m_qsize;
+
+       flow->m_flow.m_exts = nullptr;
+       flow->reuse(); // Clean counters, set time first to last
+       flow->update(pkt, source_flow); // Set new counters from packet
+
+       ret = plugins_post_create(flow->m_flow, pkt);
+       if (ret & FLOW_FLUSH) {
+           flush(pkt, flow_index, ret, source_flow);
+       }
+   } else {
+       m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_FORCED;
+       export_flow(flow_index);
+   }
+}
+
+int NHTFlowCache::put_pkt(Packet &pkt)
+{
+   int ret = plugins_pre_create(pkt);
+
+   if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key and NHTFlowCache::m_keylen
+       return 0;
+   }
+
+   uint64_t hashval = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
+
+   FlowRecord *flow; /* Pointer to flow we will be working with. */
+   bool found = false;
+   bool source_flow = true;
+   uint32_t line_index = hashval & m_line_mask; /* Get index of flow line. */
+   uint32_t flow_index = 0;
+   uint32_t next_line = line_index + m_line_size;
+
+   /* Find existing flow record in flow cache. */
+   for (flow_index = line_index; flow_index < next_line; flow_index++) {
+       if (m_flow_table[flow_index]->belongs(hashval)) {
+           found = true;
+           break;
+       }
+   }
+
+   /* Find inversed flow. */
+   if (!found && !m_split_biflow) {
+       uint64_t hashval_inv = XXH64(m_key_inv, m_keylen, 0);
+       uint64_t line_index_inv = hashval_inv & m_line_mask;
+       uint64_t next_line_inv = line_index_inv + m_line_size;
+       for (flow_index = line_index_inv; flow_index < next_line_inv; flow_index++) {
+           if (m_flow_table[flow_index]->belongs(hashval_inv)) {
+               found = true;
+               source_flow = false;
+               hashval = hashval_inv;
+               line_index = line_index_inv;
+               break;
+           }
+       }
+   }
+
+   if (found) {
+       /* Existing flow record was found, put flow record at the first index of flow line. */
+#ifdef FLOW_CACHE_STATS
+       m_lookups += (flow_index - line_index + 1);
+       m_lookups2 += (flow_index - line_index + 1) * (flow_index - line_index + 1);
+#endif /* FLOW_CACHE_STATS */
+
+       flow = m_flow_table[flow_index];
+       for (decltype(flow_index) j = flow_index; j > line_index; j--) {
+           m_flow_table[j] = m_flow_table[j - 1];
+       }
+
+       m_flow_table[line_index] = flow;
+       flow_index = line_index;
+#ifdef FLOW_CACHE_STATS
+       m_hits++;
+#endif /* FLOW_CACHE_STATS */
+   } else {
+       /* Existing flow record was not found. Find free place in flow line. */
+       for (flow_index = line_index; flow_index < next_line; flow_index++) {
+           if (m_flow_table[flow_index]->is_empty()) {
+               found = true;
+               break;
+           }
+       }
+       if (!found) {
+           /* If free place was not found (flow line is full), find
+         * record which will be replaced by new record. */
+           flow_index = next_line - 1;
+
+           // Export flow
+           plugins_pre_export(m_flow_table[flow_index]->m_flow);
+           m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_NO_RES;
+           export_flow(flow_index);
+
+#ifdef FLOW_CACHE_STATS
+           m_expired++;
+#endif /* FLOW_CACHE_STATS */
+           uint32_t flow_new_index = line_index + m_line_new_idx;
+           flow = m_flow_table[flow_index];
+           for (decltype(flow_index) j = flow_index; j > flow_new_index; j--) {
+               m_flow_table[j] = m_flow_table[j - 1];
+           }
+           flow_index = flow_new_index;
+           m_flow_table[flow_new_index] = flow;
+#ifdef FLOW_CACHE_STATS
+           m_not_empty++;
+       } else {
+           m_empty++;
+#endif /* FLOW_CACHE_STATS */
+       }
+   }
+
+   pkt.source_pkt = source_flow;
+   flow = m_flow_table[flow_index];
+
+   uint8_t flw_flags = source_flow ? flow->m_flow.src_tcp_flags : flow->m_flow.dst_tcp_flags;
+   if ((pkt.tcp_flags & 0x02) && (flw_flags & (0x01 | 0x04))) {
+       // Flows with FIN or RST TCP flags are exported when new SYN packet arrives
+       m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_EOF;
+       export_flow(flow_index);
+       put_pkt(pkt);
+       return 0;
+   }
+
+   if (flow->is_empty()) {
+       flow->create(pkt, hashval);
+       ret = plugins_post_create(flow->m_flow, pkt);
+
+       if (ret & FLOW_FLUSH) {
+           export_flow(flow_index);
+#ifdef FLOW_CACHE_STATS
+           m_flushed++;
+#endif /* FLOW_CACHE_STATS */
+       }
+   } else {
+       /* Check if flow record is expired (inactive timeout). */
+       if (pkt.ts.tv_sec - flow->m_flow.time_last.tv_sec >= m_inactive) {
+           m_flow_table[flow_index]->m_flow.end_reason = get_export_reason(flow->m_flow);
+           plugins_pre_export(flow->m_flow);
+           export_flow(flow_index);
+#ifdef FLOW_CACHE_STATS
+           m_expired++;
+#endif /* FLOW_CACHE_STATS */
+           return put_pkt(pkt);
+       }
+
+       /* Check if flow record is expired (active timeout). */
+       if (pkt.ts.tv_sec - flow->m_flow.time_first.tv_sec >= m_active) {
+           m_flow_table[flow_index]->m_flow.end_reason = FLOW_END_ACTIVE;
+           plugins_pre_export(flow->m_flow);
+           export_flow(flow_index);
+#ifdef FLOW_CACHE_STATS
+           m_expired++;
+#endif /* FLOW_CACHE_STATS */
+           return put_pkt(pkt);
+       }
+
+       ret = plugins_pre_update(flow->m_flow, pkt);
+       if (ret & FLOW_FLUSH) {
+           flush(pkt, flow_index, ret, source_flow);
+           return 0;
+       } else {
+           flow->update(pkt, source_flow);
+           ret = plugins_post_update(flow->m_flow, pkt);
+
+           if (ret & FLOW_FLUSH) {
+               flush(pkt, flow_index, ret, source_flow);
+               return 0;
+           }
+       }
+   }
+
+   export_expired(pkt.ts.tv_sec);
+   return 0;
+}
+
+uint8_t NHTFlowCache::get_export_reason(Flow &flow)
+{
+   if ((flow.src_tcp_flags | flow.dst_tcp_flags) & (0x01 | 0x04)) {
+       // When FIN or RST is set, TCP connection ended naturally
+       return FLOW_END_EOF;
+   } else {
+       return FLOW_END_INACTIVE;
+   }
+}
+
+void NHTFlowCache::export_expired(time_t ts)
+{
+   for (decltype(m_timeout_idx) i = m_timeout_idx; i < m_timeout_idx + m_line_new_idx; i++) {
+       if (!m_flow_table[i]->is_empty() && ts - m_flow_table[i]->m_flow.time_last.tv_sec >= m_inactive) {
+           m_flow_table[i]->m_flow.end_reason = get_export_reason(m_flow_table[i]->m_flow);
+           plugins_pre_export(m_flow_table[i]->m_flow);
+           export_flow(i);
+#ifdef FLOW_CACHE_STATS
+           m_expired++;
+#endif /* FLOW_CACHE_STATS */
+       }
+   }
+
+   m_timeout_idx = (m_timeout_idx + m_line_new_idx) & (m_cache_size - 1);
+}
+
+bool NHTFlowCache::create_hash_key(Packet &pkt)
+{
+   if (pkt.ip_version == IP::v4) {
+       struct flow_key_v4_t *key_v4 = reinterpret_cast<struct flow_key_v4_t *>(m_key);
+       struct flow_key_v4_t *key_v4_inv = reinterpret_cast<struct flow_key_v4_t *>(m_key_inv);
+
+       key_v4->proto = pkt.ip_proto;
+       key_v4->ip_version = IP::v4;
+       key_v4->src_port = pkt.src_port;
+       key_v4->dst_port = pkt.dst_port;
+       key_v4->src_ip = pkt.src_ip.v4;
+       key_v4->dst_ip = pkt.dst_ip.v4;
+       key_v4->vlan_id = pkt.vlan_id;
+
+       key_v4_inv->proto = pkt.ip_proto;
+       key_v4_inv->ip_version = IP::v4;
+       key_v4_inv->src_port = pkt.dst_port;
+       key_v4_inv->dst_port = pkt.src_port;
+       key_v4_inv->src_ip = pkt.dst_ip.v4;
+       key_v4_inv->dst_ip = pkt.src_ip.v4;
+       key_v4_inv->vlan_id = pkt.vlan_id;
+
+       m_keylen = sizeof(flow_key_v4_t);
+       return true;
+   } else if (pkt.ip_version == IP::v6) {
+       struct flow_key_v6_t *key_v6 = reinterpret_cast<struct flow_key_v6_t *>(m_key);
+       struct flow_key_v6_t *key_v6_inv = reinterpret_cast<struct flow_key_v6_t *>(m_key_inv);
+
+       key_v6->proto = pkt.ip_proto;
+       key_v6->ip_version = IP::v6;
+       key_v6->src_port = pkt.src_port;
+       key_v6->dst_port = pkt.dst_port;
+       memcpy(key_v6->src_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
+       memcpy(key_v6->dst_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
+       key_v6->vlan_id = pkt.vlan_id;
+
+       key_v6_inv->proto = pkt.ip_proto;
+       key_v6_inv->ip_version = IP::v6;
+       key_v6_inv->src_port = pkt.dst_port;
+       key_v6_inv->dst_port = pkt.src_port;
+       memcpy(key_v6_inv->src_ip, pkt.dst_ip.v6, sizeof(pkt.dst_ip.v6));
+       memcpy(key_v6_inv->dst_ip, pkt.src_ip.v6, sizeof(pkt.src_ip.v6));
+       key_v6_inv->vlan_id = pkt.vlan_id;
+
+       m_keylen = sizeof(flow_key_v6_t);
+       return true;
+   }
+
+   return false;
+}
+
+#ifdef FLOW_CACHE_STATS
+void NHTFlowCache::print_report()
+{
+   float tmp = float(m_lookups) / m_hits;
+
+   cout << "Hits: " << m_hits << endl;
+   cout << "Empty: " << m_empty << endl;
+   cout << "Not empty: " << m_not_empty << endl;
+   cout << "Expired: " << m_expired << endl;
+   cout << "Flushed: " << m_flushed << endl;
+   cout << "Average Lookup:  " << tmp << endl;
+   cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << endl;
+}
+#endif /* FLOW_CACHE_STATS */
+
+}

--- a/storage/old_cache.cpp
+++ b/storage/old_cache.cpp
@@ -1,45 +1,45 @@
 /**
-* \file cache.cpp
-* \brief "NewHashTable" flow cache
-* \author Martin Zadnik <zadnik@cesnet.cz>
-* \author Vaclav Bartos <bartos@cesnet.cz>
-* \author Jiri Havranek <havranek@cesnet.cz>
-* \date 2014
-* \date 2015
-* \date 2016
-*/
+ * \file cache.cpp
+ * \brief "NewHashTable" flow cache
+ * \author Martin Zadnik <zadnik@cesnet.cz>
+ * \author Vaclav Bartos <bartos@cesnet.cz>
+ * \author Jiri Havranek <havranek@cesnet.cz>
+ * \date 2014
+ * \date 2015
+ * \date 2016
+ */
 /*
-* Copyright (C) 2014-2016 CESNET
-*
-* LICENSE TERMS
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-* 1. Redistributions of source code must retain the above copyright
-*    notice, this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-*    notice, this list of conditions and the following disclaimer in
-*    the documentation and/or other materials provided with the
-*    distribution.
-* 3. Neither the name of the Company nor the names of its contributors
-*    may be used to endorse or promote products derived from this
-*    software without specific prior written permission.
-*
-*
-*
-*/
+ * Copyright (C) 2014-2016 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ *
+ *
+ */
 
 #include <cstdlib>
-#include <iostream>
 #include <cstring>
-#include <sys/time.h>
-#include <iomanip>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sys/time.h>
 
-#include <ipfixprobe/ring.h>
 #include "old_cache.hpp"
 #include "xxhash.h"
+#include <ipfixprobe/ring.h>
 
 namespace ipxp {
 namespace old_cache {
@@ -311,26 +311,13 @@ void OldNHTFlowCache::flush(Packet& pkt, size_t flow_index, int ret, bool source
         export_flow(flow_index);
     }
 }
-#ifdef FLOW_CACHE_STATS
-void OldNHTFlowCache::print_cache_dump()const noexcept{
-    /*std::ofstream outfile;
-    outfile.open("old_cache_res.txt", std::ios_base::app);
-    const uint32_t field_count = sizeof(FlowRecord)/sizeof(uint32_t);
-    for(uint32_t i = 0; i < m_cache_size + m_qsize; i++)
-        for(uint32_t k = 0; k < field_count; k++)
-            outfile<<reinterpret_cast<uint32_t*>(&m_flow_records[i])[k];
-    outfile.close();*/
-}
-#endif /*FLOW_CACHE_STATS*/
 
 int OldNHTFlowCache::put_pkt(Packet& pkt)
 {
-#ifdef FLOW_CACHE_STATS
-    print_cache_dump();
-#endif /*FLOW_CACHE_STATS*/
     int ret = plugins_pre_create(pkt);
 
-    if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key and NHTFlowCache::m_keylen
+    if (!create_hash_key(pkt)) { // saves key value and key length into attributes NHTFlowCache::key
+                                 // and NHTFlowCache::m_keylen
         return 0;
     }
 
@@ -349,7 +336,7 @@ int OldNHTFlowCache::put_pkt(Packet& pkt)
         if (m_flow_table[flow_index]->belongs(hashval)) {
             found = true;
 #ifdef FLOW_CACHE_STATS
-            //std::cout<<m_order << " was found directly\n";
+            // std::cout<<m_order << " was found directly\n";
 #endif /*FLOW_CACHE_STATS*/
             break;
         }
@@ -367,7 +354,7 @@ int OldNHTFlowCache::put_pkt(Packet& pkt)
                 hashval = hashval_inv;
                 line_index = line_index_inv;
 #ifdef FLOW_CACHE_STATS
-                //std::cout<<m_order << " was found reversed\n";
+                // std::cout<<m_order << " was found reversed\n";
 #endif /*FLOW_CACHE_STATS*/
                 break;
             }
@@ -393,7 +380,7 @@ int OldNHTFlowCache::put_pkt(Packet& pkt)
 #endif /* FLOW_CACHE_STATS */
     } else {
 #ifdef FLOW_CACHE_STATS
-       // std::cout<<m_order << " was not found\n";
+        // std::cout<<m_order << " was not found\n";
 #endif /*FLOW_CACHE_STATS*/
         /* Existing flow record was not found. Find free place in flow line. */
         for (flow_index = line_index; flow_index < next_line; flow_index++) {
@@ -404,7 +391,7 @@ int OldNHTFlowCache::put_pkt(Packet& pkt)
         }
         if (!found) {
             /* If free place was not found (flow line is full), find
-         * record which will be replaced by new record. */
+             * record which will be replaced by new record. */
             flow_index = next_line - 1;
 
             // Export flow
@@ -586,5 +573,5 @@ void OldNHTFlowCache::print_report()
     std::cout << "Variance Lookup: " << float(m_lookups2) / m_hits - tmp * tmp << std::endl;
 }
 #endif /* FLOW_CACHE_STATS */
-}
-}
+} // namespace old_cache
+} // namespace ipxp

--- a/storage/old_cache.cpp
+++ b/storage/old_cache.cpp
@@ -325,7 +325,7 @@ int OldNHTFlowCache::put_pkt(Packet& pkt)
     uint64_t hashval
         = XXH64(m_key, m_keylen, 0); /* Calculates hash value from key created before. */
 
-    //std::cerr<< hashval << std::endl;
+    // std::cerr<< hashval << std::endl;
     FlowRecord* flow; /* Pointer to flow we will be working with. */
     bool found = false;
     bool source_flow = true;

--- a/storage/old_cache.cpp
+++ b/storage/old_cache.cpp
@@ -183,7 +183,8 @@ OldNHTFlowCache::OldNHTFlowCache()
 OldNHTFlowCache::~OldNHTFlowCache()
 {
 #ifdef FLOW_CACHE_STATS
-    print_report();
+    if (m_hits)
+        print_report();
 #endif /*FLOW_CACHE_STATS */
     close();
 }

--- a/storage/old_cache.hpp
+++ b/storage/old_cache.hpp
@@ -29,8 +29,9 @@
 *
 *
 */
-#ifndef IPXP_STORAGE_CACHE_HPP
-#define IPXP_STORAGE_CACHE_HPP
+#define FLOW_CACHE_STATS true
+#ifndef IPXP_STORAGE_OLD_CACHE_HPP
+#define IPXP_STORAGE_OLD_CACHE_HPP
 
 #include <string>
 
@@ -40,25 +41,26 @@
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
+namespace old_cache {
 
 struct __attribute__((packed)) flow_key_v4_t {
-   uint16_t src_port;
-   uint16_t dst_port;
-   uint8_t proto;
-   uint8_t ip_version;
-   uint32_t src_ip;
-   uint32_t dst_ip;
-   uint16_t vlan_id;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t proto;
+    uint8_t ip_version;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+    uint16_t vlan_id;
 };
 
 struct __attribute__((packed)) flow_key_v6_t {
-   uint16_t src_port;
-   uint16_t dst_port;
-   uint8_t proto;
-   uint8_t ip_version;
-   uint8_t src_ip[16];
-   uint8_t dst_ip[16];
-   uint16_t vlan_id;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t proto;
+    uint8_t ip_version;
+    uint8_t src_ip[16];
+    uint8_t dst_ip[16];
+    uint16_t vlan_id;
 };
 
 #define MAX_KEY_LENGTH (max<size_t>(sizeof(flow_key_v4_t), sizeof(flow_key_v6_t)))
@@ -78,121 +80,182 @@ static const uint32_t DEFAULT_FLOW_LINE_SIZE = 4; // 16 records per line
 static const uint32_t DEFAULT_INACTIVE_TIMEOUT = 30;
 static const uint32_t DEFAULT_ACTIVE_TIMEOUT = 300;
 
-static_assert(std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(), "Static checks of default cache sizes won't properly work without unsigned type.");
-static_assert(bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE, "Flow cache size is too big to fit in variable!");
-static_assert(bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE, "Flow cache line size is too big to fit in variable!");
+static_assert(
+    std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(),
+    "Static checks of default cache sizes won't properly work without unsigned type.");
+static_assert(
+    bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE,
+    "Flow cache size is too big to fit in variable!");
+static_assert(
+    bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE,
+    "Flow cache line size is too big to fit in variable!");
 
 static_assert(DEFAULT_FLOW_LINE_SIZE >= 1, "Flow cache line size must be at least 1!");
-static_assert(DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE, "Flow cache size must be at least cache line size!");
+static_assert(
+    DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE,
+    "Flow cache size must be at least cache line size!");
 
-class CacheOptParser : public OptionsParser
-{
+class CacheOptParser : public OptionsParser {
 public:
-   uint32_t m_cache_size;
-   uint32_t m_line_size;
-   uint32_t m_active;
-   uint32_t m_inactive;
-   bool m_split_biflow;
+    uint32_t m_cache_size;
+    uint32_t m_line_size;
+    uint32_t m_active;
+    uint32_t m_inactive;
+    bool m_split_biflow;
 
-   CacheOptParser() : OptionsParser("cache", "Storage plugin implemented as a hash table"),
-       m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE), m_line_size(1 << DEFAULT_FLOW_LINE_SIZE),
-       m_active(DEFAULT_ACTIVE_TIMEOUT), m_inactive(DEFAULT_INACTIVE_TIMEOUT), m_split_biflow(false)
-   {
-       register_option("s", "size", "EXPONENT", "Cache size exponent to the power of two",
-           [this](const char *arg){try {unsigned exp = str2num<decltype(exp)>(arg);
-              if (exp < 4 || exp > 30) {
-                 throw PluginError("Flow cache size must be between 4 and 30");
-              }
-              m_cache_size = static_cast<uint32_t>(1) << exp;
-           } catch(std::invalid_argument &e) {return false;} return true;},
-           OptionFlags::RequiredArgument);
-       register_option("l", "line", "EXPONENT", "Cache line size exponent to the power of two",
-           [this](const char *arg){try {m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
-              if (m_line_size < 1) {
-                 throw PluginError("Flow cache line size must be at least 1");
-              }
-           } catch(std::invalid_argument &e) {return false;} return true;},
-           OptionFlags::RequiredArgument);
-       register_option("a", "active", "TIME", "Active timeout in seconds",
-           [this](const char *arg){try {m_active = str2num<decltype(m_active)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-           OptionFlags::RequiredArgument);
-       register_option("i", "inactive", "TIME", "Inactive timeout in seconds",
-           [this](const char *arg){try {m_inactive = str2num<decltype(m_inactive)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
-           OptionFlags::RequiredArgument);
-       register_option("S", "split", "", "Split biflows into uniflows",
-           [this](const char *arg){ m_split_biflow = true; return true;}, OptionFlags::NoArgument);
-   }
+    CacheOptParser()
+        : OptionsParser("old_cache", "Storage plugin implemented as a hash table")
+        , m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE)
+        , m_line_size(1 << DEFAULT_FLOW_LINE_SIZE)
+        , m_active(DEFAULT_ACTIVE_TIMEOUT)
+        , m_inactive(DEFAULT_INACTIVE_TIMEOUT)
+        , m_split_biflow(false)
+    {
+        register_option(
+            "s",
+            "size",
+            "EXPONENT",
+            "Cache size exponent to the power of two",
+            [this](const char* arg) {
+                try {
+                    unsigned exp = str2num<decltype(exp)>(arg);
+                    if (exp < 4 || exp > 30) {
+                        throw PluginError("Flow cache size must be between 4 and 30");
+                    }
+                    m_cache_size = static_cast<uint32_t>(1) << exp;
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "l",
+            "line",
+            "EXPONENT",
+            "Cache line size exponent to the power of two",
+            [this](const char* arg) {
+                try {
+                    m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
+                    if (m_line_size < 1) {
+                        throw PluginError("Flow cache line size must be at least 1");
+                    }
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "a",
+            "active",
+            "TIME",
+            "Active timeout in seconds",
+            [this](const char* arg) {
+                try {
+                    m_active = str2num<decltype(m_active)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "i",
+            "inactive",
+            "TIME",
+            "Inactive timeout in seconds",
+            [this](const char* arg) {
+                try {
+                    m_inactive = str2num<decltype(m_inactive)>(arg);
+                } catch (std::invalid_argument& e) {
+                    return false;
+                }
+                return true;
+            },
+            OptionFlags::RequiredArgument);
+        register_option(
+            "S",
+            "split",
+            "",
+            "Split biflows into uniflows",
+            [this](const char* arg) {
+                m_split_biflow = true;
+                return true;
+            },
+            OptionFlags::NoArgument);
+    }
 };
 
-class FlowRecord
-{
-   uint64_t m_hash;
+class FlowRecord {
+    uint64_t m_hash;
 
 public:
-   Flow m_flow;
+    Flow m_flow;
 
-   FlowRecord();
-   ~FlowRecord();
+    FlowRecord();
+    ~FlowRecord();
 
-   void erase();
-   void reuse();
+    void erase();
+    void reuse();
 
-   inline bool is_empty() const;
-   inline bool belongs(uint64_t pkt_hash) const;
-   void create(const Packet &pkt, uint64_t pkt_hash);
-   void update(const Packet &pkt, bool src);
+    inline bool is_empty() const;
+    inline bool belongs(uint64_t pkt_hash) const;
+    void create(const Packet& pkt, uint64_t pkt_hash);
+    void update(const Packet& pkt, bool src);
 };
 
-class NHTFlowCache : public StoragePlugin
-{
+class OldNHTFlowCache : public StoragePlugin {
 public:
-   NHTFlowCache();
-   ~NHTFlowCache();
-   void init(const char *params);
-   void close();
-   void set_queue(ipx_ring_t *queue);
-   OptionsParser *get_parser() const { return new CacheOptParser(); }
-   std::string get_name() const { return "cache"; }
+    OldNHTFlowCache();
+    ~OldNHTFlowCache();
+    void init(const char* params);
+    void close();
+    void set_queue(ipx_ring_t* queue);
+    OptionsParser* get_parser() const { return new CacheOptParser(); }
+    std::string get_name() const { return "cache"; }
 
-   int put_pkt(Packet &pkt);
-   void export_expired(time_t ts);
+    int put_pkt(Packet& pkt);
+    void export_expired(time_t ts);
 
 private:
-   uint32_t m_cache_size;
-   uint32_t m_line_size;
-   uint32_t m_line_mask;
-   uint32_t m_line_new_idx;
-   uint32_t m_qsize;
-   uint32_t m_qidx;
-   uint32_t m_timeout_idx;
+    uint32_t m_cache_size;
+    uint32_t m_line_size;
+    uint32_t m_line_mask;
+    uint32_t m_line_new_idx;
+    uint32_t m_qsize;
+    uint32_t m_qidx;
+    uint32_t m_timeout_idx;
 #ifdef FLOW_CACHE_STATS
-   uint64_t m_empty;
-   uint64_t m_not_empty;
-   uint64_t m_hits;
-   uint64_t m_expired;
-   uint64_t m_flushed;
-   uint64_t m_lookups;
-   uint64_t m_lookups2;
+    uint64_t m_empty;
+    uint64_t m_not_empty;
+    uint64_t m_hits;
+    uint64_t m_expired;
+    uint64_t m_flushed;
+    uint64_t m_lookups;
+    uint64_t m_lookups2;
+    uint64_t m_order;
 #endif /* FLOW_CACHE_STATS */
-   uint32_t m_active;
-   uint32_t m_inactive;
-   bool m_split_biflow;
-   uint8_t m_keylen;
-   char m_key[MAX_KEY_LENGTH];
-   char m_key_inv[MAX_KEY_LENGTH];
-   FlowRecord **m_flow_table;
-   FlowRecord *m_flow_records;
+    uint32_t m_active;
+    uint32_t m_inactive;
+    bool m_split_biflow;
+    uint8_t m_keylen;
+    char m_key[MAX_KEY_LENGTH];
+    char m_key_inv[MAX_KEY_LENGTH];
+    FlowRecord** m_flow_table;
+    FlowRecord* m_flow_records;
 
-   void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow);
-   bool create_hash_key(Packet &pkt);
-   void export_flow(size_t index);
-   static uint8_t get_export_reason(Flow &flow);
-   void finish();
+    void flush(Packet& pkt, size_t flow_index, int ret, bool source_flow);
+    bool create_hash_key(Packet& pkt);
+    void export_flow(size_t index);
+    static uint8_t get_export_reason(Flow& flow);
+    void finish();
 
 #ifdef FLOW_CACHE_STATS
-   void print_report();
+    void print_report();
+    void print_cache_dump()const noexcept;
 #endif /* FLOW_CACHE_STATS */
 };
-
 }
-#endif /* IPXP_STORAGE_CACHE_HPP */
+}
+#endif /* IPXP_STORAGE_OLD_CACHE_HPP */

--- a/storage/old_cache.hpp
+++ b/storage/old_cache.hpp
@@ -1,0 +1,198 @@
+/**
+* \file cache.hpp
+* \brief "NewHashTable" flow cache
+* \author Martin Zadnik <zadnik@cesnet.cz>
+* \author Vaclav Bartos <bartos@cesnet.cz>
+* \author Jiri Havranek <havranek@cesnet.cz>
+* \date 2014
+* \date 2015
+* \date 2016
+*/
+/*
+* Copyright (C) 2014-2016 CESNET
+*
+* LICENSE TERMS
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name of the Company nor the names of its contributors
+*    may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+*
+*
+*/
+#ifndef IPXP_STORAGE_CACHE_HPP
+#define IPXP_STORAGE_CACHE_HPP
+
+#include <string>
+
+#include <ipfixprobe/storage.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/utils.hpp>
+
+namespace ipxp {
+
+struct __attribute__((packed)) flow_key_v4_t {
+   uint16_t src_port;
+   uint16_t dst_port;
+   uint8_t proto;
+   uint8_t ip_version;
+   uint32_t src_ip;
+   uint32_t dst_ip;
+   uint16_t vlan_id;
+};
+
+struct __attribute__((packed)) flow_key_v6_t {
+   uint16_t src_port;
+   uint16_t dst_port;
+   uint8_t proto;
+   uint8_t ip_version;
+   uint8_t src_ip[16];
+   uint8_t dst_ip[16];
+   uint16_t vlan_id;
+};
+
+#define MAX_KEY_LENGTH (max<size_t>(sizeof(flow_key_v4_t), sizeof(flow_key_v6_t)))
+
+#ifdef IPXP_FLOW_CACHE_SIZE
+static const uint32_t DEFAULT_FLOW_CACHE_SIZE = IPXP_FLOW_CACHE_SIZE;
+#else
+static const uint32_t DEFAULT_FLOW_CACHE_SIZE = 17; // 131072 records total
+#endif /* IPXP_FLOW_CACHE_SIZE */
+
+#ifdef IPXP_FLOW_LINE_SIZE
+static const uint32_t DEFAULT_FLOW_LINE_SIZE = IPXP_FLOW_LINE_SIZE;
+#else
+static const uint32_t DEFAULT_FLOW_LINE_SIZE = 4; // 16 records per line
+#endif /* IPXP_FLOW_LINE_SIZE */
+
+static const uint32_t DEFAULT_INACTIVE_TIMEOUT = 30;
+static const uint32_t DEFAULT_ACTIVE_TIMEOUT = 300;
+
+static_assert(std::is_unsigned<decltype(DEFAULT_FLOW_CACHE_SIZE)>(), "Static checks of default cache sizes won't properly work without unsigned type.");
+static_assert(bitcount<decltype(DEFAULT_FLOW_CACHE_SIZE)>(-1) > DEFAULT_FLOW_CACHE_SIZE, "Flow cache size is too big to fit in variable!");
+static_assert(bitcount<decltype(DEFAULT_FLOW_LINE_SIZE)>(-1) > DEFAULT_FLOW_LINE_SIZE, "Flow cache line size is too big to fit in variable!");
+
+static_assert(DEFAULT_FLOW_LINE_SIZE >= 1, "Flow cache line size must be at least 1!");
+static_assert(DEFAULT_FLOW_CACHE_SIZE >= DEFAULT_FLOW_LINE_SIZE, "Flow cache size must be at least cache line size!");
+
+class CacheOptParser : public OptionsParser
+{
+public:
+   uint32_t m_cache_size;
+   uint32_t m_line_size;
+   uint32_t m_active;
+   uint32_t m_inactive;
+   bool m_split_biflow;
+
+   CacheOptParser() : OptionsParser("cache", "Storage plugin implemented as a hash table"),
+       m_cache_size(1 << DEFAULT_FLOW_CACHE_SIZE), m_line_size(1 << DEFAULT_FLOW_LINE_SIZE),
+       m_active(DEFAULT_ACTIVE_TIMEOUT), m_inactive(DEFAULT_INACTIVE_TIMEOUT), m_split_biflow(false)
+   {
+       register_option("s", "size", "EXPONENT", "Cache size exponent to the power of two",
+           [this](const char *arg){try {unsigned exp = str2num<decltype(exp)>(arg);
+              if (exp < 4 || exp > 30) {
+                 throw PluginError("Flow cache size must be between 4 and 30");
+              }
+              m_cache_size = static_cast<uint32_t>(1) << exp;
+           } catch(std::invalid_argument &e) {return false;} return true;},
+           OptionFlags::RequiredArgument);
+       register_option("l", "line", "EXPONENT", "Cache line size exponent to the power of two",
+           [this](const char *arg){try {m_line_size = static_cast<uint32_t>(1) << str2num<decltype(m_line_size)>(arg);
+              if (m_line_size < 1) {
+                 throw PluginError("Flow cache line size must be at least 1");
+              }
+           } catch(std::invalid_argument &e) {return false;} return true;},
+           OptionFlags::RequiredArgument);
+       register_option("a", "active", "TIME", "Active timeout in seconds",
+           [this](const char *arg){try {m_active = str2num<decltype(m_active)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
+           OptionFlags::RequiredArgument);
+       register_option("i", "inactive", "TIME", "Inactive timeout in seconds",
+           [this](const char *arg){try {m_inactive = str2num<decltype(m_inactive)>(arg);} catch(std::invalid_argument &e) {return false;} return true;},
+           OptionFlags::RequiredArgument);
+       register_option("S", "split", "", "Split biflows into uniflows",
+           [this](const char *arg){ m_split_biflow = true; return true;}, OptionFlags::NoArgument);
+   }
+};
+
+class FlowRecord
+{
+   uint64_t m_hash;
+
+public:
+   Flow m_flow;
+
+   FlowRecord();
+   ~FlowRecord();
+
+   void erase();
+   void reuse();
+
+   inline bool is_empty() const;
+   inline bool belongs(uint64_t pkt_hash) const;
+   void create(const Packet &pkt, uint64_t pkt_hash);
+   void update(const Packet &pkt, bool src);
+};
+
+class NHTFlowCache : public StoragePlugin
+{
+public:
+   NHTFlowCache();
+   ~NHTFlowCache();
+   void init(const char *params);
+   void close();
+   void set_queue(ipx_ring_t *queue);
+   OptionsParser *get_parser() const { return new CacheOptParser(); }
+   std::string get_name() const { return "cache"; }
+
+   int put_pkt(Packet &pkt);
+   void export_expired(time_t ts);
+
+private:
+   uint32_t m_cache_size;
+   uint32_t m_line_size;
+   uint32_t m_line_mask;
+   uint32_t m_line_new_idx;
+   uint32_t m_qsize;
+   uint32_t m_qidx;
+   uint32_t m_timeout_idx;
+#ifdef FLOW_CACHE_STATS
+   uint64_t m_empty;
+   uint64_t m_not_empty;
+   uint64_t m_hits;
+   uint64_t m_expired;
+   uint64_t m_flushed;
+   uint64_t m_lookups;
+   uint64_t m_lookups2;
+#endif /* FLOW_CACHE_STATS */
+   uint32_t m_active;
+   uint32_t m_inactive;
+   bool m_split_biflow;
+   uint8_t m_keylen;
+   char m_key[MAX_KEY_LENGTH];
+   char m_key_inv[MAX_KEY_LENGTH];
+   FlowRecord **m_flow_table;
+   FlowRecord *m_flow_records;
+
+   void flush(Packet &pkt, size_t flow_index, int ret, bool source_flow);
+   bool create_hash_key(Packet &pkt);
+   void export_flow(size_t index);
+   static uint8_t get_export_reason(Flow &flow);
+   void finish();
+
+#ifdef FLOW_CACHE_STATS
+   void print_report();
+#endif /* FLOW_CACHE_STATS */
+};
+
+}
+#endif /* IPXP_STORAGE_CACHE_HPP */

--- a/storage/old_cache.hpp
+++ b/storage/old_cache.hpp
@@ -1,43 +1,42 @@
 /**
-* \file cache.hpp
-* \brief "NewHashTable" flow cache
-* \author Martin Zadnik <zadnik@cesnet.cz>
-* \author Vaclav Bartos <bartos@cesnet.cz>
-* \author Jiri Havranek <havranek@cesnet.cz>
-* \date 2014
-* \date 2015
-* \date 2016
-*/
+ * \file cache.hpp
+ * \brief "NewHashTable" flow cache
+ * \author Martin Zadnik <zadnik@cesnet.cz>
+ * \author Vaclav Bartos <bartos@cesnet.cz>
+ * \author Jiri Havranek <havranek@cesnet.cz>
+ * \date 2014
+ * \date 2015
+ * \date 2016
+ */
 /*
-* Copyright (C) 2014-2016 CESNET
-*
-* LICENSE TERMS
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-* 1. Redistributions of source code must retain the above copyright
-*    notice, this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-*    notice, this list of conditions and the following disclaimer in
-*    the documentation and/or other materials provided with the
-*    distribution.
-* 3. Neither the name of the Company nor the names of its contributors
-*    may be used to endorse or promote products derived from this
-*    software without specific prior written permission.
-*
-*
-*
-*/
-#define FLOW_CACHE_STATS true
+ * Copyright (C) 2014-2016 CESNET
+ *
+ * LICENSE TERMS
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the Company nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ *
+ *
+ */
 #ifndef IPXP_STORAGE_OLD_CACHE_HPP
 #define IPXP_STORAGE_OLD_CACHE_HPP
 
 #include <string>
 
-#include <ipfixprobe/storage.hpp>
-#include <ipfixprobe/options.hpp>
 #include <ipfixprobe/flowifc.hpp>
+#include <ipfixprobe/options.hpp>
+#include <ipfixprobe/storage.hpp>
 #include <ipfixprobe/utils.hpp>
 
 namespace ipxp {
@@ -234,7 +233,6 @@ private:
     uint64_t m_flushed;
     uint64_t m_lookups;
     uint64_t m_lookups2;
-    uint64_t m_order;
 #endif /* FLOW_CACHE_STATS */
     uint32_t m_active;
     uint32_t m_inactive;
@@ -253,9 +251,9 @@ private:
 
 #ifdef FLOW_CACHE_STATS
     void print_report();
-    void print_cache_dump()const noexcept;
+    void print_cache_dump() const noexcept;
 #endif /* FLOW_CACHE_STATS */
 };
-}
-}
+} // namespace old_cache
+} // namespace ipxp
 #endif /* IPXP_STORAGE_OLD_CACHE_HPP */

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -6,7 +6,7 @@ cppflags=
 ldflags=
 endif
 
-check_PROGRAMS=utils byte_utils options flowifc unirec
+check_PROGRAMS=utils byte_utils options flowifc unirec cache
 
 if HAVE_GOOGLETEST
 utils_SOURCES=utils.cpp
@@ -47,5 +47,13 @@ unirec_SOURCES=skip.cpp
 endif
 unirec_CPPFLAGS=$(cppflags)
 unirec_LDFLAGS=$(ldflags)
+
+if HAVE_GOOGLETEST
+cache_SOURCES=cache.cpp
+else
+cache_SOURCES=skip.cpp
+endif
+cache_CPPFLAGS=$(cppflags)
+cache_LDFLAGS=$(ldflags)
 
 TESTS=$(check_PROGRAMS)

--- a/tests/unit/cache.cpp
+++ b/tests/unit/cache.cpp
@@ -1,60 +1,51 @@
 #include <algorithm>
 #include "gtest/gtest.h"
 
-#include "ipfixprobe/flowifc.hpp"
+#include "storage/cache.hpp"
+#include "storage/old_cache.hpp"
+#include "fstream"
+#include <sys/stat.h>
+#include <limits.h>
 
 namespace ipxp_test {
 
 using namespace ipxp;
 
-RecordExt *genext(int id)
+TEST(TestCaches,compareResult)
 {
-   return new RecordExt(id);
-}
-
-class TestExt : public RecordExt
-{
-public:
-   static int REGISTERED_ID;
-
-   TestExt() : RecordExt(REGISTERED_ID) {}
-};
-
-int TestExt::REGISTERED_ID = -1;
-
-class TestRec : public::testing::Test, public Record
-{
-protected:
-   std::vector<RecordExt *> m_vec;
-
-   void SetUp() {
-      m_vec.push_back(genext(1));
-      m_vec.push_back(genext(2));
-      m_vec.push_back(genext(1));
-      m_vec.push_back(genext(3));
-
-      for (auto it : m_vec) {
-         add_extension(it);
-      }
-   }
-
-   void TearDown() {
-      remove_extensions();
-   }
-};
-
-
-TEST(TestExt, registration)
-{
-   EXPECT_EQ(0, 1);
+    auto list ={"dns","mixed","bstats","dnssd","tls","sip","ssdp",
+                "ovpn","vlan","wg","http","rtsp","quic_initial-sample",
+                "smtp","idpcontent","arp","ntp","netbios"};
+    for(const auto& filename : list){
+        system((std::string("../../ipfixprobe -i 'pcap;file=../../pcaps/") + filename
+            +".pcap' -o 'text' -s old_cache > old_cache.res").c_str());
+        system((std::string("../../ipfixprobe -i 'pcap;file=../../pcaps/") + filename
+            + ".pcap' -o 'text' -s cache > cache.res").c_str());
+        std::ifstream f1("cache.res"),f2("old_cache.res");
+        std::cout<<"Testing:" << filename  << "\n";
+        if (!f1 || !f2)
+            FAIL() << "Some file(s) wasn't created\n";
+        std::string str1,str2;
+        while(true){
+            std::getline(f1,str1);
+            std::getline(f2,str2);
+            EXPECT_EQ(str1, str2) << "Mismatch\n";
+            if (f2.eof() && f1.eof())
+                break;
+            if (f1.bad() || f2.bad() || (f1.eof() && !f2.eof()) || (f2.eof() && !f1.eof()))
+                FAIL() << "Error\n";
+        }
+        f1.close();
+        f2.close();
+    }
 }
 
 }
 
 int main(int argc, char **argv)
 {
-   // invoking the tests
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+    // invoking the tests
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }
 

--- a/tests/unit/cache.cpp
+++ b/tests/unit/cache.cpp
@@ -1,0 +1,60 @@
+#include <algorithm>
+#include "gtest/gtest.h"
+
+#include "ipfixprobe/flowifc.hpp"
+
+namespace ipxp_test {
+
+using namespace ipxp;
+
+RecordExt *genext(int id)
+{
+   return new RecordExt(id);
+}
+
+class TestExt : public RecordExt
+{
+public:
+   static int REGISTERED_ID;
+
+   TestExt() : RecordExt(REGISTERED_ID) {}
+};
+
+int TestExt::REGISTERED_ID = -1;
+
+class TestRec : public::testing::Test, public Record
+{
+protected:
+   std::vector<RecordExt *> m_vec;
+
+   void SetUp() {
+      m_vec.push_back(genext(1));
+      m_vec.push_back(genext(2));
+      m_vec.push_back(genext(1));
+      m_vec.push_back(genext(3));
+
+      for (auto it : m_vec) {
+         add_extension(it);
+      }
+   }
+
+   void TearDown() {
+      remove_extensions();
+   }
+};
+
+
+TEST(TestExt, registration)
+{
+   EXPECT_EQ(0, 1);
+}
+
+}
+
+int main(int argc, char **argv)
+{
+   // invoking the tests
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+

--- a/tests/unit/unirec.cpp
+++ b/tests/unit/unirec.cpp
@@ -4,7 +4,7 @@
 
 namespace ipxp_test {
 
-using namespace ipxp;
+/*using namespace ipxp;
 
 TEST(UnirecOptParser, pluginMap) {
    UnirecOptParser p;
@@ -46,7 +46,7 @@ TEST(UnirecOptParser, plugins) {
    EXPECT_EQ(m[1][0], "bar1");
    EXPECT_EQ(m[1][1], "bar2");
    EXPECT_EQ(m[2][0], "foo2");
-}
+}*/
 
 }
 


### PR DESCRIPTION
Dobrý den,
Provedl jsem:
Refactoring souborů cache.hpp/cpp, spolu s tím ponechal jsem staré soubory jako old_cache.hpp/cpp.
Přidal jsem parameter --with-debugcache do autoconfigu, potřebný pro vypisování statistický údajů cache na konci programu.
Ty statistické údaje používám v testu, který jsem přidal do tests/unit/cache.cpp, ten by měl podtvrdit, že náhrada, co jsem udělal nic nerozbila.
Zajímal by mě váš názor, co mám upravit? Mám udělat lepší test? Nebo udělat lepší refactoring? Obzvlášť by mě zajímalo jak je to s testem, jelikož nová verze cache dělá to samé, co i stará, takže, dalším krokem bude odstraněni nepotřebných souborů a spolu s tím i mého testu?
S pozdravem, Zainullin Damir.