### PR TITLE
docker - introduce docker container for processing pcaps to csvs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,7 +262,8 @@ EXTRA_DIST=README.md \
 	pcaps/quic_initial-sample.pcap \
 	debian/control debian/changelog debian/watch debian/copyright debian/patches debian/patches/series \
 	debian/source debian/source/format debian/source/local-options debian/source/include-binaries \
-	debian/rules debian/README.Debian debian/compat
+	debian/rules debian/README.Debian debian/compat \
+	docker/Dockerfile docker/ipfixprobe_wrapper.sh docker/process_script.sh docker/README.md
 
 bashcompl_DATA=ipfixprobe.bash
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM rockylinux:9
+
+RUN dnf install -y dnf-plugins-core && \
+    dnf copr -y enable @CESNET/NEMEA && \
+    dnf install -y epel-release && \
+    dnf install -y ipfixprobe nemea && \
+    dnf clean all
+
+RUN mkdir -p /output
+WORKDIR /output
+ENTRYPOINT ["/bin/bash", "-c"]
+
+VOLUME ["/output"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,45 @@
+# ipfixprobe Docker wrapper 
+
+This repository contains a Docker container that processes network traffic from a pcap file using `ipfixprobe`. It accepts a pcap file and a processing script, runs it inside the container, and outputs the results in CSV format.
+
+## Requirements
+ * Docker or Podman
+ * bash
+ * which, mktemp
+
+## Usage
+This container performs the following tasks:
+ 1. Copies a pcap file and processing script into the container.
+ 2.	Runs the ipfixprobe tool to export flows.
+ 3.	Logs the results in CSV format.
+
+### Build
+
+The script builds the image automatically, but be sure that Dockerfile is in the same directory.
+
+To build the manually image, navigate to the directory containing the Dockerfile and run:
+
+```bash
+docker build -t docker_ipfixprobe .
+```
+
+### Run
+To run, use
+    
+```bash
+bash ./ipfixprobe_wrapper.sh <process_script.sh> <input_file.pcap> <output_file.csv>
+```
+
+To process a file `../pcaps/mixed.pcap` using a processing script `process_script.sh` and output the results to `output.csv`, use the following wrapper script:
+
+```bash
+bash ./ipfixprobe_wrapper.sh ./process_script.sh ../pcaps/mixed.pcap ./output.csv
+```
+
+* `process_script.sh` Script for processing the pcap file inside the container.
+* `input_file.pcap` Path to the input pcap file
+* `output_file.csv` Path to the output CSV file
+
+### Volumes
+
+The container uses `/output` as a volume to share files between your host system temporary dir (with `mktemp`) and the container.

--- a/docker/ipfixprobe_wrapper.sh
+++ b/docker/ipfixprobe_wrapper.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+IMAGE_NAME="docker_ipfixprobe"
+
+# Run the ipfixprobe on the input pcap file with defined script, and save the output CSV file to the output path.
+PROCESS_SCRIPT_PATH=$1
+INPUT_FILE_PATH=$2
+OUTPUT_CSV_PATH=$3
+
+if [ -z "$PROCESS_SCRIPT_PATH" ] || [ -z "$INPUT_FILE_PATH" ] || [ -z "$OUTPUT_CSV_PATH" ] ; then
+    echo "Usage: $0 <process_script> <input_file_path> <output_csv_path>"
+    exit 1
+fi
+
+CONT_BIN="$(which podman 2>/dev/null)"
+if [ -z "$CONT_BIN" ]; then
+   CONT_BIN="$(which docker 2>/dev/null)"
+fi
+if [ -z "$CONT_BIN" ]; then
+   echo "Missing podman or docker."
+   exit 2
+fi
+
+# Check if the Docker image exists
+if ! $CONT_BIN image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+    echo "Docker image '$IMAGE_NAME' not found. Attempting to build it..."
+
+    # Determine the script directory
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    DOCKERFILE_PATH="$SCRIPT_DIR/Dockerfile"
+
+    if [ ! -f "$DOCKERFILE_PATH" ]; then
+        echo "Dockerfile not found at $DOCKERFILE_PATH"
+        exit 3
+    fi
+
+    # Build the Docker image
+    echo "Building Docker image '$IMAGE_NAME'..."
+    $CONT_BIN build -t "$IMAGE_NAME" -f "$DOCKERFILE_PATH" "$SCRIPT_DIR"
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to build Docker image."
+        exit 4
+    fi
+fi
+
+
+INPUT_FILE=$(basename "$INPUT_FILE_PATH")
+PROCESS_SCRIPT=$(basename "$PROCESS_SCRIPT_PATH")
+TMP_FOLDER="$(mktemp -d)"
+
+cp "$INPUT_FILE_PATH" "$TMP_FOLDER/$INPUT_FILE"
+cp "$PROCESS_SCRIPT_PATH" "$TMP_FOLDER/$PROCESS_SCRIPT"
+chmod +x "$TMP_FOLDER/$PROCESS_SCRIPT"
+
+"$CONT_BIN" run --privileged --rm -v $TMP_FOLDER:/output "$IMAGE_NAME"  "/output/$PROCESS_SCRIPT \"$INPUT_FILE\""
+[ -f "$TMP_FOLDER/$INPUT_FILE.csv" ] && cp "$TMP_FOLDER/$INPUT_FILE.csv" "$OUTPUT_CSV_PATH" || echo "No output CSV file found."
+
+# Clean up
+rm "$TMP_FOLDER/$INPUT_FILE"
+rm "$TMP_FOLDER/$PROCESS_SCRIPT"
+[ -f "$TMP_FOLDER/$INPUT_FILE.csv" ] && rm "$TMP_FOLDER/$INPUT_FILE.csv"
+rm -rf "$TMP_FOLDER"

--- a/docker/process_script.sh
+++ b/docker/process_script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+FILE=$1 # input file
+cd /output # workdir
+
+
+ipfixprobe -i "pcap;file=$FILE" -p "pstats" -p "nettisa" -o "unirec;i=f:$FILE.trapcap:timeout=WAIT;p=(pstats,nettisa)"
+/usr/bin/nemea/logger -t -i "f:$FILE.trapcap"  -w "$FILE.csv"
+rm $FILE.trapcap


### PR DESCRIPTION
This PR adds a docker/podman setup for running ipfixprobe to export pcap files to csv. It includes:
1. Dockerfile that installs all necessary dependencies.
2. Wrapper script to build image if necessary, run ipfixprobe inside the container, handling input and output files.
3. A (example) processing script that uses ipfixprobe and nemea to generate CSV logs from pcap data.
4. Readme with doc

Usage:
1. Build the Docker image: docker build -t docker_ipfixprobe .
2. Run the export: ./ipfixprobe_wrapper.sh <process_script.sh> <input_file.pcap> <output_file.csv>