### PR TITLE
CI: Change default containter to oraclelinux:10

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -38,10 +38,11 @@ runs:
     - name: Install build dependencies
       shell: bash
       run: |
-        dnf config-manager --set-enabled ol9_codeready_builder
-        dnf install -y dnf-plugins-core epel-release
+        dnf config-manager --set-enabled ol10_codeready_builder
+        dnf install -y dnf-plugins-core
+        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
         dnf install -y make gcc-c++ cmake3 git rpm-build
-        dnf install -y fuse3-devel openssl-devel gcc-toolset-14-libatomic-devel libunwind-devel lz4-devel
+        dnf install -y fuse3-devel openssl-devel libatomic libunwind-devel lz4-devel
 
     - name: Install clang tools
       if: ${{ inputs.clang-tools == 'true' }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,7 @@ on: [workflow_call]
 jobs:
   clang-checks:
     runs-on: ubuntu-latest
-    container: oraclelinux:9
+    container: oraclelinux:10
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4

--- a/.github/workflows/checkIpfixElemets.yml
+++ b/.github/workflows/checkIpfixElemets.yml
@@ -5,13 +5,14 @@ on: [workflow_call]
 jobs:
   ipfix-elements-checks:
     runs-on: ubuntu-latest
-    container: oraclelinux:9
+    container: oraclelinux:10
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
-        dnf install -y dnf-plugins-core epel-release cpp
+        dnf install -y dnf-plugins-core cpp
+        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
         dnf copr enable @CESNET/NEMEA
         dnf install cesnet-ipfix-elements
     - name: Check IPFIX elements

--- a/.github/workflows/ciEntryPoint.yml
+++ b/.github/workflows/ciEntryPoint.yml
@@ -15,7 +15,7 @@ jobs:
         id: os
         run: |
           osArray=()
-          osArray+=("oraclelinux:9")
+          osArray+=("oraclelinux:10")
           osArray=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${osArray[@]}")
           echo "Updated os list: $osArray"
           echo "os=$osArray" >> $GITHUB_OUTPUT

--- a/.github/workflows/copr-upload.yml
+++ b/.github/workflows/copr-upload.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   upload-srpm-to-copr:
     runs-on: ubuntu-latest
-    container: oraclelinux:9
+    container: oraclelinux:10
     steps:
     - name: Install git
       run: dnf install -y git
@@ -24,7 +24,7 @@ jobs:
         nemea: true
     - name: Install copr-cli
       run: |
-        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
         dnf install -y copr-cli
     - name: Mark github workspace as safe
       run: git config --system --add safe.directory $PWD

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         cd build
         cmake3 .. -DCMAKE_BUILD_TYPE=Release -DENABLE_INPUT_PCAP=ON -DENABLE_INPUT_DPDK=ON -DENABLE_INPUT_NFB=ON -DENABLE_PROCESS_EXPERIMENTAL=ON
-        make -j $(nproc) rpm
+    - name: make rpm
+      run: make -j $(nproc) rpm
     - name: make rpm-msec
       run: make -j $(nproc) rpm-msec
     - name: make rpm-nemea

--- a/.github/workflows/rpm-install.yml
+++ b/.github/workflows/rpm-install.yml
@@ -14,8 +14,9 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        dnf config-manager --set-enabled ol9_codeready_builder
-        dnf install -y dnf-plugins-core epel-release
+        dnf config-manager --set-enabled ol10_codeready_builder
+        dnf install -y dnf-plugins-core
+        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
         dnf copr enable @CESNET/nfb-framework
         dnf copr enable @CESNET/NEMEA-stable
     - name: extract artifact name


### PR DESCRIPTION
### Summary

CI: Change default container image to oraclelinux:10

### Details

- Updated all GitHub Actions workflows to use Oracle Linux 10 instead of Oracle Linux 9 as the default container image.
- Adjusted dependency installation accordingly:
   - Replaced ol9_codeready_builder with ol10_codeready_builder.
   - Updated EPEL release to epel-release-latest-10.

---

### ✅ Checks

- [x] Relevant documentation was updated (if needed)
- [x] CI pipeline passes (build, tests, lint, static analysis)
- [x] New code follows clang-tidy rules
- [x] The change is clearly related to a specific issue / requirement
- [x] Documentation (e.g. Doxygen) is updated if needed
- [x] The PR is rebased on the latest `master`
- [x] No unrelated changes are included

---
