### PR TITLE
TLS - Fix empty string pop_back() if all elliptic curve point formats are grease values

### DIFF
--- a/src/plugins/process/tls/src/tls.cpp
+++ b/src/plugins/process/tls/src/tls.cpp
@@ -153,9 +153,6 @@ static std::string concatenate_vector_to_hex_string(const std::vector<uint16_t>&
 static std::string
 concatenate_extensions_vector_to_string(const std::vector<TLSExtension>& extensions)
 {
-	if (extensions.empty()) {
-		return "";
-	}
 	auto res = std::accumulate(
 		extensions.begin(),
 		extensions.end(),
@@ -166,7 +163,10 @@ concatenate_extensions_vector_to_string(const std::vector<TLSExtension>& extensi
 			}
 			return a + std::to_string(extension.type) + "-";
 		});
-	res.pop_back();
+
+	if (!res.empty()) {
+		res.pop_back();
+	}
 	return res;
 }
 


### PR DESCRIPTION
### Summary

Fixed undefined behavior in TLS extension string concatenation when all values are GREASE

### Details

Check if string is empty before pop_back(). Similar code sections were checked for the same class of errors

---

### ✅ Checks

- ~~[ ] Relevant documentation was updated (if needed)~~
- [x] CI pipeline passes (build, tests, lint, static analysis)
- [X] New code follows clang-tidy rules
- [X] The change is clearly related to a specific issue / requirement
- ~~[ ] Documentation (e.g. Doxygen) is updated if needed~~
- [X] The PR is rebased on the latest `master`
- ~~[] No unrelated changes are included~~

---
