### PR TITLE
Process - Quic - fix invalid return code from add_quic()

### DIFF
--- a/src/plugins/process/quic/src/quic.cpp
+++ b/src/plugins/process/quic/src/quic.cpp
@@ -543,9 +543,12 @@ int QUICPlugin::add_quic(Flow& rec, const Packet& pkt)
 	}
 	// Correct if QUIC has already been detected
 	if (!new_qptr && (ret == QUIC_NOT_DETECTED)) {
-		return QUIC_DETECTED;
+		return 0;
 	}
-	return ret;
+	if (ret == FLOW_FLUSH) {
+		return FLOW_FLUSH;
+	}
+	return 0;
 }
 
 void QUICPlugin::finish(bool print_stats)


### PR DESCRIPTION
### Summary

Fix add_quic() function invalid return code that caused pipeline infinite loop

### Details

Fix invalid return code in add_quic() that caused possibility the processing pipeline to enter an infinite loop. 
The function previously returned internal QUIC status codes that were not properly handled by the pipeline.

---

### ✅ Checks
- ~~[ ] Relevant documentation was updated (if needed)~~
- [x] CI pipeline passes (build, tests, lint, static analysis)
- [x] New code follows clang-tidy rules
- [x] The change is clearly related to a specific issue / requirement
- ~~[ ] Documentation (e.g. Doxygen) is updated if needed~~
- [x] The PR is rebased on the latest `master`
- [x] No unrelated changes are included

---
