### PR TITLE
output: add telemetry support to OutputPlugin

### DIFF
--- a/include/ipfixprobe/outputPlugin.hpp
+++ b/include/ipfixprobe/outputPlugin.hpp
@@ -17,11 +17,14 @@
 #include "flowifc.hpp"
 #include "plugin.hpp"
 #include "processPlugin.hpp"
+#include "telemetry-utils.hpp"
 
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <telemetry.hpp>
 
 namespace ipxp {
 
@@ -30,7 +33,9 @@ namespace ipxp {
 /**
  * \brief Base class for flow exporters.
  */
-class IPXP_API OutputPlugin : public Plugin {
+class IPXP_API OutputPlugin
+	: public TelemetryUtils
+	, public Plugin {
 public:
 	using ProcessPlugins = std::vector<std::pair<std::string, std::shared_ptr<ProcessPlugin>>>;
 	uint64_t m_flows_seen; /**< Number of flows received to export. */
@@ -52,6 +57,12 @@ public:
 	 * \return 0 on success
 	 */
 	virtual int export_flow(const Flow& flow) = 0;
+
+	/**
+	 * \brief Set the telemetry directory for this plugin.
+	 * \param [in] output_dir The telemetry directory for this plugin.
+	 */
+	void set_telemetry_dirs(std::shared_ptr<telemetry::Directory> output_dir);
 
 	/**
 	 * \brief Force exporter to flush flows to collector.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(ipfixprobe-core STATIC
 	workers.cpp
 	workers.hpp
 	inputPlugin.cpp
+	outputPlugin.cpp
 	pluginManager.cpp
 	pluginManager.hpp
 )

--- a/src/core/ipfixprobe.cpp
+++ b/src/core/ipfixprobe.cpp
@@ -338,6 +338,7 @@ bool process_plugin_args(ipxp_conf_t& conf, IpfixprobeOptParser& parser)
 		if (outputPlugin == nullptr) {
 			throw IPXPError("invalid output plugin " + output_name);
 		}
+		outputPlugin->set_telemetry_dirs(output_dir);
 		conf.outputPlugin = outputPlugin;
 	} catch (PluginError& e) {
 		throw IPXPError(output_name + std::string(": ") + e.what());

--- a/src/core/outputPlugin.cpp
+++ b/src/core/outputPlugin.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * @brief Implementation of OutputPlugin telemetry integration
+ * @author Pavel Siska <siska@cesnet.cz>
+ * @date 2026
+ *
+ * This file contains the implementation of telemetry-related functions for
+ * the OutputPlugin class. It provides functionality to register parser statistics
+ * in the telemetry system and manage telemetry directories.
+ *
+ * Copyright (c) 2025 CESNET
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <ipfixprobe/outputPlugin.hpp>
+
+namespace ipxp {
+
+static telemetry::Content get_output_stats(const OutputPlugin* plugin)
+{
+	telemetry::Dict dict;
+	dict["processed"] = plugin->m_flows_seen;
+	dict["dropped"] = plugin->m_flows_dropped;
+	return dict;
+}
+
+void OutputPlugin::set_telemetry_dirs(std::shared_ptr<telemetry::Directory> output_dir)
+{
+	telemetry::FileOps statsOps = {[this]() { return get_output_stats(this); }, nullptr};
+
+	register_file(output_dir, "stats", statsOps);
+}
+
+} // namespace ipxp

--- a/src/plugins/output/ipfix/CMakeLists.txt
+++ b/src/plugins/output/ipfix/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(ipfixprobe-output-ipfix PROPERTIES
 
 target_include_directories(ipfixprobe-output-ipfix PRIVATE
 	${CMAKE_SOURCE_DIR}/include/
+	${telemetry_SOURCE_DIR}/include
 )
 
 target_link_libraries(ipfixprobe-output-ipfix PRIVATE

--- a/src/plugins/output/text/CMakeLists.txt
+++ b/src/plugins/output/text/CMakeLists.txt
@@ -10,7 +10,10 @@ set_target_properties(ipfixprobe-output-text PROPERTIES
 	VISIBILITY_INLINES_HIDDEN YES
 )
 
-target_include_directories(ipfixprobe-output-text PRIVATE ${CMAKE_SOURCE_DIR}/include/)
+target_include_directories(ipfixprobe-output-text PRIVATE
+	${CMAKE_SOURCE_DIR}/include/
+	${telemetry_SOURCE_DIR}/include
+)
 
 install(
 	TARGETS ipfixprobe-output-text

--- a/src/plugins/output/unirec/CMakeLists.txt
+++ b/src/plugins/output/unirec/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(ipfixprobe-output-unirec PROPERTIES
 
 target_include_directories(ipfixprobe-output-unirec PRIVATE
 	${CMAKE_SOURCE_DIR}/include/
+	${telemetry_SOURCE_DIR}/include
 )
 
 target_link_libraries(ipfixprobe-output-unirec PRIVATE


### PR DESCRIPTION
Add telemetry integration to OutputPlugin — exposes processed/dropped flow counters as a stats file in the telemetry directory
