### PR TITLE
Telemetry: build external telemetry library as shared instead of static

### DIFF
--- a/external/telemetry.cmake
+++ b/external/telemetry.cmake
@@ -5,7 +5,7 @@
 # - telemetry::telemetry (C++ library for telemetry data collection)
 # - telemetry::appFs     (C++ library that expose telemetry data as a Fuse filesystem)
 
-set(TELEMETRY_BUILD_SHARED OFF)
+set(TELEMETRY_BUILD_SHARED ON)
 set(TELEMETRY_INSTALL_TARGETS OFF)
 set(TELEMETRY_PACKAGE_BUILDER OFF)
 set(TELEMETRY_ENABLE_TESTS OFF)


### PR DESCRIPTION
### Summary

Build telemetry library as shared (dynamic) instead of static.

### Details

- The telemetry library (telemetry and appFs) was previously built and linked as static archives.
- This caused One Definition Rule (ODR) violations during RPM builds on newer g++ versions, because multiple translation units ended up with duplicate (and slightly diverging) definitions of FileOps, File, and related classes.
- By switching to a shared library (.so), there is only a single definition of each symbol at runtime, preventing ODR conflicts.

---

### ✅ Checks

- [x] Relevant documentation was updated (if needed)
- [x] CI pipeline passes (build, tests, lint, static analysis)
- [x] New code follows clang-tidy rules
- [x] The change is clearly related to a specific issue / requirement
- [x] Documentation (e.g. Doxygen) is updated if needed
- [x] The PR is rebased on the latest `master`
- [x] No unrelated changes are included

---
