### PR TITLE
Dpdk rx queue size fix

### DIFF
--- a/input/dpdk.h
+++ b/input/dpdk.h
@@ -44,7 +44,7 @@ namespace ipxp {
 class DpdkOptParser : public OptionsParser {
 private:
     static constexpr size_t DEFAULT_MBUF_BURST_SIZE = 64;
-    static constexpr size_t DEFAULT_MBUF_POOL_SIZE = 16384;
+    static constexpr size_t DEFAULT_MBUF_POOL_SIZE = 4096;
     size_t pkt_buffer_size_;
     size_t pkt_mempool_size_;
     std::vector<uint16_t> port_numbers_;

--- a/input/dpdk/dpdkDevice.cpp
+++ b/input/dpdk/dpdkDevice.cpp
@@ -54,7 +54,7 @@ DpdkDevice::DpdkDevice(
 	recognizeDriver();
 	configurePort();
 	initMemPools(memPoolSize);
-	setupRxQueues();
+	setupRxQueues(memPoolSize);
 	configureRSS();
 	enablePort();
 }
@@ -194,13 +194,13 @@ void DpdkDevice::initMemPools(uint16_t memPoolSize)
 	}
 }
 
-void DpdkDevice::setupRxQueues()
+void DpdkDevice::setupRxQueues(uint16_t memPoolSize)
 {
 	for (uint16_t rxQueueID = 0; rxQueueID < m_rxQueueCount; rxQueueID++) {
 		int ret = rte_eth_rx_queue_setup(
 			m_portID,
 			rxQueueID,
-			m_mBufsCount,
+			memPoolSize,
 			rte_eth_dev_socket_id(m_portID),
 			nullptr,
 			m_memPools[rxQueueID]);

--- a/input/dpdk/dpdkDevice.hpp
+++ b/input/dpdk/dpdkDevice.hpp
@@ -76,7 +76,7 @@ private:
 	void configurePort();
 	rte_eth_conf createPortConfig();
 	void initMemPools(uint16_t memPoolSize);
-	void setupRxQueues();
+	void setupRxQueues(uint16_t memPoolSize);
 	void configureRSS();
 	void enablePort();
 	void createRteMempool(uint16_t mempoolSize);


### PR DESCRIPTION
Ipfixprobe with DpdkDevice plugin used burst size as number of descriptors in rx queue between HW and SW. It was too small number and traffic was dropped. Now plugin uses the same size for mempool and number of descriptors. Default size of mempool was decreased to standard 4096 mbufs. Default burst size remains at 64 mbufs.