### PR TITLE
ipfixprobe.cpp: handle SIGABRT to support libunwind-based diagnostics

### DIFF
--- a/src/core/ipfixprobe.cpp
+++ b/src/core/ipfixprobe.cpp
@@ -64,9 +64,9 @@ const uint32_t DEFAULT_FPS = 0; // unlimited
 void signal_handler(int sig)
 {
 	(void) sig;
-	if (sig == SIGSEGV) {
+	if (sig == SIGSEGV || sig == SIGABRT) {
 		st_dump(STDERR_FILENO, sig);
-		abort();
+		exit(EXIT_FAILURE);
 	}
 	stop = 1;
 }
@@ -76,6 +76,7 @@ void register_handlers()
 	signal(SIGTERM, signal_handler);
 	signal(SIGINT, signal_handler);
 	signal(SIGSEGV, signal_handler);
+	signal(SIGABRT, signal_handler);
 #ifdef WITH_NEMEA
 	signal(SIGPIPE, SIG_IGN);
 #endif


### PR DESCRIPTION
### Summary
Handle SIGABRT alongside SIGSEGV to improve diagnostic capabilities during abnormal termination, especially when triggered by libunwind, sanitizers, or runtime assertions.

### Details
This PR updates the signal handling mechanism to treat SIGABRT similarly to SIGSEGV.
When the application receives SIGABRT (e.g. due to abort(), failed assert(), or sanitizers), it now properly invokes st_dump() to capture diagnostic output.
The handler then exits using exit(EXIT_FAILURE) instead of abort() to prevent recursive signal triggering.

This ensures that crashes triggered by internal runtime mechanisms (like libunwind, ASan, or failed invariants) are logged consistently.

---

### ✅ Checks

- [x] CI pipeline passes (build, tests, lint, static analysis)
- [x] New code follows clang-tidy rules
- [x] The change is clearly related to a specific issue / requirement
- [x] The PR is rebased on the latest `master`
- [x] No unrelated changes are included
~- [ ] Documentation (e.g. Doxygen) is updated if needed~
~- [ ] Relevant documentation was updated (if needed)~
---
