### PR TITLE
Github-actions: speed up builds in GitHub Actions by using parallel make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,4 @@ jobs:
         cd build
         cmake3 .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_INPUT_PCAP=ON -DENABLE_INPUT_DPDK=ON -DENABLE_INPUT_NFB=ON -DENABLE_PROCESS_EXPERIMENTAL=ON
     - name: make
-      run: make
+      run: make -j $(nproc)

--- a/.github/workflows/copr-upload.yml
+++ b/.github/workflows/copr-upload.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Mark github workspace as safe
       run: git config --system --add safe.directory $PWD
     - name: make rpm
-      run: make rpm
+      run: make -j $(nproc) rpm
     - name: make rpm-msec
-      run: make rpm-msec
+      run: make -j $(nproc) rpm-msec
     - name: make rpm-nemea
-      run: make rpm-nemea
+      run: make -j $(nproc) rpm-nemea
     - name: Create copr config
       run: |
         mkdir ~/.config

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -32,14 +32,14 @@ jobs:
       run: |
         cd build
         cmake3 .. -DCMAKE_BUILD_TYPE=Release -DENABLE_INPUT_PCAP=ON -DENABLE_INPUT_DPDK=ON -DENABLE_INPUT_NFB=ON -DENABLE_PROCESS_EXPERIMENTAL=ON
-        make rpm
+        make -j $(nproc) rpm
     - name: make rpm-msec
-      run: make rpm-msec
+      run: make -j $(nproc) rpm-msec
     - name: make rpm-nemea
       run: |
         cd build
         cmake3 .. -DCMAKE_BUILD_TYPE=Release -DENABLE_OUTPUT_UNIREC=ON -DENABLE_PROCESS_EXPERIMENTAL=ON
-        make rpm-nemea
+        make -j $(nproc) rpm-nemea
     - name: extract artifact name
       run: |
         OS=${{ inputs.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,5 +32,5 @@ jobs:
         cmake3 .. -DENABLE_NEMEA=ON -DENABLE_INPUT_PCAP=ON -DENABLE_OUTPUT_UNIREC=ON -DENABLE_PROCESS_EXPERIMENTAL=ON -DENABLE_TESTS=ON
     - name: make tests
       run: |
-        make
+        make -j $(nproc)
         make tests


### PR DESCRIPTION
Replaced all plain `make` calls with `make -j $(nproc)` to enable parallel builds based on the number of available CPU cores.