### PR TITLE
Fix raw interface parameters quoting

### DIFF
--- a/init/config2args.py
+++ b/init/config2args.py
@@ -280,14 +280,14 @@ def process_input_raw_plugin(settings):
 
     params = []
     for interface in interfaces_list:
-        param = f"-i \"raw;ifc={interface}\""
+        param = f"-i \"raw;ifc={interface}"
 
         # Add blocks_count and packets_in_block only if they have a value
         if blocks_count:
             param += f";blocks={blocks_count}"
         if packets_in_block:
             param += f";pkts={packets_in_block}"
-
+        param += "\""
         params.append(param)
 
     return " ".join(params)


### PR DESCRIPTION
### Summary

Fix incorrect quoting when building raw interface parameter strings in **config2args.py**.
Previously the closing quote was on incorrect place.

### Details
If configuration file contains _block_count_ or _packets_in_block_ parameters, the final string contains unquoted **;**. The final string then is **ipfixprobe -i "raw;ifc=eth0";blocks=2048 ...** and rest of the command is ignored.

---

### ✅ Checks

- [ ] ~~Relevant documentation was updated (if needed)~~
- [x] CI pipeline passes (build, tests, lint, static analysis)
- [x] New code follows clang-tidy rules
- [x] The change is clearly related to a specific issue / requirement
- [ ] ~~Documentation (e.g. Doxygen) is updated if needed~~
- [x] The PR is rebased on the latest `master`
- [x] No unrelated changes are included

---
