### PR TITLE
Telemetry: add per-VLAN parser statistics and size histogram support

### DIFF
--- a/include/ipfixprobe/inputPlugin.hpp
+++ b/include/ipfixprobe/inputPlugin.hpp
@@ -61,10 +61,14 @@ public:
 	 * @brief Sets the telemetry directories for this plugin.
 	 * @param plugin_dir Shared pointer to the plugin-specific telemetry directory.
 	 * @param queues_dir Shared pointer to the telemetry directory for queues.
+	 * @param summary_dir Shared pointer to the telemetry directory for summary statistics.
+	 * @param pipeline_dir Shared pointer to the telemetry directory for the pipeline.
 	 */
 	void set_telemetry_dirs(
 		std::shared_ptr<telemetry::Directory> plugin_dir,
-		std::shared_ptr<telemetry::Directory> queues_dir);
+		std::shared_ptr<telemetry::Directory> queues_dir,
+		std::shared_ptr<telemetry::Directory> summary_dir,
+		std::shared_ptr<telemetry::Directory> pipeline_dir);
 
 	/// Number of packets seen by the plugin.
 	uint64_t m_seen = 0;
@@ -95,7 +99,10 @@ protected:
 	ParserStats m_parser_stats = {};
 
 private:
-	void create_parser_stats_telemetry(std::shared_ptr<telemetry::Directory> queues_dir);
+	void create_parser_stats_telemetry(
+		std::shared_ptr<telemetry::Directory> queues_dir,
+		std::shared_ptr<telemetry::Directory> summaryDirectory,
+		std::shared_ptr<telemetry::Directory> pipelineDirectory);
 };
 
 /**

--- a/include/ipfixprobe/parser-stats.hpp
+++ b/include/ipfixprobe/parser-stats.hpp
@@ -25,9 +25,138 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
+#include <string>
+
+#include <ipfixprobe/packet.hpp>
+#include <telemetry.hpp>
 
 namespace ipxp {
+
+static constexpr std::size_t MAX_VLAN_ID = 4096;
+
+class PacketSizeHistogram {
+public:
+	static constexpr std::size_t HISTOGRAM_SIZE = 10;
+
+	struct Value {
+		uint64_t packets = 0;
+		uint64_t bytes = 0;
+	};
+
+	PacketSizeHistogram()
+	{
+		for (uint16_t bucketID = 0; bucketID < 8192; ++bucketID) {
+			if (bucketID <= 64) {
+				m_size_to_bucket[bucketID] = 0;
+			} else if (bucketID < 128) {
+				m_size_to_bucket[bucketID] = 1;
+			} else if (bucketID < 256) {
+				m_size_to_bucket[bucketID] = 2;
+			} else if (bucketID < 512) {
+				m_size_to_bucket[bucketID] = 3;
+			} else if (bucketID < 1024) {
+				m_size_to_bucket[bucketID] = 4;
+			} else if (bucketID < 1518) {
+				m_size_to_bucket[bucketID] = 5;
+			} else if (bucketID < 2048) {
+				m_size_to_bucket[bucketID] = 6;
+			} else if (bucketID < 4096) {
+				m_size_to_bucket[bucketID] = 7;
+			} else if (bucketID < 8192) {
+				m_size_to_bucket[bucketID] = 8;
+			} else {
+				m_size_to_bucket[bucketID] = 9;
+			}
+		}
+	}
+
+	void update(uint16_t size)
+	{
+		if (size < 8192) {
+			const std::size_t bucket = m_size_to_bucket[size];
+			m_histogram[bucket].packets++;
+			m_histogram[bucket].bytes += size;
+		} else {
+			m_histogram[HISTOGRAM_SIZE - 1].packets++;
+			m_histogram[HISTOGRAM_SIZE - 1].bytes += size;
+		}
+	}
+
+	Value get_bucket_value(std::size_t bucket) const
+	{
+		if (bucket < HISTOGRAM_SIZE) {
+			return m_histogram[bucket];
+		}
+		return {};
+	}
+
+	std::string get_bucket_name(std::size_t bucket) const
+	{
+		if (bucket == 0) {
+			return "0-64";
+		} else if (bucket == 1) {
+			return "65-127";
+		} else if (bucket == 2) {
+			return "128-255";
+		} else if (bucket == 3) {
+			return "256-511";
+		} else if (bucket == 4) {
+			return "512-1023";
+		} else if (bucket == 5) {
+			return "1024-1518";
+		} else if (bucket == 6) {
+			return "1519-2047";
+		} else if (bucket == 7) {
+			return "2048-4095";
+		} else if (bucket == 8) {
+			return "4096-8191";
+		}
+		return "8192+";
+	}
+
+private:
+	std::array<Value, HISTOGRAM_SIZE> m_histogram = {};
+	std::array<uint8_t, 8192> m_size_to_bucket = {};
+};
+
+struct VlanStats {
+	void update(const Packet& pkt)
+	{
+		if (pkt.ip_version == IP::v4) {
+			ipv4_packets++;
+			ipv4_bytes += pkt.packet_len;
+		} else if (pkt.ip_version == IP::v6) {
+			ipv6_packets++;
+			ipv6_bytes += pkt.packet_len;
+		}
+
+		if (pkt.ip_proto == IPPROTO_TCP) {
+			tcp_packets++;
+		} else if (pkt.ip_proto == IPPROTO_UDP) {
+			udp_packets++;
+		}
+
+		total_packets++;
+		total_bytes += pkt.packet_len;
+
+		size_histogram.update(pkt.packet_len);
+	}
+
+	uint64_t ipv4_packets;
+	uint64_t ipv6_packets;
+	uint64_t ipv4_bytes;
+	uint64_t ipv6_bytes;
+
+	uint64_t tcp_packets;
+	uint64_t udp_packets;
+
+	uint64_t total_packets;
+	uint64_t total_bytes;
+
+	PacketSizeHistogram size_histogram;
+};
 
 /**
  * \brief Structure for storing parser statistics.
@@ -40,12 +169,16 @@ struct ParserStats {
 
 	uint64_t ipv4_packets;
 	uint64_t ipv6_packets;
+	uint64_t ipv4_bytes;
+	uint64_t ipv6_bytes;
 
 	uint64_t tcp_packets;
 	uint64_t udp_packets;
 
 	uint64_t seen_packets;
 	uint64_t unknown_packets;
+
+	VlanStats vlan_stats[MAX_VLAN_ID];
 };
 
 } // namespace ipxp

--- a/include/ipfixprobe/telemetry-utils.hpp
+++ b/include/ipfixprobe/telemetry-utils.hpp
@@ -56,6 +56,32 @@ public:
 		m_holder.add(file);
 	}
 
+	/**
+	 * @brief Register an aggregated file in the telemetry holder
+	 *
+	 * If the file is already registered, it will not be registered again.
+	 *
+	 * @param directory Directory to register the file in
+	 * @param name Name of the aggregated file
+	 * @param aggFilesPattern Pattern for aggregated files
+	 * @param aggOps Aggregation operations to perform on the files
+	 * @param patternRootDir Optional root directory for pattern matching
+	 */
+	void register_agg_file(
+		std::shared_ptr<telemetry::Directory> directory,
+		const std::string_view& name,
+		const std::string& aggFilesPattern,
+		const std::vector<telemetry::AggOperation>& aggOps,
+		std::shared_ptr<telemetry::Directory> patternRootDir = nullptr)
+	{
+		if (directory->getEntry(name)) {
+			return;
+		}
+
+		auto file = directory->addAggFile(name, aggFilesPattern, aggOps, patternRootDir);
+		m_holder.add(file);
+	}
+
 protected:
 	telemetry::Holder m_holder;
 };

--- a/src/core/inputPlugin.cpp
+++ b/src/core/inputPlugin.cpp
@@ -27,29 +27,139 @@ static telemetry::Content get_parser_stats_content(const ParserStats& parserStat
 
 	dict["ipv4_packets"] = parserStats.ipv4_packets;
 	dict["ipv6_packets"] = parserStats.ipv6_packets;
+	dict["ipv4_bytes"] = parserStats.ipv4_bytes;
+	dict["ipv6_bytes"] = parserStats.ipv6_bytes;
 
 	dict["tcp_packets"] = parserStats.tcp_packets;
 	dict["udp_packets"] = parserStats.udp_packets;
 
 	dict["seen_packets"] = parserStats.seen_packets;
 	dict["unknown_packets"] = parserStats.unknown_packets;
+	return dict;
+}
 
+static telemetry::Content get_vlan_stats(const VlanStats& vlanStats)
+{
+	telemetry::Dict dict;
+	dict["ipv4_packets"] = vlanStats.ipv4_packets;
+	dict["ipv4_bytes"] = vlanStats.ipv4_bytes;
+	dict["ipv6_packets"] = vlanStats.ipv6_packets;
+	dict["ipv6_bytes"] = vlanStats.ipv6_bytes;
+	dict["tcp_packets"] = vlanStats.tcp_packets;
+	dict["udp_packets"] = vlanStats.udp_packets;
+	dict["total_packets"] = vlanStats.total_packets;
+	dict["total_bytes"] = vlanStats.total_bytes;
+	return dict;
+}
+
+static telemetry::Content get_vlan_size_histogram_content(const PacketSizeHistogram& sizeHistogram)
+{
+	telemetry::Dict dict;
+	for (std::size_t bucket = 0; bucket < PacketSizeHistogram::HISTOGRAM_SIZE; ++bucket) {
+		const PacketSizeHistogram::Value value = sizeHistogram.get_bucket_value(bucket);
+		dict["etherPacketCount[" + sizeHistogram.get_bucket_name(bucket) + "]"]
+			= telemetry::ScalarWithUnit {value.packets, "packets"};
+		dict["etherPacketSize[" + sizeHistogram.get_bucket_name(bucket) + "]"]
+			= telemetry::ScalarWithUnit {value.bytes, "bytes"};
+	}
 	return dict;
 }
 
 void InputPlugin::create_parser_stats_telemetry(
-	std::shared_ptr<telemetry::Directory> queueDirectory)
+	std::shared_ptr<telemetry::Directory> queueDirectory,
+	std::shared_ptr<telemetry::Directory> summaryDirectory,
+	std::shared_ptr<telemetry::Directory> pipelineDirectory)
 {
+	auto parserDir = queueDirectory->addDir("parser");
+	auto summaryParserDir = summaryDirectory->addDir("parser");
+
 	telemetry::FileOps statsOps
 		= {[this]() { return get_parser_stats_content(m_parser_stats); }, nullptr};
-	register_file(queueDirectory, "parser-stats", statsOps);
+
+	auto vlanStatsDir = parserDir->addDir("vlan-stats");
+	for (std::size_t vlan_id = 0; vlan_id < MAX_VLAN_ID; ++vlan_id) {
+		telemetry::FileOps vlanStatsOps
+			= {[this, vlan_id]() { return get_vlan_stats(m_parser_stats.vlan_stats[vlan_id]); },
+			   nullptr};
+		telemetry::FileOps vlanHistogramOps
+			= {[this, vlan_id]() {
+				   return get_vlan_size_histogram_content(
+					   m_parser_stats.vlan_stats[vlan_id].size_histogram);
+			   },
+			   nullptr};
+		auto vlanIDDir = vlanStatsDir->addDir(std::to_string(vlan_id));
+		auto vlanSummaryDir = summaryParserDir->addDirs("vlan-stats/" + std::to_string(vlan_id));
+		register_file(vlanIDDir, "stats", vlanStatsOps);
+		register_file(vlanIDDir, "histogram", vlanHistogramOps);
+
+		const std::vector<telemetry::AggOperation> aggOps {
+			{telemetry::AggMethodType::SUM, "ipv4_packets"},
+			{telemetry::AggMethodType::SUM, "ipv4_bytes"},
+			{telemetry::AggMethodType::SUM, "ipv6_packets"},
+			{telemetry::AggMethodType::SUM, "ipv6_bytes"},
+			{telemetry::AggMethodType::SUM, "tcp_packets"},
+			{telemetry::AggMethodType::SUM, "udp_packets"},
+			{telemetry::AggMethodType::SUM, "total_packets"},
+			{telemetry::AggMethodType::SUM, "total_bytes"},
+		};
+
+		register_agg_file(
+			vlanSummaryDir,
+			"stats",
+			R"(queues/\d+/parser/vlan-stats/)" + std::to_string(vlan_id) + R"(/stats)",
+			aggOps,
+			pipelineDirectory);
+
+		std::vector<telemetry::AggOperation> aggHistogramSummaryOps;
+		for (std::size_t bucket = 0; bucket < PacketSizeHistogram::HISTOGRAM_SIZE; ++bucket) {
+			auto histogram = m_parser_stats.vlan_stats[vlan_id].size_histogram;
+			aggHistogramSummaryOps.push_back(
+				{telemetry::AggMethodType::SUM,
+				 "etherPacketCount[" + histogram.get_bucket_name(bucket) + "]"});
+			aggHistogramSummaryOps.push_back(
+				{telemetry::AggMethodType::SUM,
+				 "etherPacketSize[" + histogram.get_bucket_name(bucket) + "]"});
+		}
+		register_agg_file(
+			vlanSummaryDir,
+			"histogram",
+			R"(queues/\d+/parser/vlan-stats/)" + std::to_string(vlan_id) + R"(/histogram)",
+			aggHistogramSummaryOps,
+			pipelineDirectory);
+	}
+
+	const std::vector<telemetry::AggOperation> aggOps {
+		{telemetry::AggMethodType::SUM, "ipv4_bytes"},
+		{telemetry::AggMethodType::SUM, "ipv4_packets"},
+		{telemetry::AggMethodType::SUM, "ipv6_bytes"},
+		{telemetry::AggMethodType::SUM, "ipv6_packets"},
+		{telemetry::AggMethodType::SUM, "mpls_packets"},
+		{telemetry::AggMethodType::SUM, "pppoe_packets"},
+		{telemetry::AggMethodType::SUM, "seen_packets"},
+		{telemetry::AggMethodType::SUM, "tcp_packets"},
+		{telemetry::AggMethodType::SUM, "trill_packets"},
+		{telemetry::AggMethodType::SUM, "udp_packets"},
+		{telemetry::AggMethodType::SUM, "unknown_packets"},
+		{telemetry::AggMethodType::SUM, "vlan_packets"},
+	};
+
+	register_agg_file(
+		summaryParserDir,
+		"parser-stats",
+		R"(queues/\d+/parser/parser-stats)",
+		aggOps,
+		pipelineDirectory);
+
+	register_file(parserDir, "parser-stats", statsOps);
 }
 
 void InputPlugin::set_telemetry_dirs(
 	std::shared_ptr<telemetry::Directory> plugin_dir,
-	std::shared_ptr<telemetry::Directory> queues_dir)
+	std::shared_ptr<telemetry::Directory> queues_dir,
+	std::shared_ptr<telemetry::Directory> summary_dir,
+	std::shared_ptr<telemetry::Directory> pipeline_dir)
 {
-	create_parser_stats_telemetry(queues_dir);
+	create_parser_stats_telemetry(queues_dir, summary_dir, pipeline_dir);
 	configure_telemetry_dirs(plugin_dir, queues_dir);
 }
 

--- a/src/core/ipfixprobe.cpp
+++ b/src/core/ipfixprobe.cpp
@@ -373,6 +373,7 @@ bool process_plugin_args(ipxp_conf_t& conf, IpfixprobeOptParser& parser)
 	// Input
 	auto input_dir = conf.telemetry_root_node->addDir("input");
 	auto pipeline_dir = conf.telemetry_root_node->addDir("pipeline");
+	auto summary_dir = pipeline_dir->addDir("summary");
 	auto flowcache_dir = conf.telemetry_root_node->addDir("flowcache");
 	size_t pipeline_idx = 0;
 	for (auto& it : parser.m_input) {
@@ -393,7 +394,11 @@ bool process_plugin_args(ipxp_conf_t& conf, IpfixprobeOptParser& parser)
 			if (inputPlugin == nullptr) {
 				throw IPXPError("invalid input plugin " + input_name);
 			}
-			inputPlugin->set_telemetry_dirs(input_plugin_dir, pipeline_queue_dir);
+			inputPlugin->set_telemetry_dirs(
+				input_plugin_dir,
+				pipeline_queue_dir,
+				summary_dir,
+				pipeline_dir);
 			conf.inputPlugins.emplace_back(inputPlugin);
 		} catch (PluginError& e) {
 			throw IPXPError(input_name + std::string(": ") + e.what());

--- a/src/plugins/input/parser/parser.cpp
+++ b/src/plugins/input/parser/parser.cpp
@@ -30,6 +30,7 @@
 
 #include "headers.hpp"
 
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
@@ -765,8 +766,10 @@ void parse_packet(
 
 	if (pkt->ethertype == ETH_P_IP) {
 		stats.ipv4_packets++;
+		stats.ipv4_bytes += caplen;
 	} else if (pkt->ethertype == ETH_P_IPV6) {
 		stats.ipv6_packets++;
+		stats.ipv6_bytes += caplen;
 	}
 
 	uint16_t pkt_len = caplen;
@@ -789,6 +792,8 @@ void parse_packet(
 		pkt->payload_len = pkt_len - data_offset;
 	}
 	pkt->payload = pkt->packet + data_offset;
+
+	stats.vlan_stats[pkt->vlan_id].update(*pkt);
 
 	DEBUG_MSG("Payload length:\t%u\n", pkt->payload_len);
 	DEBUG_MSG("Packet parser exits: packet parsed\n");


### PR DESCRIPTION
- Introduced `VlanStats` structure to collect per-VLAN statistics.
- Extended `ParserStats` to include VLAN stats and histogram data.
- Enhanced telemetry support in `InputPlugin`:
  - Registers detailed per-VLAN stats and histograms.
  - Aggregates per-VLAN stats across queues into summary and pipeline dirs.