### PR TITLE
NfbPlugin: log warning instead of exiting on NUMA node detection failure

### DIFF
--- a/src/plugins/input/nfb/src/ndpReader.cpp
+++ b/src/plugins/input/nfb/src/ndpReader.cpp
@@ -72,9 +72,9 @@ int NdpReader::init_interface(const std::string& interface)
 		numa_set_bind_policy(PREFERRED_NODE_POLICY);
 		numa_set_preferred(node_id);
 	} else {
-		error_msg = "warning - NUMA node detection failed\n";
-		return 1;
+		std::cerr << "warning - cannot set NUMA preferred node. Skipping..." << std::endl;
 	}
+
 	if (ndp_queue_start(rx_handle)) { // start capturing data from NDP queue
 		error_msg = std::string() + "error starting NDP queue on NFB device";
 		return 1;


### PR DESCRIPTION
### Summary

Log a warning instead of returning an error when NUMA node detection fails.

### Details

Previously, failing to detect a NUMA node caused the function to return an error and abort execution.  
Now, the code prints a warning to stderr and continues running, allowing the program to operate without NUMA preference.  

---

### ✅ Checks

- [x] Relevant documentation was updated (if needed)
- [x] CI pipeline passes (build, tests, lint, static analysis)
- [x] New code follows clang-tidy rules
- [x] The change is clearly related to a specific issue / requirement
- [x] Documentation (e.g. Doxygen) is updated if needed
- [x] The PR is rebased on the latest `master`
- [x] No unrelated changes are included

---
