### PR TITLE
FlowHash: Rename flow_hash process plugin to flowhash

### DIFF
--- a/src/plugins/process/flowHash/src/flow_hash.cpp
+++ b/src/plugins/process/flowHash/src/flow_hash.cpp
@@ -20,8 +20,8 @@
 namespace ipxp {
 
 static const PluginManifest flowhashPluginManifest = {
-	.name = "flow_hash",
-	.description = "flow_hash process plugin for parsing flow_hash value.",
+	.name = "flowhash",
+	.description = "flowhash process plugin for parsing flowhash value.",
 	.pluginVersion = "1.0.0",
 	.apiVersion = "1.0.0",
 	.usage = nullptr,

--- a/src/plugins/process/flowHash/src/flow_hash.hpp
+++ b/src/plugins/process/flowHash/src/flow_hash.hpp
@@ -95,9 +95,9 @@ public:
 	void close();
 	OptionsParser* get_parser() const
 	{
-		return new OptionsParser("flow_hash", "Export flow hash as flow id");
+		return new OptionsParser("flowhash", "Export flow hash as flow id");
 	}
-	std::string get_name() const { return "flow_hash"; }
+	std::string get_name() const { return "flowhash"; }
 	RecordExt* get_ext() const { return new RecordExtFLOW_HASH(m_pluginID); }
 	ProcessPlugin* copy();
 


### PR DESCRIPTION
This is done to unify the names of all process plugins