### PR TITLE
ipfix: fix stuck flushing loop after TCP disconnect in LZ4 mode

### DIFF
--- a/src/plugins/output/ipfix/src/ipfix.cpp
+++ b/src/plugins/output/ipfix/src/ipfix.cpp
@@ -818,10 +818,8 @@ void IPFIXExporter::send_data()
 	 * Loop ends when len = create_data_packet() is 0
 	 */
 	while (true) {
-		pkt.data = packetDataBuffer.getWriteBuffer(mtu);
+		pkt.data = packetDataBuffer.getWriteBufferOrReset(mtu);
 		if (!pkt.data) {
-			// this should never happen because packetDataBuffer
-			// should already have enough allocated memory
 			return;
 		}
 
@@ -1225,6 +1223,16 @@ int CompressBuffer::init(bool compress, size_t compressSize, size_t writeSize)
 	shouldResetConnection = true;
 
 	return 0;
+}
+
+uint8_t* CompressBuffer::getWriteBufferOrReset(size_t requiredSize)
+{
+	uint8_t* buffer = getWriteBuffer(requiredSize);
+	if (buffer != nullptr) {
+		return buffer;
+	}
+	shrinkTo(0);
+	return getWriteBuffer(requiredSize);
 }
 
 uint8_t* CompressBuffer::getWriteBuffer(size_t requiredSize)

--- a/src/plugins/output/ipfix/src/ipfix.hpp
+++ b/src/plugins/output/ipfix/src/ipfix.hpp
@@ -458,6 +458,17 @@ public:
 	uint8_t* getWriteBuffer(size_t requiredSize);
 
 	/**
+	 * @brief Attempts to get a write buffer, resetting internal state on failure and retrying once.
+	 *
+	 *        This can happen in compress mode when a previous send failed without calling
+	 * compress(), leaving readSize non-zero and causing getWriteBuffer() to return null.
+	 *
+	 * @param requiredSize required size of the buffer
+	 * @return pointer to the buffer with the required size, null on failure
+	 */
+	uint8_t* getWriteBufferOrReset(size_t requiredSize);
+
+	/**
 	 * @brief compresses data written after last compress() call
 	 *
 	 *        In non-compression mode returns the size of the written data.


### PR DESCRIPTION
In LZ4 compress mode, a failed send_packet() call in send_templates() left readSize non-zero, causing the next getWriteBuffer() in send_data() to return null and exit without clearing template buffers.

Fix by adding CompressBuffer::getWriteBufferOrReset() which resets via shrinkTo(0) and retries once on null.
