### PR TITLE
ipfixprobe-nemea: Add dependency on libtrap library

### DIFF
--- a/src/plugins/process/basicplus/CMakeLists.txt
+++ b/src/plugins/process/basicplus/CMakeLists.txt
@@ -22,6 +22,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-basicplus PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/bstats/CMakeLists.txt
+++ b/src/plugins/process/bstats/CMakeLists.txt
@@ -22,6 +22,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-bstats PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/dns/CMakeLists.txt
+++ b/src/plugins/process/dns/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-dns PRIVATE
 		-Wl,--whole-archive -Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/dnssd/CMakeLists.txt
+++ b/src/plugins/process/dnssd/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-dnssd PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/flowHash/CMakeLists.txt
+++ b/src/plugins/process/flowHash/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-flowhash PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/http/CMakeLists.txt
+++ b/src/plugins/process/http/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-http PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/icmp/CMakeLists.txt
+++ b/src/plugins/process/icmp/CMakeLists.txt
@@ -16,6 +16,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-icmp PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/idpContent/CMakeLists.txt
+++ b/src/plugins/process/idpContent/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-idpcontent PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/mpls/CMakeLists.txt
+++ b/src/plugins/process/mpls/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-mpls PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/mqtt/CMakeLists.txt
+++ b/src/plugins/process/mqtt/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-mqtt PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/netbios/CMakeLists.txt
+++ b/src/plugins/process/netbios/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-netbios PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/nettisa/CMakeLists.txt
+++ b/src/plugins/process/nettisa/CMakeLists.txt
@@ -22,6 +22,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-nettisa PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/ntp/CMakeLists.txt
+++ b/src/plugins/process/ntp/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-ntp PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/osquery/CMakeLists.txt
+++ b/src/plugins/process/osquery/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-osquery PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/ovpn/CMakeLists.txt
+++ b/src/plugins/process/ovpn/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-ovpn PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/passiveDns/CMakeLists.txt
+++ b/src/plugins/process/passiveDns/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-passivedns PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/phists/CMakeLists.txt
+++ b/src/plugins/process/phists/CMakeLists.txt
@@ -22,6 +22,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-phists PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/pstats/CMakeLists.txt
+++ b/src/plugins/process/pstats/CMakeLists.txt
@@ -22,6 +22,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-pstats PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/quic/CMakeLists.txt
+++ b/src/plugins/process/quic/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-quic PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/rtsp/CMakeLists.txt
+++ b/src/plugins/process/rtsp/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-rtsp PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/sip/CMakeLists.txt
+++ b/src/plugins/process/sip/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-sip PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/smtp/CMakeLists.txt
+++ b/src/plugins/process/smtp/CMakeLists.txt
@@ -19,6 +19,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-smtp PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/ssaDetector/CMakeLists.txt
+++ b/src/plugins/process/ssaDetector/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-ssadetector PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/ssdp/CMakeLists.txt
+++ b/src/plugins/process/ssdp/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-ssdp PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/tls/CMakeLists.txt
+++ b/src/plugins/process/tls/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-tls PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/vlan/CMakeLists.txt
+++ b/src/plugins/process/vlan/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-vlan PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 

--- a/src/plugins/process/wg/CMakeLists.txt
+++ b/src/plugins/process/wg/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ENABLE_NEMEA)
 	target_link_libraries(ipfixprobe-process-wg PRIVATE
 		-Wl,--whole-archive ipfixprobe-nemea-fields -Wl,--no-whole-archive
 		unirec::unirec
+		trap::trap
 	)
 endif()
 


### PR DESCRIPTION
Add missing libtrap library to CMakeLists for all process plugins